### PR TITLE
Update Logger.php

### DIFF
--- a/Logger/Logger.php
+++ b/Logger/Logger.php
@@ -14,7 +14,7 @@
 
 namespace Doctrine\Bundle\MongoDBBundle\Logger;
 
-use Symfony\Component\HttpKernel\Log\LoggerInterface as SymfonyLogger;
+use Psr\Log\LoggerInterface as PsrLogger;
 
 /**
  * A lightweight query logger.
@@ -27,7 +27,7 @@ class Logger implements LoggerInterface
     private $prefix;
     private $batchInsertTreshold;
 
-    public function __construct(SymfonyLogger $logger = null, $prefix = 'MongoDB query: ')
+    public function __construct(PsrLogger $logger = null, $prefix = 'MongoDB query: ')
     {
         $this->logger = $logger;
         $this->prefix = $prefix;


### PR DESCRIPTION
The Symfony LoggerInterface is deprecated, that class hints that the PsrLogger should be used instead.