### PR TITLE
Bypassing ORM Entities to stop raising MappingExceptions

### DIFF
--- a/Form/DoctrineMongoDBTypeGuesser.php
+++ b/Form/DoctrineMongoDBTypeGuesser.php
@@ -170,6 +170,11 @@ class DoctrineMongoDBTypeGuesser implements FormTypeGuesserInterface
 
     protected function getMetadata($class)
     {
+        // Make sure that the Class is a valid Document and not an Entity
+    	if(strpos($class, 'Entity') !== false) {
+    		return null;
+    	}
+        
         if (array_key_exists($class, $this->cache)) {
             return $this->cache[$class];
         }


### PR DESCRIPTION
Having ORM and ODM active at the same time, Doctrine ORM Entities were being passed into the DoctrineMongoDBTypeGuesser via the guess() method in Symfony\Component\Form\FormTypeGuesserChain.php, causing a MappingException to be raised.
