### PR TITLE
Annotation driver mapping pass isn't correctly instantiated

### DIFF
--- a/DependencyInjection/Compiler/DoctrineMongoDBMappingsPass.php
+++ b/DependencyInjection/Compiler/DoctrineMongoDBMappingsPass.php
@@ -128,7 +128,7 @@ class DoctrineMongoDBMappingsPass extends RegisterMappingsPass
      */
     public static function createAnnotationMappingDriver(array $namespaces, array $directories, array $managerParameters, $enabledParameter = false, array $aliasMap = array())
     {
-        $driver = new Definition('Doctrine\ODM\MongoDB\Mapping\Driver\AnnotationDriver', array(new Reference('doctrine_mongodb.odm.metadata.annotation_reader'), $directories));
+        $driver = new Definition('Doctrine\ODM\MongoDB\Mapping\Driver\AnnotationDriver', array(new Reference('annotation_reader'), $directories));
 
         return new DoctrineMongoDBMappingsPass($driver, $namespaces, $managerParameters, $enabledParameter, $aliasMap);
     }

--- a/DependencyInjection/Compiler/DoctrineMongoDBMappingsPass.php
+++ b/DependencyInjection/Compiler/DoctrineMongoDBMappingsPass.php
@@ -128,9 +128,7 @@ class DoctrineMongoDBMappingsPass extends RegisterMappingsPass
      */
     public static function createAnnotationMappingDriver(array $namespaces, array $directories, array $managerParameters, $enabledParameter = false, array $aliasMap = array())
     {
-        $arguments = array(new Reference('doctrine_mongodb.odm.metadata.annotation_reader'), $directories);
-        $locator = new Definition('Doctrine\Common\Persistence\Mapping\Driver\SymfonyFileLocator', $arguments);
-        $driver = new Definition('Doctrine\ODM\MongoDB\Mapping\Driver\AnnotationDriver', array($locator));
+        $driver = new Definition('Doctrine\ODM\MongoDB\Mapping\Driver\AnnotationDriver', array(new Reference('doctrine_mongodb.odm.metadata.annotation_reader'), $directories));
 
         return new DoctrineMongoDBMappingsPass($driver, $namespaces, $managerParameters, $enabledParameter, $aliasMap);
     }


### PR DESCRIPTION
It looks like this was a busted copy/paste from one of the other drivers; all this PR does is correct the arguments so that an annotations-based mappings pass works as expected.