### PR TITLE
Allow PHP 7 in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         {"name": "Jonathan H. Wage", "email": "jonwage@gmail.com"}
     ],
     "require": {
-        "php": "^5.5",
+        "php": "^5.5 || ^7.0",
         "doctrine/mongodb-odm": "^1.0",
         "psr/log": "^1.0",
         "symfony/options-resolver": "^2.8 || ^3.0",


### PR DESCRIPTION
While ODM does not officially support PHP 7 (due to the legacy MongoDB driver not being available), there are alternatives the people may use. This PR aims to allow those developers to use ODM with a polyfill for ext-mongo (e.g. mongofill, mongo-php-adapter) in PHP 7. This complements doctrine/mongodb-odm#1342.