### PR TITLE
restored document_manager option on form type

### DIFF
--- a/Form/Type/DocumentType.php
+++ b/Form/Type/DocumentType.php
@@ -42,6 +42,23 @@ class DocumentType extends DoctrineType
         );
     }
 
+    public function getDefaultOptions(array $options)
+    {
+        $defaultOptions = parent::getDefaultOptions($options);
+
+        // alias "em" as "document_manager"
+        $defaultOptions['document_manager'] = null;
+        if (isset($options['document_manager'])) {
+            if (isset($options['em'])) {
+                throw new \InvalidArgumentException('You cannot set both an "em" and "document_manager" option.');
+            }
+
+            $defaultOptions['em'] = $options['document_manager'];
+        }
+
+        return $defaultOptions;
+    }
+
     public function getName()
     {
         return 'document';


### PR DESCRIPTION
I have aliased the `em` option as `document_manager` to it is less confusing. Other solutions include:
- rename the option in the base class from `em` to `object_manager`
- create an abstract method to get the option name
