### PR TITLE
Changed command :data:load to fixtures:load and fix loader reference

### DIFF
--- a/Command/LoadDataFixturesDoctrineODMCommand.php
+++ b/Command/LoadDataFixturesDoctrineODMCommand.php
@@ -18,7 +18,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Output\Output;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\HttpKernel\Util\Filesystem;
-use Symfony\Bundle\DoctrineAbstractBundle\Common\DataFixtures\Loader as DataFixturesLoader;
+use Symfony\Bundle\DoctrineFixturesBundle\Common\DataFixtures\Loader as DataFixturesLoader;
 use Doctrine\Common\DataFixtures\Executor\MongoDBExecutor;
 use Doctrine\Common\DataFixtures\Purger\MongoDBPurger;
 use Doctrine\ODM\MongoDB\DocumentManager;
@@ -37,23 +37,23 @@ class LoadDataFixturesDoctrineODMCommand extends DoctrineODMCommand
     protected function configure()
     {
         $this
-            ->setName('doctrine:mongodb:data:load')
+            ->setName('doctrine:mongodb:fixtures:load')
             ->setDescription('Load data fixtures to your database.')
             ->addOption('fixtures', null, InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY, 'The directory or file to load data fixtures from.')
             ->addOption('append', null, InputOption::VALUE_NONE, 'Append the data fixtures instead of flushing the database first.')
             ->addOption('dm', null, InputOption::VALUE_REQUIRED, 'The document manager to use for this command.')
             ->setHelp(<<<EOT
-The <info>doctrine:mongodb:data:load</info> command loads data fixtures from your bundles:
+The <info>doctrine:mongodb:fixtures:load</info> command loads data fixtures from your bundles:
 
-  <info>./app/console doctrine:mongodb:data:load</info>
+  <info>./app/console doctrine:mongodb:fixtures:load</info>
 
 You can also optionally specify the path to fixtures with the <info>--fixtures</info> option:
 
-  <info>./app/console doctrine:mongodb:data:load --fixtures=/path/to/fixtures1 --fixtures=/path/to/fixtures2</info>
+  <info>./app/console doctrine:mongodb:fixtures:load --fixtures=/path/to/fixtures1 --fixtures=/path/to/fixtures2</info>
 
 If you want to append the fixtures instead of flushing the database first you can use the <info>--append</info> option:
 
-  <info>./app/console doctrine:mongodb:data:load --append</info>
+  <info>./app/console doctrine:mongodb:fixtures:load --append</info>
 EOT
         );
     }


### PR DESCRIPTION
Updated `:data:load` command to `:fixtures:load` to keep consistent with the ORM fixtures loading command.
https://github.com/symfony/DoctrineFixturesBundle/commit/f45a3008d6e2ddd42c6bcee49f75750fa652b254
as discussed:
https://github.com/symfony/symfony/pull/379

Updated path to the DataFixtures Loader, as it now lives in the DoctrineFixturesBundle
https://github.com/symfony/DoctrineFixturesBundle/blob/master/Common/DataFixtures/Loader.php
