### PR TITLE
Composer should only update current dependency

### DIFF
--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -55,7 +55,7 @@ command from the directory where your ``composer.json`` file is located:
 
 .. code-block :: bash
 
-    php composer.phar update
+    php composer.phar update doctrine/mongodb-odm doctrine/mongodb-odm-bundle
 
 Now, Composer will automatically download all required files, and install them
 for you.


### PR DESCRIPTION
Executing composer update will update all composer dependencies which can lead to undesired dependencies upgrades.

Instead, we should only call composer for update the desired packages
