### PR TITLE
Moved the "minimum-stability" setting to the "require" definition

### DIFF
--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -41,9 +41,8 @@ To install DoctrineMongoDBBundle with Composer just add the following to your
 
     {
         "require": {
-            "doctrine/mongodb-odm-bundle": "3.0.*"
+            "doctrine/mongodb-odm-bundle": "3.0.*@dev"
         },
-        "minimum-stability": "dev"
     }
 
 The ``minimum-stability`` definition is necessary until a non-beta version of


### PR DESCRIPTION
Since you don't want your whole project to rely on the "dev" stability, right?
