### PR TITLE
Fix PHP Fatal error:  MongoDbExtension missing getMappingResourceExtension

### DIFF
--- a/DependencyInjection/DoctrineMongoDBExtension.php
+++ b/DependencyInjection/DoctrineMongoDBExtension.php
@@ -324,10 +324,10 @@ class DoctrineMongoDBExtension extends AbstractDoctrineExtension
         return 'Resources/config/doctrine/metadata/mongodb';
     }
     
-    /*protected function getMappingResourceExtension()
+    protected function getMappingResourceExtension()
     {
         return 'doctrine_mongodb';
-    }*/
+    }
 
     public function getAlias()
     {


### PR DESCRIPTION
Fix PHP Fatal error:  Class Symfony\Bundle\DoctrineMongoDBBundle\DependencyInjection\DoctrineMongoDBExtension contains 1 abstract method and must therefore be declared abstract or implement the remaining methods (Symfony\Bundle\DoctrineAbstractBundle\DependencyInjection\AbstractDoctrineExtension::getMappingResourceExtension)
By adding the getMappingResourceExtension method

I'm not really sure what the function should return, maybe "" would be correct as well?
