### PR TITLE
Update Resources/doc/index.rst

### DIFF
--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -64,7 +64,7 @@ Register the annotations and the bundle
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Next, register the annotations library by adding the following to the autoloader
-(below the existing ``AnnotationRegistry::registerFile`` line)::
+(below the existing ``AnnotationRegistry::registerLoader`` line)::
 
     // app/autoload.php
     AnnotationRegistry::registerFile(


### PR DESCRIPTION
I don't see a `AnnotationRegistry::registerFile` in the `app/autoload.php` that
ships with the Symfony 2.1 standard distribution (as of
67cbb5771f38ca1ab71c83916d2fedb3c0311b16).
