### PR TITLE
Symfony master

### DIFF
--- a/Mapping/Driver/XmlDriver.php
+++ b/Mapping/Driver/XmlDriver.php
@@ -27,9 +27,11 @@ class XmlDriver extends BaseXmlDriver
     protected $classCache;
     protected $fileExtension = '.mongodb.xml';
 
-    public function __construct($prefixes = array())
+    public function __construct($prefixesByPath = array())
     {
-        $this->setNamespacePrefixes($prefixes);
+        parent::__construct(array_keys($prefixesByPath));
+
+        $this->setNamespacePrefixes($prefixesByPath);
     }
 
     public function setGlobalBasename($file)

--- a/Mapping/Driver/YamlDriver.php
+++ b/Mapping/Driver/YamlDriver.php
@@ -27,9 +27,11 @@ class YamlDriver extends BaseYamlDriver
     protected $classCache;
     protected $fileExtension = '.mongodb.yml';
 
-    public function __construct($prefixes = array())
+    public function __construct($prefixesByPath = array())
     {
-        $this->setNamespacePrefixes($prefixes);
+        parent::__construct(array_keys($prefixesByPath));
+
+        $this->setNamespacePrefixes($prefixesByPath);
     }
 
     public function setGlobalBasename($file)


### PR DESCRIPTION
This update the bundle to be compatible with Symfony master where the base class used by the DI extension uses a constructor argument for the prefixes now as Doctrine ORM choose to do it this way when integrating the "simplified" drivers.

The argument is optional to keep the compatibility with Symfony 2.0 where the setter is used directly.

The issue has been reported by @jmikola on https://github.com/symfony/symfony/commit/3ca1ccbf6764de5e2d48b2ddabdd2f1eb7075459#commitcomment-671454 and he tested the patch to confirm it fixes the issue.
