### PR TITLE
move to PSR4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,11 +30,6 @@
             "Doctrine\\Bundle\\MongoDBBundle\\": ""
         }
     },
-    "autoload-dev": {
-        "psr-4": {
-            "Doctrine\\Bundle\\MongoDBBundle\\Tests\\": "Tests"
-        }
-    },
     "extra": {
         "branch-alias": {
             "dev-master": "3.0-dev"


### PR DESCRIPTION
can we do it?

I proposed this on a quick rush, so apologize, but i see that it triggered a good discussion. I believe updating a bundle just shows how we care about improving it and keeping it update. I am sure that even in bundles where we break the current PRs those bundles are aided by the contributors and it is not hard at all, with search and replace, to move folder structure, we have tests too for that.

I believe the main reason why to move is because of maintenance and there is no need to have multiple directories like @stof mentioned below. Good call @dbu. I guess the question is who takes upon the job. I can take a stab after June 13 :baby: 
