### PR TITLE
add support for bundle namespace alias

### DIFF
--- a/DependencyInjection/Compiler/DoctrineMongoDBMappingsPass.php
+++ b/DependencyInjection/Compiler/DoctrineMongoDBMappingsPass.php
@@ -20,6 +20,8 @@ use Symfony\Component\DependencyInjection\Reference;
  * Class for Symfony bundles to configure mappings for model classes not in the
  * automapped folder.
  *
+ * NOTE: alias is only supported by Symfony 2.6+ and will be ignored with older versions.
+ *
  * @author David Buchmann <mail@davidbu.ch>
  */
 class DoctrineMongoDBMappingsPass extends RegisterMappingsPass
@@ -33,8 +35,9 @@ class DoctrineMongoDBMappingsPass extends RegisterMappingsPass
      * @param string[]             $managerParameters list of parameters that could tell the manager name to use
      * @param bool                 $enabledParameter  if specified, the compiler pass only
      *                                                executes if this parameter exists in the service container.
+     * @param string[]             $aliasMap          Map of alias to namespace.
      */
-    public function __construct($driver, array $namespaces, array $managerParameters, $enabledParameter = false)
+    public function __construct($driver, array $namespaces, array $managerParameters, $enabledParameter = false, array $aliasMap = array())
     {
         $managerParameters[] = 'doctrine_mongodb.odm.default_document_manager';
         parent::__construct(
@@ -42,7 +45,11 @@ class DoctrineMongoDBMappingsPass extends RegisterMappingsPass
             $namespaces,
             $managerParameters,
             'doctrine_mongodb.odm.%s_metadata_driver',
-            $enabledParameter
+            $enabledParameter,
+            'doctrine_mongodb.odm.%s_configuration',
+            'addDocumentNamespace',
+            $aliasMap
+
         );
 
     }
@@ -56,14 +63,15 @@ class DoctrineMongoDBMappingsPass extends RegisterMappingsPass
      * @param string   $enabledParameter  Service container parameter that must be present to
      *                                    enable the mapping. Set to false to not do any check,
      *                                    optional.
+     * @param string[] $aliasMap          Map of alias to namespace.
      */
-    public static function createXmlMappingDriver(array $mappings, array $managerParameters, $enabledParameter = false)
+    public static function createXmlMappingDriver(array $mappings, array $managerParameters, $enabledParameter = false, array $aliasMap = array())
     {
         $arguments = array($mappings, '.mongodb.xml');
         $locator = new Definition('Doctrine\Common\Persistence\Mapping\Driver\SymfonyFileLocator', $arguments);
         $driver = new Definition('Doctrine\ODM\MongoDB\Mapping\Driver\XmlDriver', array($locator));
 
-        return new DoctrineMongoDBMappingsPass($driver, $mappings, $managerParameters, $enabledParameter);
+        return new DoctrineMongoDBMappingsPass($driver, $mappings, $managerParameters, $enabledParameter, $aliasMap);
     }
 
     /**
@@ -75,14 +83,15 @@ class DoctrineMongoDBMappingsPass extends RegisterMappingsPass
      * @param string   $enabledParameter  Service container parameter that must be present to
      *                                    enable the mapping. Set to false to not do any check,
      *                                    optional.
+     * @param string[] $aliasMap          Map of alias to namespace.
      */
-    public static function createYamlMappingDriver(array $mappings, array $managerParameters, $enabledParameter = false)
+    public static function createYamlMappingDriver(array $mappings, array $managerParameters, $enabledParameter = false, array $aliasMap = array())
     {
         $arguments = array($mappings, '.mongodb.yml');
         $locator = new Definition('Doctrine\Common\Persistence\Mapping\Driver\SymfonyFileLocator', $arguments);
         $driver = new Definition('Doctrine\ODM\MongoDB\Mapping\Driver\YamlDriver', array($locator));
 
-        return new DoctrineMongoDBMappingsPass($driver, $mappings, $managerParameters, $enabledParameter);
+        return new DoctrineMongoDBMappingsPass($driver, $mappings, $managerParameters, $enabledParameter, $aliasMap);
     }
 
     /**
@@ -94,14 +103,15 @@ class DoctrineMongoDBMappingsPass extends RegisterMappingsPass
      * @param string   $enabledParameter  Service container parameter that must be present to
      *                                    enable the mapping. Set to false to not do any check,
      *                                    optional.
+     * @param string[] $aliasMap          Map of alias to namespace.
      */
-    public static function createPhpMappingDriver(array $mappings, array $managerParameters = array(), $enabledParameter = false)
+    public static function createPhpMappingDriver(array $mappings, array $managerParameters = array(), $enabledParameter = false, array $aliasMap = array())
     {
         $arguments = array($mappings, '.php');
         $locator = new Definition('Doctrine\Common\Persistence\Mapping\Driver\SymfonyFileLocator', $arguments);
         $driver = new Definition('Doctrine\Common\Persistence\Mapping\Driver\PHPDriver', array($locator));
 
-        return new DoctrineMongoDBMappingsPass($driver, $mappings, $managerParameters, $enabledParameter);
+        return new DoctrineMongoDBMappingsPass($driver, $mappings, $managerParameters, $enabledParameter, $aliasMap);
     }
 
     /**
@@ -114,14 +124,15 @@ class DoctrineMongoDBMappingsPass extends RegisterMappingsPass
      * @param string   $enabledParameter  Service container parameter that must be present to
      *                                    enable the mapping. Set to false to not do any check,
      *                                    optional.
+     * @param string[] $aliasMap          Map of alias to namespace.
      */
-    public static function createAnnotationMappingDriver(array $namespaces, array $directories, array $managerParameters, $enabledParameter = false)
+    public static function createAnnotationMappingDriver(array $namespaces, array $directories, array $managerParameters, $enabledParameter = false, array $aliasMap = array())
     {
         $arguments = array(new Reference('doctrine_mongodb.odm.metadata.annotation_reader'), $directories);
         $locator = new Definition('Doctrine\Common\Persistence\Mapping\Driver\SymfonyFileLocator', $arguments);
         $driver = new Definition('Doctrine\ODM\MongoDB\Mapping\Driver\AnnotationDriver', array($locator));
 
-        return new DoctrineMongoDBMappingsPass($driver, $namespaces, $managerParameters, $enabledParameter);
+        return new DoctrineMongoDBMappingsPass($driver, $namespaces, $managerParameters, $enabledParameter, $aliasMap);
     }
 
     /**
@@ -134,11 +145,12 @@ class DoctrineMongoDBMappingsPass extends RegisterMappingsPass
      * @param string   $enabledParameter  Service container parameter that must be present to
      *                                    enable the mapping. Set to false to not do any check,
      *                                    optional.
+     * @param string[] $aliasMap          Map of alias to namespace.
      */
-    public static function createStaticPhpMappingDriver(array $namespaces, array $directories, array $managerParameters = array(), $enabledParameter = false)
+    public static function createStaticPhpMappingDriver(array $namespaces, array $directories, array $managerParameters = array(), $enabledParameter = false, array $aliasMap = array())
     {
         $driver = new Definition('Doctrine\Common\Persistence\Mapping\Driver\StaticPHPDriver', array($directories));
 
-        return new DoctrineMongoDBMappingsPass($driver, $namespaces, $managerParameters, $enabledParameter);
+        return new DoctrineMongoDBMappingsPass($driver, $namespaces, $managerParameters, $enabledParameter, $aliasMap);
     }
 }


### PR DESCRIPTION
add support for https://github.com/symfony/symfony/pull/10853 . this is compatible with older symfony versions because we just add one more parameter that will be ignored.
