### PR TITLE
Fix namespace typo

### DIFF
--- a/Command/UpdateSchemaDoctrineODMCommand.php
+++ b/Command/UpdateSchemaDoctrineODMCommand.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Bundle\DoctrineMongoDBBundle\Command;
+namespace Doctrine\Bundle\DoctrineMongoDBBundle\Command;
 
 use Doctrine\ODM\MongoDB\Tools\Console\Command\Schema\UpdateCommand;
 use Symfony\Component\Console\Input\InputInterface;


### PR DESCRIPTION
When upgrading an composer upgrade this morning, I add the following error :

``` php
  [RuntimeException]                                                                                                                                                                                                                                                                                                                                                         
  The autoloader expected class "Doctrine\Bundle\MongoDBBundle\Command\UpdateSchemaDoctrineODMCommand" to be defined in file "/Users/dguyon/Sites/Plemi/api/vendor/doctrine/mongodb-odm-bundle//Doctrine/Bundle/MongoDBBundle/Command/UpdateSchemaDoctrineODMCommand.php". The file was found but the class was not in it, the class name or namespace probably has a typo.  
```

Let me know If I misunderstood.
