### PR TITLE
DocumentType prepends more than one client transformerto same field.

### DIFF
--- a/Form/Type/DocumentType.php
+++ b/Form/Type/DocumentType.php
@@ -98,7 +98,7 @@ class DocumentType extends AbstractType
         $hasAlready = false;
         $transformers = $builder->getClientTransformers();
         foreach ($transformers as $transformer) {
-            if (gettype($prependedTransformer) === gettype($transformer)) {
+            if ($prependedTransformer == $transformer) {
                 $hasAlready = true;
             }
         }


### PR DESCRIPTION
DocumentType should not append client transformer second time when using more than one same field on form, e.g. in case of prototype && allow_add options
