### PR TITLE
Allow to load fixtures from files through the command

### DIFF
--- a/Command/LoadDataFixturesDoctrineODMCommand.php
+++ b/Command/LoadDataFixturesDoctrineODMCommand.php
@@ -79,6 +79,8 @@ EOT
         foreach ($paths as $path) {
             if (is_dir($path)) {
                 $loader->loadFromDirectory($path);
+            } else if (is_file($path)) {
+                $loader->loadFromFile($path);
             }
         }
 


### PR DESCRIPTION
Currently, it's not possible to target specific files when loading the fixtures with the --fixtures option in the command, as it will only take folders into account.
This PR allows to specify files when running the command.