### PR TITLE
use getter to access metadata reflClass property

### DIFF
--- a/Command/GenerateDocumentsDoctrineODMCommand.php
+++ b/Command/GenerateDocumentsDoctrineODMCommand.php
@@ -70,7 +70,7 @@ EOT
             $documentGenerator->setBackupExisting(!$input->getOption('no-backup'));
 
             foreach ($metadatas as $metadata) {
-                if ($filterDocument && $metadata->reflClass->getShortName() != $filterDocument) {
+                if ($filterDocument && $metadata->getReflectionClass()->getShortName() != $filterDocument) {
                     continue;
                 }
 


### PR DESCRIPTION
It fixes a null pointer exception when using the --documents option in the generate documents command line.
