### PR TITLE
Add PHP 7 to the build matrix using polyfill

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,15 @@ php:
   - 5.5
   - 5.6
 
+env:
+  - MONGO_DRIVER=mongo
+
 matrix:
   include:
     - php: 5.5
-      env: COMPOSER_FLAGS='--prefer-lowest --prefer-stable'
+      env: MONGO_DRIVER=mongo COMPOSER_FLAGS='--prefer-lowest --prefer-stable'
+    - php: 7.0
+      env: ADAPTER_VERSION="^1.0.0" MONGO_DRIVER=mongodb
 
 sudo: false
 
@@ -18,8 +23,8 @@ cache:
 services: mongodb
 
 before_install:
-  - yes '' | pecl -q install -f mongo
-  - php --ri mongo
+  - yes '' | pecl -q install -f $MONGO_DRIVER
+  - if [ "x${ADAPTER_VERSION}" != "x" ]; then composer require "alcaeus/mongo-php-adapter=${ADAPTER_VERSION}" --ignore-platform-reqs; fi
 
 install:
   - composer update $COMPOSER_FLAGS

--- a/Tests/Fixtures/Form/Category.php
+++ b/Tests/Fixtures/Form/Category.php
@@ -11,7 +11,7 @@ class Category
     /** @ODM\Id */
     protected $id;
 
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     public $name;
 
     /**

--- a/Tests/Fixtures/Form/Document.php
+++ b/Tests/Fixtures/Form/Document.php
@@ -11,7 +11,7 @@ class Document
     /** @ODM\Id(strategy="none") */
     protected $id;
 
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     public $name;
 
     /**

--- a/Tests/Fixtures/Security/User.php
+++ b/Tests/Fixtures/Security/User.php
@@ -11,7 +11,7 @@ class User implements UserInterface
     /** @ODM\Id(strategy="none") */
     protected $id;
 
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     public $name;
 
     public function __construct($id, $name) {

--- a/Tests/Fixtures/Validator/Document.php
+++ b/Tests/Fixtures/Validator/Document.php
@@ -10,10 +10,10 @@ class Document
     /** @ODM\Id(strategy="none") */
     protected $id;
 
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     public $name;
 
-    /** @ODM\Hash */
+    /** @ODM\Field(type="hash") */
     public $hash;
 
     /** @ODM\Collection */
@@ -36,6 +36,6 @@ class Document
 /** @ODM\EmbeddedDocument */
 class EmbeddedDocument
 {
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     public $name;
 }


### PR DESCRIPTION
While composer.json has allowed installing on PHP 7 for a while (given that the `ext-mongo` requirement is fulfilled), there were no tests for that platform. This PR adds alcaeus/mongo-php-adapter as polyfill to the PHP 7 version of the build matrix.

Note: due to a [bug with composer](https://github.com/composer/composer/issues/5030) the build step installing the polyfill is running with the `ignore-platform-reqs` flag. Once this bug is fixed the flag should be removed.