### PR TITLE
[Command] Removing out-dated function call from command

### DIFF
--- a/Command/DoctrineODMCommand.php
+++ b/Command/DoctrineODMCommand.php
@@ -42,7 +42,6 @@ abstract class DoctrineODMCommand extends Command
     protected function getDocumentGenerator()
     {
         $documentGenerator = new DocumentGenerator();
-        $documentGenerator->setAnnotationPrefix('mongodb:');
         $documentGenerator->setGenerateAnnotations(false);
         $documentGenerator->setGenerateStubMethods(true);
         $documentGenerator->setRegenerateDocumentIfExists(false);


### PR DESCRIPTION
Hey guys-

Generating the getters and setters seems to work fine, once this extra line is removed.

Thanks!
