### PR TITLE
Return the parent return value to keep the proper exit code

### DIFF
--- a/Command/CreateSchemaDoctrineODMCommand.php
+++ b/Command/CreateSchemaDoctrineODMCommand.php
@@ -50,6 +50,6 @@ EOT
     {
         DoctrineODMCommand::setApplicationDocumentManager($this->getApplication(), $input->getOption('dm'));
 
-        parent::execute($input, $output);
+        return parent::execute($input, $output);
     }
 }

--- a/Command/DropSchemaDoctrineODMCommand.php
+++ b/Command/DropSchemaDoctrineODMCommand.php
@@ -50,6 +50,6 @@ EOT
     {
         DoctrineODMCommand::setApplicationDocumentManager($this->getApplication(), $input->getOption('dm'));
 
-        parent::execute($input, $output);
+        return parent::execute($input, $output);
     }
 }

--- a/Command/UpdateSchemaDoctrineODMCommand.php
+++ b/Command/UpdateSchemaDoctrineODMCommand.php
@@ -45,6 +45,6 @@ EOT
     {
         DoctrineODMCommand::setApplicationDocumentManager($this->getApplication(), $input->getOption('dm'));
 
-        parent::execute($input, $output);
+        return parent::execute($input, $output);
     }
 }


### PR DESCRIPTION
I got quit a surprise in my deploy process when I found out the `doctrine:mongodb:schema:update` was always returning a success error code even when everything went wrong.
For exemple sometimes creating an index on a huge collection can reach my socket timeout ; so the indexes are deleted, not re-created, and I go live with a Mongo server going full CPU because some indexes are missing. 

Long story short, the issue is only in this bundle code. ODM return 255 when something goes bad: https://github.com/doctrine/mongodb-odm/blob/72ea5c74e7e4df6f22de14e8af71927db5110ae4/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/Schema/UpdateCommand.php#L69 but this bundle does not always return the parent return value: https://github.com/doctrine/DoctrineMongoDBBundle/blob/97ac93c6058d53eb1dd59a1c296bbc8c94ea4d4b/Command/UpdateSchemaDoctrineODMCommand.php#L48

The PR fix that for all commands where the return was missing.