### PR TITLE
Remove deprecated calls (Symfony 2.8 specific)

### DIFF
--- a/Form/Type/DocumentType.php
+++ b/Form/Type/DocumentType.php
@@ -78,12 +78,24 @@ class DocumentType extends DoctrineType
     /**
      * @inheritdoc
      *
+     * @internal Symfony 2.8 compatibility
+     *
+     * @return string
+     */
+    public function getBlockPrefix()
+    {
+        return 'document';
+    }
+
+    /**
+     * @inheritdoc
+     *
      * @internal Symfony 2.7 compatibility
      *
      * @return string
      */
     public function getName()
     {
-        return 'document';
+        return $this->getBlockPrefix();
     }
 }

--- a/Tests/Form/Type/GuesserTestType.php
+++ b/Tests/Form/Type/GuesserTestType.php
@@ -34,8 +34,13 @@ class GuesserTestType extends AbstractType
         ])->setRequired('dm');
     }
 
-    public function getName()
+    public function getBlockPrefix()
     {
         return 'guesser_test';
+    }
+
+    public function getName()
+    {
+        return $this->getBlockPrefix();
     }
 }


### PR DESCRIPTION
Hey!

This PR removes deprecatec calls which are only triger on Symfony 2.8. Since travis does not run the tests on this specific version, the regression has not been detected but travis reported it to me via https://travis-ci.org/php-lug/lug/jobs/107559855