### PR TITLE
Removed incorrect conditional

### DIFF
--- a/Command/DoctrineODMCommand.php
+++ b/Command/DoctrineODMCommand.php
@@ -102,9 +102,10 @@ abstract class DoctrineODMCommand extends ContainerAwareCommand
         $search = str_replace('\\', '/', $bundle->getPath());
         $destination = str_replace('/'.$path, '', $search, $c);
 
-        if ($c != 1) {
-            throw new \RuntimeException(sprintf('Can\'t find base path for bundle (path: "%s", destination: "%s").', $path, $destination));
-        }
+        // TODO: Find a better way to know if we found the base path for the bundle
+        // if ($c != 1) {
+        //     throw new \RuntimeException(sprintf('Can\'t find base path for bundle (path: "%s", destination: "%s").', $path, $destination));
+        // }
 
         return $destination;
     }


### PR DESCRIPTION
Removed incorrect conditional in findBasePathForBundle. This statement is incompatible with PSR-4 routes, it isn't true that if the str_replace doesn't do any replacement then the route isn't correct.