### PR TITLE
sanity-check DI configuration

### DIFF
--- a/DependencyInjection/DoctrineMongoDBExtension.php
+++ b/DependencyInjection/DoctrineMongoDBExtension.php
@@ -20,6 +20,7 @@ use Symfony\Component\DependencyInjection\Alias;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\DefinitionDecorator;
+use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 
@@ -39,10 +40,19 @@ class DoctrineMongoDBExtension extends AbstractDoctrineExtension
     {
         // Load DoctrineMongoDBBundle/Resources/config/mongodb.xml
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
-        $loader->load('mongodb.xml');
 
         $configuration = new Configuration();
         $config = $this->processConfiguration($configuration, $configs);
+
+        if (! count($config['document_managers'])) {
+            throw new InvalidArgumentException('You need to define at least one entry in doctrine_mongodb.document_managers');
+
+        }
+        if (! count($config['connections'])) {
+            throw new InvalidArgumentException('You need to define at least one entry in doctrine_mongodb.connections');
+        }
+
+        $loader->load('mongodb.xml');
 
         if (empty($config['default_connection'])) {
             $keys = array_keys($config['connections']);

--- a/Tests/DependencyInjection/AbstractMongoDBExtensionTest.php
+++ b/Tests/DependencyInjection/AbstractMongoDBExtensionTest.php
@@ -29,7 +29,7 @@ abstract class AbstractMongoDBExtensionTest extends TestCase
         $container = $this->getContainer();
         $loader = new DoctrineMongoDBExtension();
 
-        $loader->load(array(array()), $container);
+        $loader->load(DoctrineMongoDBExtensionTest::buildConfiguration(), $container);
 
         $this->assertEquals('Doctrine\MongoDB\Connection', $container->getParameter('doctrine_mongodb.odm.connection.class'));
         $this->assertEquals('Doctrine\ODM\MongoDB\Configuration', $container->getParameter('doctrine_mongodb.odm.configuration.class'));
@@ -50,13 +50,13 @@ abstract class AbstractMongoDBExtensionTest extends TestCase
 
         $this->assertEquals('Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntityValidator', $container->getParameter('doctrine_odm.mongodb.validator.unique.class'));
 
-        $config = array(
+        $config = DoctrineMongoDBExtensionTest::buildConfiguration(array(
             'proxy_namespace' => 'MyProxies',
             'auto_generate_proxy_classes' => true,
             'connections' => array('default' => array()),
             'document_managers' => array('default' => array())
-        );
-        $loader->load(array($config), $container);
+        ));
+        $loader->load($config, $container);
 
         $this->assertEquals('MyProxies', $container->getParameter('doctrine_mongodb.odm.proxy_namespace'));
         $this->assertEquals(true, $container->getParameter('doctrine_mongodb.odm.auto_generate_proxy_classes'));
@@ -276,7 +276,10 @@ abstract class AbstractMongoDBExtensionTest extends TestCase
         $container = $this->getContainer();
         $loader = new DoctrineMongoDBExtension();
 
-        $loader->load(array(array('document_managers' => array('default' => array('mappings' => array('YamlBundle' => array()))))), $container);
+        $config = DoctrineMongoDBExtensionTest::buildConfiguration(
+            array('document_managers' => array('default' => array('mappings' => array('YamlBundle' => array()))))
+        );
+        $loader->load($config, $container);
 
         $definition = $container->getDefinition('doctrine_mongodb.odm.default_configuration');
         $calls = $definition->getMethodCalls();
@@ -288,8 +291,10 @@ abstract class AbstractMongoDBExtensionTest extends TestCase
     {
         $container = $this->getContainer('YamlBundle');
         $loader = new DoctrineMongoDBExtension();
-
-        $loader->load(array(array('document_managers' => array('default' => array('mappings' => array('YamlBundle' => array()))))), $container);
+        $config = DoctrineMongoDBExtensionTest::buildConfiguration(
+            array('document_managers' => array('default' => array('mappings' => array('YamlBundle' => array()))))
+        );
+        $loader->load($config, $container);
 
         $calls = $container->getDefinition('doctrine_mongodb.odm.default_metadata_driver')->getMethodCalls();
         $this->assertEquals('doctrine_mongodb.odm.default_yml_metadata_driver', (string) $calls[0][1][0]);
@@ -300,8 +305,10 @@ abstract class AbstractMongoDBExtensionTest extends TestCase
     {
         $container = $this->getContainer('XmlBundle');
         $loader = new DoctrineMongoDBExtension();
-
-        $loader->load(array(array('document_managers' => array('default' => array('mappings' => array('XmlBundle' => array()))))), $container);
+        $config = DoctrineMongoDBExtensionTest::buildConfiguration(
+            array('document_managers' => array('default' => array('mappings' => array('XmlBundle' => array()))))
+        );
+        $loader->load($config, $container);
 
         $calls = $container->getDefinition('doctrine_mongodb.odm.default_metadata_driver')->getMethodCalls();
         $this->assertEquals('doctrine_mongodb.odm.default_xml_metadata_driver', (string) $calls[0][1][0]);
@@ -312,8 +319,10 @@ abstract class AbstractMongoDBExtensionTest extends TestCase
     {
         $container = $this->getContainer('AnnotationsBundle');
         $loader = new DoctrineMongoDBExtension();
-
-        $loader->load(array(array('document_managers' => array('default' => array('mappings' => array('AnnotationsBundle' => array()))))), $container);
+        $config = DoctrineMongoDBExtensionTest::buildConfiguration(
+            array('document_managers' => array('default' => array('mappings' => array('AnnotationsBundle' => array()))))
+        );
+        $loader->load($config, $container);
 
         $calls = $container->getDefinition('doctrine_mongodb.odm.default_metadata_driver')->getMethodCalls();
         $this->assertEquals('doctrine_mongodb.odm.default_annotation_metadata_driver', (string) $calls[0][1][0]);
@@ -372,6 +381,8 @@ abstract class AbstractMongoDBExtensionTest extends TestCase
         $container = $this->getContainer();
         $loader = new DoctrineMongoDBExtension();
         $container->registerExtension($loader);
+        $config = DoctrineMongoDBExtensionTest::buildConfiguration();
+        $container->prependExtensionConfig($loader->getAlias(), reset($config));
 
         $this->loadFromFile($container, 'odm_imports');
 

--- a/Tests/DependencyInjection/DoctrineMongoDBExtensionTest.php
+++ b/Tests/DependencyInjection/DoctrineMongoDBExtensionTest.php
@@ -17,14 +17,36 @@ namespace Doctrine\Bundle\MongoDBBundle\Tests\DependencyInjection;
 use Doctrine\Bundle\MongoDBBundle\DependencyInjection\DoctrineMongoDBExtension;
 use Symfony\Component\Config\Definition\Processor;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
 
 class DoctrineMongoDBExtensionTest extends \PHPUnit_Framework_TestCase
 {
+    public static function buildConfiguration(array $settings = array())
+    {
+        return array(array_merge(
+            array(
+                'connections' => array('dummy' => array()),
+                'document_managers' => array('dummy' => array()),
+            ),
+            $settings
+        ));
+    }
+
+    public function buildMinimalContainer()
+    {
+        $container = new ContainerBuilder(new ParameterBag(array(
+            'kernel.root_dir'    => __DIR__,
+            'kernel.environment' => 'test',
+            'kernel.debug'       => 'true',
+        )));
+        return $container;
+    }
 
     public function testBackwardCompatibilityAliases()
     {
         $loader = new DoctrineMongoDBExtension();
-        $loader->load(array(), $container = new ContainerBuilder());
+
+        $loader->load(self::buildConfiguration(), $container = $this->buildMinimalContainer());
 
         $this->assertEquals('doctrine_mongodb.odm.document_manager', (string) $container->getAlias('doctrine.odm.mongodb.document_manager'));
     }
@@ -34,10 +56,10 @@ class DoctrineMongoDBExtensionTest extends \PHPUnit_Framework_TestCase
      */
     public function testParameterOverride($option, $parameter, $value)
     {
-        $container = new ContainerBuilder();
+        $container = $this->buildMinimalContainer();
         $container->setParameter('kernel.debug', false);
         $loader = new DoctrineMongoDBExtension();
-        $loader->load(array(array($option => $value)), $container);
+        $loader->load(self::buildConfiguration(array($option => $value)), $container);
 
         $this->assertEquals($value, $container->getParameter('doctrine_mongodb.odm.'.$parameter));
     }


### PR DESCRIPTION
i installed dev-master of the mongo bundle in a current symfony standard edition without adding any configuration. the output was 

    [Symfony\Component\DependencyInjection\Exception\InvalidArgumentException]
    Unable to replace alias "doctrine_mongodb.odm.document_manager" with "doctrine.odm.mongodb.document_manager".  

    [Symfony\Component\DependencyInjection\Exception\InvalidArgumentException]
    The service definition "doctrine_mongodb.odm.document_manager" does not exist. 

with this change, we get the more telling message

    [Symfony\Component\DependencyInjection\Exception\InvalidArgumentException]
    You need to define at least one entry in document_managers   
