### PR TITLE
Symfony 3.0 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,13 @@
 language: php
 
 php:
-  - 5.3
-  - 5.4
   - 5.5
   - 5.6
 
 matrix:
   include:
-    - php: 5.3
+    - php: 5.5
       env: COMPOSER_FLAGS='--prefer-lowest --prefer-stable'
-    - php: 5.6
-      env: MONGO_VERSION=1.2.12
-    - php: 5.6
-      env: MONGO_VERSION=1.3.3
 
 sudo: false
 
@@ -24,9 +18,8 @@ cache:
 services: mongodb
 
 before_install:
-  - if [ "$MONGO_VERSION" != "" ]; then pecl -q install -f mongo-${MONGO_VERSION}; fi # Use a specific driver version when needed rather than the one shipped by Travis
-  - echo "extension=mongo.so" >> `php --ini | grep "Loaded Configuration" | sed -e "s|.*:\s*||"`
+  - yes '' | pecl -q install -f mongo
+  - php --ri mongo
 
 install:
   - composer update $COMPOSER_FLAGS
-

--- a/CacheWarmer/HydratorCacheWarmer.php
+++ b/CacheWarmer/HydratorCacheWarmer.php
@@ -29,12 +29,12 @@ use Symfony\Component\HttpKernel\CacheWarmer\CacheWarmerInterface;
 class HydratorCacheWarmer implements CacheWarmerInterface
 {
     /**
-     * @var Container
+     * @var ContainerInterface
      */
     private $container;
 
     /**
-     * @param Container $container
+     * @param ContainerInterface $container
      */
     public function __construct(ContainerInterface $container)
     {

--- a/CacheWarmer/ProxyCacheWarmer.php
+++ b/CacheWarmer/ProxyCacheWarmer.php
@@ -29,12 +29,12 @@ use Symfony\Component\HttpKernel\CacheWarmer\CacheWarmerInterface;
 class ProxyCacheWarmer implements CacheWarmerInterface
 {
     /**
-     * @var Container
+     * @var ContainerInterface
      */
     private $container;
 
     /**
-     * @param Container $container
+     * @param ContainerInterface $container
      */
     public function __construct(ContainerInterface $container)
     {

--- a/Command/InfoDoctrineODMCommand.php
+++ b/Command/InfoDoctrineODMCommand.php
@@ -51,7 +51,7 @@ EOT
             $input->getOption('dm') :
             $this->getContainer()->get('doctrine_mongodb')->getDefaultManagerName();
 
-        /* @var $documentManager Doctrine\ODM\MongoDB\DocumentManager */
+        /* @var $documentManager \Doctrine\ODM\MongoDB\DocumentManager */
         $documentManager = $this->getContainer()->get('doctrine_mongodb')->getManager($documentManagerName);
 
         $documentClassNames = $documentManager->getConfiguration()

--- a/DependencyInjection/DoctrineMongoDBExtension.php
+++ b/DependencyInjection/DoctrineMongoDBExtension.php
@@ -237,12 +237,7 @@ class DoctrineMongoDBExtension extends AbstractDoctrineExtension
             new Reference(sprintf('doctrine_mongodb.odm.%s_connection.event_manager', $connectionName)),
         );
         $odmDmDef = new Definition('%doctrine_mongodb.odm.document_manager.class%', $odmDmArgs);
-        if (method_exists($odmDmDef, 'setFactory')) {
-            $odmDmDef->setFactory(array('%doctrine_mongodb.odm.document_manager.class%', 'create'));
-        } else {
-            $odmDmDef->setFactoryClass('%doctrine_mongodb.odm.document_manager.class%');
-            $odmDmDef->setFactoryMethod('create');
-        }
+        $odmDmDef->setFactory(array('%doctrine_mongodb.odm.document_manager.class%', 'create'));
         $odmDmDef->addTag('doctrine_mongodb.odm.document_manager');
 
         $container

--- a/Form/Type/DocumentType.php
+++ b/Form/Type/DocumentType.php
@@ -18,7 +18,7 @@ use Doctrine\Bundle\MongoDBBundle\Form\ChoiceList\MongoDBQueryBuilderLoader;
 use Doctrine\Common\Persistence\ObjectManager;
 use Symfony\Bridge\Doctrine\Form\Type\DoctrineType;
 use Symfony\Component\OptionsResolver\Options;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * Form type for a MongoDB document
@@ -41,11 +41,11 @@ class DocumentType extends DoctrineType
     }
 
     /**
-     * @param OptionsResolverInterface $resolver
+     * @param OptionsResolver $resolver
      */
-    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    public function configureOptions(OptionsResolver $resolver)
     {
-        parent::setDefaultOptions($resolver);
+        parent::configureOptions($resolver);
 
         $resolver->setDefaults(array(
             'document_manager' => null,
@@ -66,16 +66,6 @@ class DocumentType extends DoctrineType
             return $registry->getManager($manager);
         };
 
-        $resolver->setNormalizers(array(
-            'em' => $normalizer,
-        ));
-    }
-
-    /**
-     * @see Symfony\Component\Form\FormTypeInterface::getName()
-     */
-    public function getName()
-    {
-        return 'document';
+        $resolver->setNormalizer('em', $normalizer);
     }
 }

--- a/Logger/Logger.php
+++ b/Logger/Logger.php
@@ -25,7 +25,7 @@ class Logger implements LoggerInterface
 {
     private $logger;
     private $prefix;
-    private $batchInsertTreshold;
+    private $batchInsertThreshold;
 
     public function __construct(PsrLogger $logger = null, $prefix = 'MongoDB query: ')
     {
@@ -33,9 +33,9 @@ class Logger implements LoggerInterface
         $this->prefix = $prefix;
     }
 
-    public function setBatchInsertThreshold($batchInsertTreshold)
+    public function setBatchInsertThreshold($batchInsertThreshold)
     {
-        $this->batchInsertTreshold = $batchInsertTreshold;
+        $this->batchInsertThreshold = $batchInsertThreshold;
     }
 
     public function logQuery(array $query)
@@ -44,7 +44,7 @@ class Logger implements LoggerInterface
             return;
         }
 
-        if (isset($query['batchInsert']) && null !== $this->batchInsertTreshold && $this->batchInsertTreshold <= $query['num']) {
+        if (isset($query['batchInsert']) && null !== $this->batchInsertThreshold && $this->batchInsertThreshold <= $query['num']) {
             $query['data'] = '**'.$query['num'].' item(s)**';
         }
 

--- a/Tests/DependencyInjection/AbstractMongoDBExtensionTest.php
+++ b/Tests/DependencyInjection/AbstractMongoDBExtensionTest.php
@@ -76,12 +76,7 @@ abstract class AbstractMongoDBExtensionTest extends TestCase
 
         $definition = $container->getDefinition('doctrine_mongodb.odm.default_document_manager');
         $this->assertEquals('%doctrine_mongodb.odm.document_manager.class%', $definition->getClass());
-        if (method_exists($definition, 'getFactory')) {
-            $this->assertEquals(array('%doctrine_mongodb.odm.document_manager.class%', 'create'), $definition->getFactory());
-        } else {
-            $this->assertEquals('%doctrine_mongodb.odm.document_manager.class%', $definition->getFactoryClass());
-            $this->assertEquals('create', $definition->getFactoryMethod());
-        }
+        $this->assertEquals(array('%doctrine_mongodb.odm.document_manager.class%', 'create'), $definition->getFactory());
         $this->assertArrayHasKey('doctrine_mongodb.odm.document_manager', $definition->getTags());
 
         $arguments = $definition->getArguments();
@@ -120,12 +115,7 @@ abstract class AbstractMongoDBExtensionTest extends TestCase
 
         $definition = $container->getDefinition('doctrine_mongodb.odm.default_document_manager');
         $this->assertEquals('%doctrine_mongodb.odm.document_manager.class%', $definition->getClass());
-        if (method_exists($definition, 'getFactory')) {
-            $this->assertEquals(array('%doctrine_mongodb.odm.document_manager.class%', 'create'), $definition->getFactory());
-        } else {
-            $this->assertEquals('%doctrine_mongodb.odm.document_manager.class%', $definition->getFactoryClass());
-            $this->assertEquals('create', $definition->getFactoryMethod());
-        }
+        $this->assertEquals(array('%doctrine_mongodb.odm.document_manager.class%', 'create'), $definition->getFactory());
         $this->assertArrayHasKey('doctrine_mongodb.odm.document_manager', $definition->getTags());
 
         $arguments = $definition->getArguments();
@@ -166,12 +156,7 @@ abstract class AbstractMongoDBExtensionTest extends TestCase
 
         $definition = $container->getDefinition('doctrine_mongodb.odm.default_document_manager');
         $this->assertEquals('%doctrine_mongodb.odm.document_manager.class%', $definition->getClass());
-        if (method_exists($definition, 'getFactory')) {
-            $this->assertEquals(array('%doctrine_mongodb.odm.document_manager.class%', 'create'), $definition->getFactory());
-        } else {
-            $this->assertEquals('%doctrine_mongodb.odm.document_manager.class%', $definition->getFactoryClass());
-            $this->assertEquals('create', $definition->getFactoryMethod());
-        }
+        $this->assertEquals(array('%doctrine_mongodb.odm.document_manager.class%', 'create'), $definition->getFactory());
         $this->assertArrayHasKey('doctrine_mongodb.odm.document_manager', $definition->getTags());
 
         $arguments = $definition->getArguments();
@@ -209,12 +194,7 @@ abstract class AbstractMongoDBExtensionTest extends TestCase
 
         $definition = $container->getDefinition('doctrine_mongodb.odm.default_document_manager');
         $this->assertEquals('%doctrine_mongodb.odm.document_manager.class%', $definition->getClass());
-        if (method_exists($definition, 'getFactory')) {
-            $this->assertEquals(array('%doctrine_mongodb.odm.document_manager.class%', 'create'), $definition->getFactory());
-        } else {
-            $this->assertEquals('%doctrine_mongodb.odm.document_manager.class%', $definition->getFactoryClass());
-            $this->assertEquals('create', $definition->getFactoryMethod());
-        }
+        $this->assertEquals(array('%doctrine_mongodb.odm.document_manager.class%', 'create'), $definition->getFactory());
         $this->assertArrayHasKey('doctrine_mongodb.odm.document_manager', $definition->getTags());
 
         $arguments = $definition->getArguments();
@@ -252,12 +232,7 @@ abstract class AbstractMongoDBExtensionTest extends TestCase
 
         $definition = $container->getDefinition('doctrine_mongodb.odm.dm1_document_manager');
         $this->assertEquals('%doctrine_mongodb.odm.document_manager.class%', $definition->getClass());
-        if (method_exists($definition, 'getFactory')) {
-            $this->assertEquals(array('%doctrine_mongodb.odm.document_manager.class%', 'create'), $definition->getFactory());
-        } else {
-            $this->assertEquals('%doctrine_mongodb.odm.document_manager.class%', $definition->getFactoryClass());
-            $this->assertEquals('create', $definition->getFactoryMethod());
-        }
+        $this->assertEquals(array('%doctrine_mongodb.odm.document_manager.class%', 'create'), $definition->getFactory());
         $this->assertArrayHasKey('doctrine_mongodb.odm.document_manager', $definition->getTags());
 
         $arguments = $definition->getArguments();
@@ -279,12 +254,7 @@ abstract class AbstractMongoDBExtensionTest extends TestCase
 
         $definition = $container->getDefinition('doctrine_mongodb.odm.dm2_document_manager');
         $this->assertEquals('%doctrine_mongodb.odm.document_manager.class%', $definition->getClass());
-        if (method_exists($definition, 'getFactory')) {
-            $this->assertEquals(array('%doctrine_mongodb.odm.document_manager.class%', 'create'), $definition->getFactory());
-        } else {
-            $this->assertEquals('%doctrine_mongodb.odm.document_manager.class%', $definition->getFactoryClass());
-            $this->assertEquals('create', $definition->getFactoryMethod());
-        }
+        $this->assertEquals(array('%doctrine_mongodb.odm.document_manager.class%', 'create'), $definition->getFactory());
         $this->assertArrayHasKey('doctrine_mongodb.odm.document_manager', $definition->getTags());
 
         $arguments = $definition->getArguments();

--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -187,7 +187,7 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
 
     public function provideFullConfiguration()
     {
-        $yaml = Yaml::parse(__DIR__.'/Fixtures/config/yml/full.yml');
+        $yaml = Yaml::parse(file_get_contents(__DIR__.'/Fixtures/config/yml/full.yml'));
         $yaml = $yaml['doctrine_mongodb'];
 
         $xml = XmlUtils::loadFile(__DIR__.'/Fixtures/config/xml/full.xml');

--- a/Tests/Form/Type/DocumentTypeTest.php
+++ b/Tests/Form/Type/DocumentTypeTest.php
@@ -2,6 +2,7 @@
 
 namespace Doctrine\Bundle\MongoDBBundle\Tests\Form\Type;
 
+use Doctrine\Bundle\MongoDBBundle\Form\Type\DocumentType;
 use Doctrine\Bundle\MongoDBBundle\Tests\TestCase;
 use Doctrine\Bundle\MongoDBBundle\Form\DoctrineMongoDBExtension;
 use Symfony\Component\Form\Test\TypeTestCase;
@@ -30,7 +31,7 @@ class DocumentTypeTest extends TypeTestCase
 
     public function testDocumentManagerOptionSetsEmOption()
     {
-        $field = $this->factory->createNamed('name', 'document', null, array(
+        $field = $this->factory->createNamed('name', DocumentType::CLASS, null, array(
             'class' => 'Doctrine\Bundle\MongoDBBundle\Tests\Fixtures\Form\Document',
             'document_manager' => 'default',
         ));
@@ -39,11 +40,11 @@ class DocumentTypeTest extends TypeTestCase
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     * @expectedException \InvalidArgumentException
      */
     public function testSettingDocumentManagerAndEmOptionShouldThrowException()
     {
-        $field = $this->factory->createNamed('name', 'document', null, array(
+        $field = $this->factory->createNamed('name', DocumentType::CLASS, null, array(
             'document_manager' => 'default',
             'em' => 'default',
         ));

--- a/Tests/Logger/LoggerTest.php
+++ b/Tests/Logger/LoggerTest.php
@@ -22,7 +22,7 @@ class LoggerTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        $this->logger = $this->getMock('Symfony\Component\HttpKernel\Log\LoggerInterface');
+        $this->logger = $this->getMock('Psr\Log\LoggerInterface');
     }
 
     protected function tearDown()

--- a/composer.json
+++ b/composer.json
@@ -12,19 +12,20 @@
     ],
     "require": {
         "php": "^5.5",
-        "doctrine/mongodb-odm": "~1.0",
-        "psr/log": "~1.0",
-        "symfony/options-resolver": "~2.1",
-        "symfony/doctrine-bridge": "~2.1",
-        "symfony/framework-bundle": "~2.1",
-        "symfony/dependency-injection": "~2.2",
-        "symfony/console": "~2.1",
-        "symfony/config": "~2.2"
+        "doctrine/mongodb-odm": "^1.0",
+        "psr/log": "^1.0",
+        "symfony/options-resolver": "^2.8 || ^3.0",
+        "symfony/doctrine-bridge": "^2.8 || ^3.0",
+        "symfony/framework-bundle": "^2.8 || ^3.0",
+        "symfony/dependency-injection": "^2.8 || ^3.0",
+        "symfony/console": "^2.8 || ^3.0",
+        "symfony/config": "^2.8 || ^3.0"
     },
     "require-dev": {
         "doctrine/data-fixtures": "@dev",
-        "symfony/form": "~2.3",
-        "symfony/yaml": "~2.1"
+        "symfony/form": "^2.8 || ^3.0",
+        "symfony/yaml": "^2.8 || ^3.0",
+        "symfony/phpunit-bridge": "^2.8 || ^3.0"
     },
     "suggest": {
         "doctrine/data-fixtures": "Load data fixtures"

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         {"name": "Jonathan H. Wage", "email": "jonwage@gmail.com"}
     ],
     "require": {
-        "php": ">=5.3.2",
+        "php": "^5.5",
         "doctrine/mongodb-odm": "~1.0",
         "psr/log": "~1.0",
         "symfony/options-resolver": "~2.1",


### PR DESCRIPTION
Supersedes #327, #310 and #285
Closes #325 

Thank you @tomasbro and @Soullivaneuh for getting started on this. I have taken your work for 3.0 compatibility and put it in here.

With the coming version (either 3.1 or 4.0, which is TBD) we are removing support for all Symfony versions older than 2.8 and in turn introduce compatibility with Symfony 3.0. We will tag one last release of the 3.0 line to have a 2.x version out that requires a stable version of doctrine/mongodb-odm. Please note that we are not providing any long term support for versions of our bundle that work with LTS versions of Symfony.

While there are a few open issues I'd like to look at in the coming days, getting this merged will allow people to use dev-master should they be using Symfony 3.0. I'm still hoping to get a release out rather sooner than later, but there are a few issues that fell through the cracks that I think are worth at least looking at.

One reason of concern is our test coverage, I know that the form types are poorly tested. Any PRs in this direction which can help timely adoption of future Symfony versions are greatly appreciated.