### PR TITLE
Document db connection option

### DIFF
--- a/Resources/doc/config.rst
+++ b/Resources/doc/config.rst
@@ -335,6 +335,7 @@ Full Default Configuration
                         replicaSet:           ~
                         username:             ~
                         password:             ~
+                        db:                   ~
             proxy_namespace:      MongoDBODMProxies
             proxy_dir:            %kernel.cache_dir%/doctrine/odm/mongodb/Proxies
             auto_generate_proxy_classes:  false


### PR DESCRIPTION
Adding undocumented config directive to indicate database name. This is discussed in DoctrineMongoDBBundle/issues/191
