### PR TITLE
spl_object_hash() error when using option by_reference in DocumentType

### DIFF
--- a/Tests/Fixtures/Form/Playlist.php
+++ b/Tests/Fixtures/Form/Playlist.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Doctrine\Bundle\MongoDBBundle\Tests\Fixtures\Form;
+
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\Common\Collections\ArrayCollection;
+
+/**
+ * @ODM\Document
+ */
+class Playlist
+{
+    /**
+     * @ODM\Id
+     */
+    protected $id;
+
+    /**
+     * @ODM\ReferenceMany(targetDocument="Video", inversedBy="playlists")
+     */
+    protected $videos;
+
+    public function __construct()
+    {
+        $this->videos = new ArrayCollection();
+    }
+
+    public function __toString()
+    {
+        return (string) $this->getId();
+    }
+
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    public function setId($id)
+    {
+        $this->id = $id;
+    }
+
+    public function getVideos()
+    {
+        return $this->videos;
+    }
+
+    public function addVideo(Video $video)
+    {
+        $this->videos->add($video);
+        $video->addPlaylist($this);
+    }
+
+    public function removeVideo(Video $video)
+    {
+        $this->videos->removeElement($video);
+        $video->removePlaylist($this);
+    }
+}

--- a/Tests/Fixtures/Form/Playlist.php
+++ b/Tests/Fixtures/Form/Playlist.php
@@ -45,6 +45,17 @@ class Playlist
         return $this->videos;
     }
 
