### PR TITLE
Fix deps

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
         "php": ">=5.3.2",
         "doctrine/mongodb-odm": "dev-master",
         "symfony/doctrine-bridge": "2.1.*@beta",
-        "symfony/framework-bundle": "2.1.*@beta"
+        "symfony/framework-bundle": "2.1.*@beta",
+        "doctrine/data-fixtures": "dev-master"
     },
     "minimum-stability": "dev",
     "autoload": {


### PR DESCRIPTION
Without this dependency I get this error:

``` bash
$ app/console doctrine:mongodb:fixtures:load
PHP Fatal error:  Class 'Doctrine\Common\DataFixtures\Loader' not found in /home/vagrant/vendor/symfony/symfony/src/Symfony/Bridge/Doctrine/DataFixtures/ContainerAwareLoader.php on line 27

Fatal error: Class 'Doctrine\Common\DataFixtures\Loader' not found in /home/vagrant/vendor/symfony/symfony/src/Symfony/Bridge/Doctrine/DataFixtures/ContainerAwareLoader.php on line 27
```
