### PR TITLE
Raised the priority of the cache warmers

### DIFF
--- a/Resources/config/mongodb.xml
+++ b/Resources/config/mongodb.xml
@@ -99,11 +99,11 @@
 
         <!-- Cache Warmers -->
         <service id="doctrine.odm.mongodb.proxy_cache_warmer" class="%doctrine.odm.mongodb.proxy_cache_warmer.class%" public="false">
-            <tag name="kernel.cache_warmer" />
+            <tag name="kernel.cache_warmer" priority="25" />
             <argument type="service" id="service_container" />
         </service>
         <service id="doctrine.odm.mongodb.hydrator_cache_warmer" class="%doctrine.odm.mongodb.hydrator_cache_warmer.class%" public="false">
-            <tag name="kernel.cache_warmer" />
+            <tag name="kernel.cache_warmer" priority="25" />
             <argument type="service" id="service_container" />
         </service>
 


### PR DESCRIPTION
The cache warmers are currently at priority 0, together with e.g. the routing cache warmer.

In EbutikMongoSessionBundle we have an issue that if using it together with Assetic routes and translation, the session may be started before hydrators and proxies are generated, which may cause an attempt to fetch a document. This of course fails, because there's no hydrators.

In the general case though, it's definitely conceivable that you might want cache warmers that accesses MongoDB ODM, and that makes it entirely appropriate for these cache warmers to have a higher priority than 0.
