### PR TITLE
Require stable ODM version

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -15,6 +15,11 @@ To generate a changelog summary since the last version, run
 3.0.x-dev
 ---------
 
+3.0.1 (2015-08-31)
+------------------
+
+* [42565f1](https://github.com/doctrine/DoctrineMongoDBBundle/commit/42565f1511d0cae687319e0479b9628aa963589c) fixed security vulnerability [CVE-2015-5723](http://www.cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2015-5723)
+
 3.0.0 (2015-05-22)
 ------------------
 

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "php": ">=5.3.2",
-        "doctrine/mongodb-odm": "~1.0.0-beta10@dev",
+        "doctrine/mongodb-odm": "~1.0",
         "symfony/options-resolver": "~2.1",
         "symfony/doctrine-bridge": "~2.1",
         "symfony/framework-bundle": "~2.1",


### PR DESCRIPTION
ODM 1.0.0 was released in August. It's about time we update that version constraint here.