### PR TITLE
[FormGuesser] Update length guesses to match latest sf2.1

### DIFF
--- a/Form/DoctrineMongoDBTypeGuesser.php
+++ b/Form/DoctrineMongoDBTypeGuesser.php
@@ -138,16 +138,25 @@ class DoctrineMongoDBTypeGuesser implements FormTypeGuesserInterface
             $mapping = $ret[0]->getFieldMapping($property);
 
             if (isset($mapping['length'])) {
-                return new ValueGuess(
-                    $mapping['length'],
-                    Guess::HIGH_CONFIDENCE
-                );
+                return new ValueGuess($mapping['length'], Guess::HIGH_CONFIDENCE);
+            }
+
+            if ('float' === $mapping['type']) {
+                return new ValueGuess(null, Guess::MEDIUM_CONFIDENCE);
             }
         }
     }
 
     public function guessMinLength($class, $property)
     {
+        $ret = $this->getMetadata($class);
+        if ($ret && $ret[0]->hasField($property) && !$ret[0]->hasAssociation($property)) {
+            $mapping = $ret[0]->getFieldMapping($property);
+
+            if ('float' === $mapping['type']) {
+                return new ValueGuess(null, Guess::MEDIUM_CONFIDENCE);
+            }
+        }
     }
 
     protected function getMetadata($class)


### PR DESCRIPTION
Needed because the length for float fields can not be guessed from their max value, see symfony/symfony#3645
