### PR TITLE
[Extension] fixed parameter name for database name in the DoctrineMongoDBExtension

### DIFF
--- a/DependencyInjection/DoctrineMongoDBExtension.php
+++ b/DependencyInjection/DoctrineMongoDBExtension.php
@@ -137,7 +137,7 @@ class DoctrineMongoDBExtension extends AbstractDoctrineExtension
      */
     protected function loadDocumentManager(array $documentManager, $defaultDM, $defaultDB, $defaultMetadataCache, ContainerBuilder $container)
     {
-        $defaultDatabase = isset($documentManager['default_database']) ? $documentManager['default_database'] : $defaultDB;
+        $defaultDatabase = isset($documentManager['database']) ? $documentManager['database'] : $defaultDB;
         $configServiceName = sprintf('doctrine.odm.mongodb.%s_configuration', $documentManager['name']);
 
         if ($container->hasDefinition($configServiceName)) {


### PR DESCRIPTION
So, you can customize the database name of document managers: 

``` yaml
document_managers: 
  default: 
    database: yourDatabase
    mappings: 
      YourBundle: { type: annotation, dir: Document }
```
