### PR TITLE
Added "doctrine" alise to "doctrine_mongodb" service

### DIFF
--- a/Resources/config/mongodb.xml
+++ b/Resources/config/mongodb.xml
@@ -148,6 +148,7 @@
                 <argument type="service" id="service_container" />
             </call>
         </service>
+        <service id="doctrine" alias="doctrine_mongodb" />
 
         <!-- listeners -->
         <service id="doctrine_mongodb.odm.listeners.resolve_target_document" class="%doctrine_mongodb.odm.listeners.resolve_target_document.class%" public="false" />


### PR DESCRIPTION
We need this to have ability use:

``` php
$this->getDoctrine()
```

in controllers that have extends by Symfony\Bundle\FrameworkBundle\Controller\Controller
There we have this:

``` php
public function getDoctrine()
    {
        if (!$this->container->has('doctrine')) {
            throw new \LogicException('The DoctrineBundle is not registered in your application.');
        }

        return $this->container->get('doctrine');
    }
```
