### PR TITLE
generateHydratorClasses doesn't exist and give a fatal error. Looking at 

### DIFF
--- a/CacheWarmer/HydratorCacheWarmer.php
+++ b/CacheWarmer/HydratorCacheWarmer.php
@@ -70,7 +70,7 @@ class HydratorCacheWarmer implements CacheWarmerInterface
             $dm = $this->container->get(sprintf('doctrine.odm.mongodb.%s_document_manager', $documentManagerName));
             /* @var $dm Doctrine\ODM\MongoDB\DocumentManager */
             $classes = $dm->getMetadataFactory()->getAllMetadata();
-            $dm->getHydratorFactory()->generateHydratorClasses($classes);
+            $dm->getHydratorFactory()->generateHydratorClass($classes);
         }
     }
 }


### PR DESCRIPTION
generateHydratorClasses doesn't exist and give a fatal error. Looking at Doctrine-mongodb-odm the function name is: generateHydratorClass
