### PR TITLE
AbstractDoctrineExtension not found in Bridge

### DIFF
--- a/DependencyInjection/DoctrineMongoDBExtension.php
+++ b/DependencyInjection/DoctrineMongoDBExtension.php
@@ -18,7 +18,7 @@ use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\Config\Definition\Processor;
-use Symfony\Bridge\Doctrine\DependencyInjection\AbstractDoctrineExtension;
+use Symfony\Bundle\DoctrineAbstractBundle\DependencyInjection\AbstractDoctrineExtension;
 
 /**
  * Doctrine MongoDB ODM extension.


### PR DESCRIPTION
The DoctrineMongoDBBundle stopped working for me, because the location of AbstractDoctrineExtension did not exist. 
