### PR TITLE
Fix DoctrineMongoDBTypeGuesser to use "em" instead of "document_manager"

### DIFF
--- a/Form/DoctrineMongoDBTypeGuesser.php
+++ b/Form/DoctrineMongoDBTypeGuesser.php
@@ -55,7 +55,7 @@ class DoctrineMongoDBTypeGuesser implements FormTypeGuesserInterface
             return new TypeGuess(
                 'document',
                 array(
-                    'document_manager' => $name,
+                    'em' => $name,
                     'class' => $mapping['targetDocument'],
                     'multiple' => $multiple,
                     'expanded' => $multiple


### PR DESCRIPTION
Fix DoctrineMongoDBTypeGuesser to use "em" instead of "document_manager" option as needed now by the use of the Doctrine Bridge.

Without this fix you get this error if creating a form:

The option "document_manager" does not exist. Known options are: "em", "class", "property", "query_builder", "loader", "choices", "group_by", "choice_list", "multiple", "expanded", "choice_list", "choices", "preferred_choices", "empty_data", "empty_value", "error_bubbling", "data", "data_class", "trim", "required", "read_only", "max_length", "pattern", "property_path", "by_reference", "error_bubbling", "error_mapping", "label", "attr", "invalid_message", "invalid_message_parameters", "translation_domain", "empty_data", "validation_groups", "validation_constraint", "sonata_admin", "sonata_field_description"
