### PR TITLE
Add DataFixtures library as dev dependency and as a suggested package.

### DIFF
--- a/Command/LoadDataFixturesDoctrineODMCommand.php
+++ b/Command/LoadDataFixturesDoctrineODMCommand.php
@@ -30,6 +30,14 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class LoadDataFixturesDoctrineODMCommand extends DoctrineODMCommand
 {
+    /**
+     * @return boolean
+     */
+    public function isEnabled()
+    {
+        return parent::isEnabled() && class_exists('Doctrine\Common\DataFixtures\Loader');
+    }
+
     protected function configure()
     {
         $this

--- a/Tests/Command/LoadDataFixturesDoctrineODMCommandTest.php
+++ b/Tests/Command/LoadDataFixturesDoctrineODMCommandTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Doctrine\Bundle\MongoDBBundle\Tests\Command;
+
+use Doctrine\Bundle\MongoDBBundle\Command\LoadDataFixturesDoctrineODMCommand;
+
+/**
+ * @author Henrik Bjornskov <henrik@bjrnskov.dk>
+ */
+class LoadDataFixturesDoctrineODMCommandTest extends \PHPUnit_Framework_TestCase
+{
+    public function setUp()
+    {
+        $this->command = new LoadDataFixturesDoctrineODMCommand();
+    }
+
+    public function testCommandIsNotEnabledWithMissingDependency()
+    {
+        if (class_exists('Doctrine\Common\DataFixtures\Loader')) {
+            $this->markTestSkipped();
+        }
+
+        $this->assertFalse($this->command->isEnabled());
+    }
+
+    public function testCommandIsEnabledWithDependency()
+    {
+        if (!class_exists('Doctrine\Common\DataFixtures\Loader')) {
+            $this->markTestSkipped();
+        }
+
+        $this->assertTrue($this->command->isEnabled());
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,12 @@
         "symfony/doctrine-bridge": "2.1.*@beta",
         "symfony/framework-bundle": "2.1.*@beta"
     },
+    "require-dev" : {
+        "doctrine/data-fixtures" : "@dev"
+    },
+    "suggest" : {
+        "doctrine/data-fixtures" : "Import data into the database from Fixtures"
+    },
     "minimum-stability": "dev",
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
Disable the LoadDataFixturesDoctrineODMCommand when DataFixtures cannot
be found (incl Tests). This only works for 2.1+

``` shell
[~/Code/DoctrineMongoDBBundle] phpunit --testdox | ack 'Command'
Doctrine\Bundle\MongoDBBundle\Tests\Command\LoadDataFixturesDoctrineODMCommand
 [x] Command is not enabled with missing dependency
 [ ] Command is enabled with dependency

[~/Code/DoctrineMongoDBBundle] composer install --dev
Installing dependencies from lock file
Nothing to install or update
Installing dev dependencies from lock file
  - Installing doctrine/data-fixtures (dev-master)
    Cloning 779c3dfe446b6da893be87b908d6be28345d1e01

Generating autoload files

[~/Code/DoctrineMongoDBBundle] phpunit --testdox | ack 'Command'
Doctrine\Bundle\MongoDBBundle\Tests\Command\LoadDataFixturesDoctrineODMCommand
 [ ] Command is not enabled with missing dependency
 [x] Command is enabled with dependency
```
