### PR TITLE
Allow symfony 3.0 components

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,14 +13,14 @@
     "require": {
         "php": ">=5.3.2",
         "doctrine/mongodb-odm": "~1.0.0-beta10@dev",
-        "symfony/options-resolver": "~2.1",
-        "symfony/doctrine-bridge": "~2.1",
-        "symfony/framework-bundle": "~2.1"
+        "symfony/options-resolver": "~2.3|~3.0",
+        "symfony/doctrine-bridge": "~2.3|~3.0",
+        "symfony/framework-bundle": "~2.3|~3.0"
     },
     "require-dev": {
         "doctrine/data-fixtures": "@dev",
-        "symfony/form": "~2.1",
-        "symfony/yaml": "~2.1"
+        "symfony/form": "~2.3|~3.0",
+        "symfony/yaml": "~2.3|~3.0"
     },
     "suggest": {
         "doctrine/data-fixtures": "Load data fixtures"


### PR DESCRIPTION
Tests should tell if any deprecated interfaces of Symfony are used. If not, then the bundle is defacto compatible with 3.0