### PR TITLE
Update composer.json for Symfony 2.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,14 +13,14 @@
     "require": {
         "php": ">=5.3.2",
         "doctrine/mongodb-odm": "~1.0.0-beta5@dev",
-        "symfony/options-resolver": ">=2.1,<2.3-dev",
-        "symfony/doctrine-bridge": ">=2.1,<2.3-dev",
-        "symfony/framework-bundle": ">=2.1,<2.3-dev"
+        "symfony/options-resolver": "~2.1",
+        "symfony/doctrine-bridge": "~2.1",
+        "symfony/framework-bundle": "~2.1"
     },
     "require-dev": {
         "doctrine/data-fixtures": "@dev",
-        "symfony/form": ">=2.1,<2.3-dev",
-        "symfony/yaml": ">=2.1,<2.3-dev"
+        "symfony/form": "~2.1",
+        "symfony/yaml": "~2.1"
     },
     "suggest": {
         "doctrine/data-fixtures": "Load data fixtures"


### PR DESCRIPTION
It's safe to use 2.1+, since Symfony 2.3 is going to be a LTS.
