### PR TITLE
FormBuilderInterface documentation update

### DIFF
--- a/Resources/doc/form.rst
+++ b/Resources/doc/form.rst
@@ -89,12 +89,12 @@ Next, create the form for the ``User`` model::
 
     use Symfony\Component\Form\AbstractType;
     use Symfony\Component\Form\Extension\Core\Type\RepeatedType;
-    use Symfony\Component\Form\FormBuilder;
+    use Symfony\Component\Form\FormBuilderInterface;
     use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
     class UserType extends AbstractType
     {
-        public function buildForm(FormBuilder $builder, array $options)
+        public function buildForm(FormBuilderInterface $builder, array $options)
         {
             $builder->add('email', 'email');
             $builder->add('password', 'repeated', array(
@@ -185,11 +185,11 @@ Next, create the form for this ``Registration`` model::
 
     use Symfony\Component\Form\AbstractType;
     use Symfony\Component\Form\Extension\Core\Type\RepeatedType;
-    use Symfony\Component\Form\FormBuilder;
+    use Symfony\Component\Form\FormBuilderInterface;
 
     class RegistrationType extends AbstractType
     {
-        public function buildForm(FormBuilder $builder, array $options)
+        public function buildForm(FormBuilderInterface $builder, array $options)
         {
             $builder->add('user', new UserType());
             $builder->add('terms', 'checkbox', array('property_path' => 'termsAccepted'));


### PR DESCRIPTION
use Symfony\Component\Form\FormBuilderInterface; instead 
Symfony\Component\Form\FormBuilder makes tutorial work with actual Symfony version
