### PR TITLE
Added a way to enable auto_mapping option using multipe document managers

### DIFF
--- a/DependencyInjection/DoctrineMongoDBExtension.php
+++ b/DependencyInjection/DoctrineMongoDBExtension.php
@@ -62,7 +62,17 @@ class DoctrineMongoDBExtension extends AbstractDoctrineExtension
         // load the connections
         $this->loadConnections($config['connections'], $container);
 
-        $config['document_managers'] = $this->fixManagersAutoMappings($config['document_managers'], $container->getParameter('kernel.bundles'));
+        // BC logic to handle DoctrineBridge < 2.6
+        if (!method_exists($this, 'fixManagersAutoMappings')) {
+            foreach ($config['document_managers'] as $entityManager) {
+                if ($entityManager['auto_mapping'] && count($config['document_managers']) > 1) {
+                    throw new \LogicException('You cannot enable "auto_mapping" when several document managers are defined.');
+                }
+            }
+        } else {
+            $config['document_managers'] = $this->fixManagersAutoMappings($config['document_managers'], $container->getParameter('kernel.bundles'));
+        }
+
 
         // load the document managers
         $this->loadDocumentManagers(

--- a/DependencyInjection/DoctrineMongoDBExtension.php
+++ b/DependencyInjection/DoctrineMongoDBExtension.php
@@ -62,6 +62,8 @@ class DoctrineMongoDBExtension extends AbstractDoctrineExtension
         // load the connections
         $this->loadConnections($config['connections'], $container);
 
+        $config['document_managers'] = $this->fixManagersAutoMappings($config['document_managers'], $container->getParameter('kernel.bundles'));
+
         // load the document managers
         $this->loadDocumentManagers(
             $config['document_managers'],

--- a/Tests/DependencyInjection/DoctrineMongoDBExtensionTest.php
+++ b/Tests/DependencyInjection/DoctrineMongoDBExtensionTest.php
@@ -42,15 +42,15 @@ class DoctrineMongoDBExtensionTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($value, $container->getParameter('doctrine_mongodb.odm.'.$parameter));
     }
 
-    private function getContainer($bundles = 'YamlBundle', $vendor = null)
+    private function getContainer($bundles = 'YamlBundle')
     {
         $bundles = (array) $bundles;
 
         $map = array();
         foreach ($bundles as $bundle) {
-            require_once __DIR__.'/Fixtures/Bundles/'.($vendor ? $vendor.'/' : '').$bundle.'/'.$bundle.'.php';
+            require_once __DIR__.'/Fixtures/Bundles/'.$bundle.'/'.$bundle.'.php';
 
-            $map[$bundle] = 'DoctrineMongoDBBundle\Tests\DependencyInjection\Fixtures\Bundles\\'.($vendor ? $vendor.'\\' : '').$bundle.'\\'.$bundle;
+            $map[$bundle] = 'DoctrineMongoDBBundle\Tests\DependencyInjection\Fixtures\Bundles\\'.$bundle.'\\'.$bundle;
         }
 
         return new ContainerBuilder(new ParameterBag(array(

--- a/Tests/DependencyInjection/DoctrineMongoDBExtensionTest.php
+++ b/Tests/DependencyInjection/DoctrineMongoDBExtensionTest.php
@@ -23,8 +23,11 @@ class DoctrineMongoDBExtensionTest extends \PHPUnit_Framework_TestCase
 
     public function testBackwardCompatibilityAliases()
     {
+        $container = new ContainerBuilder();
+        $container->setParameter('kernel.bundles', array());
+
         $loader = new DoctrineMongoDBExtension();
-        $loader->load(array(), $container = new ContainerBuilder());
+        $loader->load(array(), $container);
 
         $this->assertEquals('doctrine_mongodb.odm.document_manager', (string) $container->getAlias('doctrine.odm.mongodb.document_manager'));
     }
@@ -36,6 +39,7 @@ class DoctrineMongoDBExtensionTest extends \PHPUnit_Framework_TestCase
     {
         $container = new ContainerBuilder();
         $container->setParameter('kernel.debug', false);
+        $container->setParameter('kernel.bundles', array());
         $loader = new DoctrineMongoDBExtension();
         $loader->load(array(array($option => $value)), $container);
 
@@ -123,11 +127,11 @@ class DoctrineMongoDBExtensionTest extends \PHPUnit_Framework_TestCase
     public function testAutomapping(array $documentManagers)
     {
 
-    	$loader = new DoctrineMongoDBExtension();
+        $loader = new DoctrineMongoDBExtension();
 
-    	if (!method_exists($loader, 'fixManagersAutoMappings')) {
-    		$this->markTestSkipped('Automapping feature non available.');
-    	}
+        if (!method_exists($loader, 'fixManagersAutoMappings')) {
+            $this->markTestSkipped('Automapping feature non available.');
+        }
 
         $container = $this->getContainer(array(
             'YamlBundle',

--- a/Tests/DependencyInjection/DoctrineMongoDBExtensionTest.php
+++ b/Tests/DependencyInjection/DoctrineMongoDBExtensionTest.php
@@ -141,12 +141,8 @@ class DoctrineMongoDBExtensionTest extends \PHPUnit_Framework_TestCase
                 )
             ), $container);
 
-
-
         $configDm1 = $container->getDefinition('doctrine_mongodb.odm.dm1_configuration');
         $configDm2 = $container->getDefinition('doctrine_mongodb.odm.dm2_configuration');
-
-        print_r($configDm1->getMethodCalls());
 
         $this->assertContains(
             array(

--- a/Tests/DependencyInjection/DoctrineMongoDBExtensionTest.php
+++ b/Tests/DependencyInjection/DoctrineMongoDBExtensionTest.php
@@ -122,12 +122,17 @@ class DoctrineMongoDBExtensionTest extends \PHPUnit_Framework_TestCase
      */
     public function testAutomapping(array $documentManagers)
     {
+
+    	$loader = new DoctrineMongoDBExtension();
+
+    	if (!method_exists($loader, 'fixManagersAutoMappings')) {
+    		$this->markTestSkipped('Automapping feature non available.');
+    	}
+
         $container = $this->getContainer(array(
             'YamlBundle',
             'XmlBundle'
         ));
-
-        $loader = new DoctrineMongoDBExtension();
 
         $loader->load(
             array(


### PR DESCRIPTION
This PR adds to DoctrineMongoDBBundle the same functionality of https://github.com/doctrine/DoctrineBundle/issues/60 

It requires the approval of https://github.com/symfony/symfony/pull/11815 and would require a new min-version constraint for `symfony/doctrine-bridge` (eg: `~2.6` if merged in SF 2.6...).