### PR TITLE
Update Form/DoctrineMongoDBTypeGuesser.php

### DIFF
--- a/Form/DoctrineMongoDBTypeGuesser.php
+++ b/Form/DoctrineMongoDBTypeGuesser.php
@@ -55,7 +55,6 @@ class DoctrineMongoDBTypeGuesser implements FormTypeGuesserInterface
             return new TypeGuess(
                 'document',
                 array(
-                    'em' => $name,
                     'class' => $mapping['targetDocument'],
                     'multiple' => $multiple,
                     'expanded' => $multiple


### PR DESCRIPTION
The option 'em' cannot be set after #129 has been merged. Here's how things are happening:

Following #129, there is a check that an 'em' option already exists or not on a given form.

Everything works fine if I write my form like:

    public function buildForm(FormBuilderInterface $builder, array $options)
    {
        $builder
            ->add('pizza', 'document', ['class' => 'Restaurant\PizzaBundle\Document\Pizza'])
            ->add(// other things )
        ;
    }

But if I only write:

    public function buildForm(FormBuilderInterface $builder, array $options)
    {
        $builder
            ->add('pizza')
            ->add(// other things )
        ;
    }

Then I get an exception thrown by the DocumentType at https://github.com/doctrine/DoctrineMongoDBBundle/blob/master/Form/Type/DocumentType.php#L57

Because the MongoDBTypeGuesser does set the 'em' option at 
https://github.com/doctrine/DoctrineMongoDBBundle/blob/master/Form/DoctrineMongoDBTypeGuesser.php#L58
