### PR TITLE
Improve the Travis setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,14 +3,30 @@ language: php
 php:
   - 5.3
   - 5.4
+  - 5.5
+  - 5.6
 
-env:
-  - MONGO_VERSION=1.2.12
-  - MONGO_VERSION=1.3.3
+matrix:
+  include:
+    - php: 5.3
+      env: COMPOSER_FLAGS='--prefer-lowest --prefer-stable'
+    - php: 5.6
+      env: MONGO_VERSION=1.2.12
+    - php: 5.6
+      env: MONGO_VERSION=1.3.3
+
+sudo: false
+
+cache:
+  directories:
+    - $HOME/.composer/cache
 
 services: mongodb
 
-before_script:
-  - pecl -q install -f mongo-${MONGO_VERSION} && echo "extension=mongo.so" >> `php --ini | grep "Loaded Configuration" | sed -e "s|.*:\s*||"`
-  - composer install --dev
+before_install:
+  - if [ "$MONGO_VERSION" != "" ]; then pecl -q install -f mongo-${MONGO_VERSION}; fi # Use a specific driver version when needed rather than the one shipped by Travis
+  - echo "extension=mongo.so" >> `php --ini | grep "Loaded Configuration" | sed -e "s|.*:\s*||"`
+
+install:
+  - composer update $COMPOSER_FLAGS
 

--- a/composer.json
+++ b/composer.json
@@ -15,11 +15,14 @@
         "doctrine/mongodb-odm": "~1.0.0-beta10@dev",
         "symfony/options-resolver": "~2.1",
         "symfony/doctrine-bridge": "~2.1",
-        "symfony/framework-bundle": "~2.1"
+        "symfony/framework-bundle": "~2.1",
+        "symfony/dependency-injection": "~2.2",
+        "symfony/console": "~2.1",
+        "symfony/config": "~2.2"
     },
     "require-dev": {
         "doctrine/data-fixtures": "@dev",
-        "symfony/form": "~2.1",
+        "symfony/form": "~2.3",
         "symfony/yaml": "~2.1"
     },
     "suggest": {


### PR DESCRIPTION
- add testing against newer PHP versions
- add testing on lowest composer deps (and fix them)
- switch to the faster container-based infrastructure
- keep the composer cache between builds
- use the mongo driver shipped by Travis for most builds (it is much newer, and already installed so faster)