### PR TITLE
Restore addDefaultsIfNotSet() for "default_commit_options"

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -50,6 +50,7 @@ class Configuration implements ConfigurationInterface
                 ->scalarNode('default_connection')->end()
                 ->scalarNode('default_database')->defaultValue('default')->end()
                 ->arrayNode('default_commit_options')
+                    ->addDefaultsIfNotSet()
                     ->children()
                         ->booleanNode('j')->end()
                         ->scalarNode('timeout')->end()

--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -38,6 +38,7 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
             'proxy_namespace'                => 'MongoDBODMProxies',
             'hydrator_dir'                   => '%kernel.cache_dir%/doctrine/odm/mongodb/Hydrators',
             'hydrator_namespace'             => 'Hydrators',
+            'default_commit_options'         => array(),
         );
 
         $this->assertEquals($defaults, $options);


### PR DESCRIPTION
This was erroneously removed in 9ec3a3b082eae354a53d54e35cb3b528339ab9f2.

Fixes #222
