### PR TITLE
Improved query building

### DIFF
--- a/Logger/DoctrineMongoDBLogger.php
+++ b/Logger/DoctrineMongoDBLogger.php
@@ -252,7 +252,7 @@ class DoctrineMongoDBLogger
                 $formatted = 'null';
             } elseif (is_bool($value)) {
                 $formatted = $value ? 'true' : 'false';
-            } elseif (is_numeric($value)) {
+            } elseif (is_int($value) || is_float($value)) {
                 $formatted = $value;
             } elseif (is_scalar($value)) {
                 $formatted = '"'.$value.'"';


### PR DESCRIPTION
In MongoDB the way you handle string vs numerics is somewhat different from php.

i.e.: if you search for a phone number: { "workPhone": "+367061546843" } is different { "workPhone": +367061546843 }

is_numeric returns true for a string containing numbers, but will mongo handle it as a string.
