### PR TITLE
Remove Symfony's HttpKernel logger in favor of PSR-3

### DIFF
--- a/Logger/Logger.php
+++ b/Logger/Logger.php
@@ -14,7 +14,7 @@
 
 namespace Doctrine\Bundle\MongoDBBundle\Logger;
 
-use Symfony\Component\HttpKernel\Log\LoggerInterface as SymfonyLogger;
+use Psr\Log\LoggerInterface as PsrLogger;
 
 /**
  * A lightweight query logger.
@@ -27,7 +27,7 @@ class Logger implements LoggerInterface
     private $prefix;
     private $batchInsertTreshold;
 
-    public function __construct(SymfonyLogger $logger = null, $prefix = 'MongoDB query: ')
+    public function __construct(PsrLogger $logger = null, $prefix = 'MongoDB query: ')
     {
         $this->logger = $logger;
         $this->prefix = $prefix;

--- a/composer.json
+++ b/composer.json
@@ -12,13 +12,15 @@
     ],
     "require": {
         "php": ">=5.3.2",
+        "psr/log": "~1.0",
         "doctrine/mongodb-odm": "~1.0.0-beta10@dev",
         "symfony/options-resolver": "~2.1",
         "symfony/doctrine-bridge": "~2.1",
         "symfony/framework-bundle": "~2.1",
         "symfony/dependency-injection": "~2.2",
         "symfony/console": "~2.1",
-        "symfony/config": "~2.2"
+        "symfony/config": "~2.2",
+        "mongofill/mongofill": "dev-master@dev"
     },
     "require-dev": {
         "doctrine/data-fixtures": "@dev",

--- a/composer.json
+++ b/composer.json
@@ -19,8 +19,7 @@
         "symfony/framework-bundle": "~2.1",
         "symfony/dependency-injection": "~2.2",
         "symfony/console": "~2.1",
-        "symfony/config": "~2.2",
-        "mongofill/mongofill": "dev-master@dev"
+        "symfony/config": "~2.2"
     },
     "require-dev": {
         "doctrine/data-fixtures": "@dev",


### PR DESCRIPTION
This is particularly relevant for Symfony 3 where the HttpKernel logger has been completely removed.