+    public function setVideos(ArrayCollection $videos)
+    {
+        foreach ($this->getVideos() as $oldVideo) {
+            $this->removeVideo($oldVideo);
+        }
+
+        foreach ($videos as $newVideo) {
+            $this->addVideo($newVideo);
+        }
+    }
+
     public function addVideo(Video $video)
     {
         $this->videos->add($video);

--- a/Tests/Fixtures/Form/Video.php
+++ b/Tests/Fixtures/Form/Video.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Doctrine\Bundle\MongoDBBundle\Tests\Fixtures\Form;
+
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\Common\Collections\ArrayCollection;
+
+/**
+ * @ODM\Document
+ */
+class Video
+{
+    /**
+     * @ODM\Id
+     */
+    protected $id;
+
+    /**
+     * @ODM\Int()
+     */
+    protected $nbPlaylists = 0;
+
+    /**
+     * @ODM\ReferenceMany(targetDocument="Playlist", mappedBy="videos")
+     */
+    protected $playlists;
+
+    public function __construct()
+    {
+        $this->playlists = new ArrayCollection();
+    }
+
+    public function __toString()
+    {
+        return (string) $this->getId();
+    }
+
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    public function setId($id)
+    {
+        $this->id = $id;
+    }
+
+    public function addPlaylist(Playlist $playlist)
+    {
+        $this->playlists->add($playlist);
+        $this->nbPlaylists++;
+    }
+
+    public function removePlaylist(Playlist $playlist)
+    {
+        $this->playlists->removeElement($playlist);
+        $this->nbPlaylists--;
+    }
+
+    public function getPlaylists()
+    {
+        return $this->playlists;
+    }
+
+    public function getNbPlaylists()
+    {
+        return $this->nbPlaylists;
+    }
+
+    public function setNbPlaylists($nbPlaylists)
+    {
+        $this->nbPlaylists = $nbPlaylists;
+    }
+}

--- a/Tests/Form/Type/DocumentTypeTest.php
+++ b/Tests/Form/Type/DocumentTypeTest.php
@@ -5,6 +5,8 @@ namespace Doctrine\Bundle\MongoDBBundle\Tests\Form\Type;
 use Doctrine\Bundle\MongoDBBundle\Tests\TestCase;
 use Doctrine\Bundle\MongoDBBundle\Form\DoctrineMongoDBExtension;
 use Symfony\Component\Form\Tests\Extension\Core\Type\TypeTestCase;
+use Doctrine\Bundle\MongoDBBundle\Tests\Fixtures\Form\Playlist;
+use Doctrine\Bundle\MongoDBBundle\Tests\Fixtures\Form\Video;
 
 class DocumentTypeTest extends TypeTestCase
 {
@@ -22,6 +24,8 @@ class DocumentTypeTest extends TypeTestCase
     {
         $this->dm = TestCase::createTestDocumentManager(array(
             __DIR__ . '/../../Fixtures/Form/Document',
+            __DIR__ . '/../../Fixtures/Form/Playlist',
+            __DIR__ . '/../../Fixtures/Form/Video',
         ));
         $this->dmRegistry = $this->createRegistryMock('default', $this->dm);
 
@@ -68,5 +72,42 @@ class DocumentTypeTest extends TypeTestCase
         return array_merge(parent::getExtensions(), array(
             new DoctrineMongoDBExtension($this->dmRegistry),
         ));
+    }
+
+    public function testManyToManyReferences()
+    {
+        $videoOne = new Video();
+        $this->dm->persist($videoOne);
+        $videoTwo = new Video();
+        $this->dm->persist($videoTwo);
+        $this->dm->flush();
+
+        $playlist = new Playlist();
+        $playlist->addVideo($videoOne);
+        $playlist->addVideo($videoTwo);
+        $this->dm->persist($playlist);
+        $this->dm->flush();
+
+        $this->assertCount(2, $playlist->getVideos());
+        $this->assertCount(1, $videoOne->getPlaylists());
+        $this->assertCount(1, $videoTwo->getPlaylists());
+        $this->assertEquals(1, $videoOne->getNbPlaylists());
+        $this->assertEquals(1, $videoTwo->getNbPlaylists());
+
+        $form = $this->factory->create('document', $playlist->getVideos(), [
+            'class' => 'Doctrine\Bundle\MongoDBBundle\Tests\Fixtures\Form\Video',
+            'multiple' => true,
+            'by_reference' => false,
+            'document_manager' => 'default',
+        ]);
+
+        $form->submit([]);
+        $this->dm->flush();
+
+        $this->assertCount(0, $playlist->getVideos());
+        $this->assertCount(0, $videoOne->getPlaylists());
+        $this->assertCount(0, $videoTwo->getPlaylists());
+        $this->assertEquals(0, $videoOne->getNbPlaylists());
+        $this->assertEquals(0, $videoTwo->getNbPlaylists());
     }
 }

--- a/Tests/Form/Type/DocumentTypeTest.php
+++ b/Tests/Form/Type/DocumentTypeTest.php
@@ -104,6 +104,7 @@ class DocumentTypeTest extends TypeTestCase
         $form->submit([]);
         $this->dm->flush();
 
+        $this->assertCount(0, $form->getData());
         $this->assertCount(0, $playlist->getVideos());
         $this->assertCount(0, $videoOne->getPlaylists());
         $this->assertCount(0, $videoTwo->getPlaylists());


### PR DESCRIPTION
I added a phpunit test with fixtures and I get the following error when executing this test:

```
spl_object_hash() expects parameter 1 to be object, null given

/home/cgorron/DoctrineMongoDBBundle/vendor/doctrine/mongodb-odm/lib/Doctrine/ODM/MongoDB/UnitOfWork.php:315
/home/cgorron/DoctrineMongoDBBundle/vendor/doctrine/mongodb-odm/lib/Doctrine/ODM/MongoDB/Persisters/CollectionPersister.php:259
/home/cgorron/DoctrineMongoDBBundle/vendor/doctrine/mongodb-odm/lib/Doctrine/ODM/MongoDB/Persisters/CollectionPersister.php:85
/home/cgorron/DoctrineMongoDBBundle/vendor/doctrine/mongodb-odm/lib/Doctrine/ODM/MongoDB/UnitOfWork.php:457
/home/cgorron/DoctrineMongoDBBundle/vendor/doctrine/mongodb-odm/lib/Doctrine/ODM/MongoDB/DocumentManager.php:543
/home/cgorron/DoctrineMongoDBBundle/Tests/Form/Type/DocumentTypeTest.php:105
```

This seems to be caused by the option 'by_reference' with a ManyToMany relationship. I need to use this option to call specific 'add' methods in the document.
(If I don't use this option and I increase the 'nbPlaylists' with a separate listener, I don't get this error)