### PR TITLE
[Security] Ensure DocumentUserProvider::refreshUser() uses id

### DIFF
--- a/Tests/Fixtures/Security/User.php
+++ b/Tests/Fixtures/Security/User.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Symfony\Bundle\DoctrineMongoDBBundle\Tests\Fixtures\Security;
+
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Symfony\Component\Security\Core\User\UserInterface;
+
+/** @ODM\Document */
+class User implements UserInterface
+{
+    /** @ODM\Id(strategy="none") */
+    protected $id;
+
+    /** @ODM\String */
+    public $name;
+
+    public function __construct($id, $name) {
+        $this->id = $id;
+        $this->name = $name;
+    }
+
+    public function getRoles()
+    {
+    }
+
+    public function getPassword()
+    {
+    }
+
+    public function getSalt()
+    {
+    }
+
+    public function getUsername()
+    {
+        return $this->name;
+    }
+
+    public function eraseCredentials()
+    {
+    }
+
+    public function equals(UserInterface $user)
+    {
+    }
+}

--- a/Tests/Security/DocumentUserProviderTest.php
+++ b/Tests/Security/DocumentUserProviderTest.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * This file is part of the Symfony framework.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Symfony\Bundle\DoctrineMongoDBBundle\Tests\Security;
+
+use Symfony\Bundle\DoctrineMongoDBBundle\Security\DocumentUserProvider;
+use Symfony\Bundle\DoctrineMongoDBBundle\Tests\TestCase;
+use Symfony\Bundle\DoctrineMongoDBBundle\Tests\Fixtures\Security\User;
+
+class DocumentUserProviderTest extends TestCase
+{
+    const DOCUMENT_CLASS = 'Symfony\Bundle\DoctrineMongoDBBundle\Tests\Fixtures\Security\User';
+
+    private $documentManager;
+
+    protected function setUp()
+    {
+        $this->documentManager = TestCase::createTestDocumentManager();
+        $this->documentManager->createQueryBuilder(self::DOCUMENT_CLASS)
+            ->remove()
+            ->getQuery()
+            ->execute();
+
+        parent::setUp();
+    }
+
+    public function testRefreshUserGetsUserByIdentifier()
+    {
+        $user1 = new User(1, 'user1');
+        $user2 = new User(2, 'user1');
+
+        $this->documentManager->persist($user1);
+        $this->documentManager->persist($user2);
+        $this->documentManager->flush();
+
+        $provider = new DocumentUserProvider($this->documentManager, self::DOCUMENT_CLASS);
+
+        // try to change the user identity
+        $user1->name = 'user2';
+
+        $this->assertSame($user1, $provider->refreshUser($user1));
+    }
+}


### PR DESCRIPTION
This is a port of @fabpot's security fix for the Doctrine Bridge: http://symfony.com/blog/security-release-symfony-2-0-6
