### PR TITLE
Improved PSR-4 compliance

### DIFF
--- a/Command/DoctrineODMCommand.php
+++ b/Command/DoctrineODMCommand.php
@@ -98,9 +98,9 @@ abstract class DoctrineODMCommand extends ContainerAwareCommand
      */
     protected function findBasePathForBundle($bundle)
     {
-        $path = str_replace('\\', '/', $bundle->getNamespace());
-        $search = str_replace('\\', '/', $bundle->getPath());
-        $destination = str_replace('/'.$path, '', $search, $c);
+        $path = str_replace('\\', DIRECTORY_SEPARATOR, $bundle->getNamespace());
+        $search = str_replace('\\', DIRECTORY_SEPARATOR, $bundle->getPath());
+        $destination = str_replace(DIRECTORY_SEPARATOR.$path, '', $search, $c);
 
         if ($c != 1) {
             throw new \RuntimeException(sprintf('Can\'t find base path for bundle (path: "%s", destination: "%s").', $path, $destination));

--- a/Command/GenerateRepositoriesDoctrineODMCommand.php
+++ b/Command/GenerateRepositoriesDoctrineODMCommand.php
@@ -67,7 +67,11 @@ EOT
                     }
 
                     $output->writeln(sprintf('  > <info>OK</info> generating <comment>%s</comment>', $metadata->customRepositoryClassName));
-                    $generator->writeDocumentRepositoryClass($metadata->customRepositoryClassName, $this->findBasePathForBundle($foundBundle));
+                    $generator->writeDocumentRepositoryClass(
+                        $metadata->customRepositoryClassName,
+                        $foundBundle->getPath(),
+                        $foundBundle->getNamespace()
+                    );
                 } else {
                     $output->writeln(sprintf('  > <error>SKIP</error> no custom repository for <comment>%s</comment>', $metadata->name));
                 }


### PR DESCRIPTION
This pull request changes the way how `GenerateRepositoriesDoctrineODMCommand` handles filepaths in order to make this bundle more PSR-4 friendly.

The change is possible because a patch has been merged in the doctrine/mongodb-odm project  https://github.com/doctrine/mongodb-odm/commit/7fe7b97324aee632d8232b6e7db7fe2bbe68512c ).

There's also a minor change (fix) in the `DoctrineODMCommand::findBasePathForBundle` method. The way it was previously done is error prone in systems like Windows. Is easy to view that the "separators normalization" is done in order to make possible the replacement done in the `$destination` variable construction, but this method also works with `DIRECTORY_SEPARATOR` instead than with `'/'`.

An extra comment: I think that there is no need to call `str_replace` in the line *102* (`Command/DoctrineODMCommand.php` file), but I left there to discuss it with other developers.

Probably the pull request needs more tests to be developed before accepting it, I'll posted before typing the tests to allow early discussion.