### PR TITLE
Using ORM and ODM together the Type Guesser gets confused

### DIFF
--- a/Form/DoctrineMongoDBTypeGuesser.php
+++ b/Form/DoctrineMongoDBTypeGuesser.php
@@ -42,7 +42,13 @@ class DoctrineMongoDBTypeGuesser implements FormTypeGuesserInterface
      */
     public function guessType($class, $property)
     {
-        if (!$ret = $this->getMetadata($class)) {
+        $ret = null;
+        try {
+            $ret = $this->getMetadata($class);
+        } catch (\Doctrine\Common\Persistence\Mapping\MappingException $e) {
+            //We should ignore this error.
+        }
+        if (is_null($ret)) {
             return new TypeGuess('text', array(), Guess::LOW_CONFIDENCE);
         }
 


### PR DESCRIPTION
TypeGuesser throws an exception rather gracefully degrading. This causes a problem when you have entities and documents in the same project (even in separate bundles)

For a full reproduction of the problem, please take a look at https://github.com/mogoman/symfony-standard

Signed-off-by: Warren van der Woude warren@vanzoo.de
