### PR TITLE
Missing parameter when install

### DIFF
--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -92,11 +92,18 @@ the MongoDB ODM across your application:
 
 .. code-block:: yaml
 
+    # app/config/parameters.yml
+    mongodb_server: "mongodb://localhost:27017"
+
+.. note::
+
+.. code-block:: yaml
+
     # app/config/config.yml
     doctrine_mongodb:
         connections:
             default:
-                server: mongodb://localhost:27017
+                server: "%mongodb_server%"
                 options: {}
         default_database: test_database
         document_managers:

--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -95,8 +95,6 @@ the MongoDB ODM across your application:
     # app/config/parameters.yml
     mongodb_server: "mongodb://localhost:27017"
 
-.. note::
-
 .. code-block:: yaml
 
     # app/config/config.yml


### PR DESCRIPTION
[Symfony\Component\DependencyInjection\Exception\ParameterNotFoundException]  
  You have requested a non-existent parameter "mongodb_server".