### PR TITLE
update xml and yml mapping

### DIFF
--- a/Mapping/Driver/XmlDriver.php
+++ b/Mapping/Driver/XmlDriver.php
@@ -130,12 +130,8 @@ class XmlDriver extends BaseXmlDriver
     {
         $defaultFileName = str_replace('\\', '.', $className) . $this->fileExtension;
         foreach ($this->paths as $path) {
-            if (!isset($this->prefixes[$path])) {
-                if (file_exists($path . DIRECTORY_SEPARATOR . $defaultFileName)) {
-                    return $path . DIRECTORY_SEPARATOR . $defaultFileName;
-                }
-
-                continue;
+            if (file_exists($path . DIRECTORY_SEPARATOR . $defaultFileName)) {
+               return $path . DIRECTORY_SEPARATOR . $defaultFileName;
             }
 
             $prefix = $this->prefixes[$path];

--- a/Mapping/Driver/YamlDriver.php
+++ b/Mapping/Driver/YamlDriver.php
@@ -130,12 +130,8 @@ class YamlDriver extends BaseYamlDriver
     {
         $defaultFileName = str_replace('\\', '.', $className) . $this->fileExtension;
         foreach ($this->paths as $path) {
-            if (!isset($this->prefixes[$path])) {
-                if (file_exists($path . DIRECTORY_SEPARATOR . $defaultFileName)) {
-                    return $path . DIRECTORY_SEPARATOR . $defaultFileName;
-                }
-
-                continue;
+            if (file_exists($path . DIRECTORY_SEPARATOR . $defaultFileName)) {
+                return $path . DIRECTORY_SEPARATOR . $defaultFileName;
             }
 
             $prefix = $this->prefixes[$path];


### PR DESCRIPTION
A little background, I have my classes that needed to be persisted outside of a bundle. So to do functional testing, inside a bundle, I created a DocumentManager, much in the same way that this bundle does in TestCase. In the paths I set my mapping to `"My\Classes" => __DIR__.'/../Resources/config/doctrine'` To get this to work I had to name my mapping files `My.Classes.ClassName.mongodb.xml`

Then when it came time to use the mapping in the framework, I mapped the bundle

```
document_managers:
    default:
        mappings: 
            MyBundle:
                type: xml
                dir: %kernel.root_dir%/../src/MyBundle/Resources/config/doctrine
                prefix: My\Classes
```

However, the naming scheme `My.Classes.ClassName.mongodb.xml` wouldn't load. After looking in the code I realized that the $this->paths and $this->prefixes were basically the same information so it would never try to load by the default name. This path resolves that issue.

This can also be used in a situation like FOSUB, where instead of having a Document folder with an empty class extending the base class from Model, you can just map to Model instead. I haven't looked at the code, but I'm assuming this could be replicated on ORM and CouchDB also.
