### PR TITLE
Form TypeGuesser: default multiple document choice to expanded

### DIFF
--- a/Form/DoctrineMongoDBTypeGuesser.php
+++ b/Form/DoctrineMongoDBTypeGuesser.php
@@ -53,6 +53,7 @@ class DoctrineMongoDBTypeGuesser implements FormTypeGuesserInterface
                         'document_manager' => $this->documentManager,
                         'class' => $mapping['targetDocument'],
                         'multiple' => $multiple,
+                        'expanded' => $multiple
                     ),
                     Guess::HIGH_CONFIDENCE
                 );


### PR DESCRIPTION
Generally for single choice we want a `<select>` tag, and for multiple choices we want checkboxes.
