### PR TITLE
Reversed filtering by document class

### DIFF
--- a/Command/GenerateDocumentsDoctrineODMCommand.php
+++ b/Command/GenerateDocumentsDoctrineODMCommand.php
@@ -60,7 +60,7 @@ EOT
             $documentGenerator = $this->getDocumentGenerator();
 
             foreach ($metadatas as $metadata) {
-                if ($filterDocument && $metadata->reflClass->getShortName() == $filterDocument) {
+                if ($filterDocument && $metadata->reflClass->getShortName() != $filterDocument) {
                     continue;
                 }
 


### PR DESCRIPTION
Fix for incorrect document name filtering in doctrine:mongodb:generate:documents command. Currently all but the specified class are generated
