### PR TITLE
Test the limitNum key when appending the limit

### DIFF
--- a/DataCollector/PrettyDataCollector.php
+++ b/DataCollector/PrettyDataCollector.php
@@ -110,7 +110,7 @@ class PrettyDataCollector extends StandardDataCollector
                     $query .= ')';
                 } elseif (isset($log['skip'])) {
                     $query .= '.skip('.$log['skipNum'].')';
-                } elseif (isset($log['limit'])) {
+                } elseif (isset($log['limit']) && isset($log['limitNum'])) {
                     $query .= '.limit('.$log['limitNum'].')';
                 } elseif (isset($log['createCollection'])) {
                     $query .= '.createCollection()';

--- a/Tests/DataCollector/PrettyDataCollectorTest.php
+++ b/Tests/DataCollector/PrettyDataCollectorTest.php
@@ -50,4 +50,78 @@ class PrettyDataCollectorTest extends \PHPUnit_Framework_TestCase
             )
         );
     }
+
+    public function testCollectLimit()
+    {
+        $queries = array(
+            array(
+                'find' => true,
+                'query' => array(
+                    'path' => '/',
+                ),
+                'fields' => array(),
+                'db' => 'foo',
+                'collection' => 'Route',
+            ),
+            array(
+                'find' => true,
+                'query' => array('_id' => 'foo'),
+                'fields' => array(),
+                'db' => 'foo',
+                'collection' => 'User',
+            ),
+            array(
+                'limit' => true,
+                'limitNum' => 1,
+                'query' => array('_id' => 'foo'),
+                'fields' => array(),
+            ),
+            array(
+                'limit' => true,
+                'limitNum' => NULL,
+                'query' => array('_id' => 'foo'),
+                'fields' => array(),
+            ),
+            array(
+                'find' => true,
+                'query' => array(
+                    '_id' => '5506fa1580c7e1ee3c8b4c60',
+                ),
+                'fields' => array(),
+                'db' => 'foo',
+                'collection' => 'Group',
+            ),
+            array(
+                'limit' => true,
+                'limitNum' => 1,
+                'query' => array(
+                    '_id' => '5506fa1580c7e1ee3c8b4c60',
+                ),
+                'fields' => array(),
+            ),
+            array(
+                'limit' => true,
+                'limitNum' => NULL,
+                'query' => array(
+                    '_id' => '5506fa1580c7e1ee3c8b4c60',
+                ),
+                'fields' => array(),
+            ),
+        );
+        $formatted = array(
+            'use foo;',
+            'db.Route.find({ "path": "/" });',
+            'db.User.find({ "_id": "foo" }).limit(1);',
+            'db.Group.find({ "_id": "5506fa1580c7e1ee3c8b4c60" }).limit(1);'
+        );
+
+        $collector = new PrettyDataCollector();
+        foreach ($queries as $query) {
+            $collector->logQuery($query);
+        }
+        $collector->collect(new Request(), new Response());
+
+        $this->assertEquals(3, $collector->getQueryCount());
+        $this->assertEquals($formatted, $collector->getQueries());
+    }
 }


### PR DESCRIPTION
In the current implementation, it is possible that invalid queries are displayed in the profiler:

```php
use myDb;
db.User.find({ "$and": [ { "_id": ObjectId("54ef2e9780c7e11e188b49ab") }, { "deletedAt": null } ] }).limit(1).limit();
db.Group.find({ "_id": { "$in": [ ObjectId("54ef2e9b80c7e11e188b4c5d") ] } }).sort([ ]);
db.Town.find({ "_id": ObjectId("54ef2e9280c7e11e188b4589") }).limit(1).limit();
```

With the suggested change, this results in:

```php
use myDb;
db.User.find({ "$and": [ { "_id": ObjectId("54ef2e9780c7e11e188b49ab") }, { "deletedAt": null } ] }).limit(1);
db.Group.find({ "_id": { "$in": [ ObjectId("54ef2e9b80c7e11e188b4c5d") ] } }).sort([ ]);
db.Town.find({ "_id": ObjectId("54ef2e9280c7e11e188b4589") }).limit(1);
```