### PR TITLE
Code cleanup for PHP 5.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,3 +27,10 @@ before_install:
 
 install:
   - composer update $COMPOSER_FLAGS
+
+script:
+    - ./vendor/bin/phpunit --coverage-clover=coverage.clover
+
+after_script:
+  - wget https://scrutinizer-ci.com/ocular.phar
+  - php ocular.phar code-coverage:upload --format=php-clover coverage.clover

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,20 @@
 language: php
+sudo: false
 
 php:
   - 5.6
+  - 7.0
+  - 7.1
 
 env:
-  - MONGO_DRIVER=mongo
+  global:
+    - DRIVER_VERSION="stable"
+    - ADAPTER_VERSION="^1.0.0"
 
 matrix:
   include:
     - php: 5.6
-      env: MONGO_DRIVER=mongo COMPOSER_FLAGS='--prefer-lowest --prefer-stable'
-    - php: 7.0
-      env: ADAPTER_VERSION="^1.0.0" MONGO_DRIVER=mongodb
-
-sudo: false
+      env: DRIVER_VERSION="1.5.8" PREFER_LOWEST="--prefer-lowest"
 
 cache:
   directories:
@@ -21,12 +22,12 @@ cache:
 
 services: mongodb
 
-before_install:
-  - yes '' | pecl -q install -f $MONGO_DRIVER
-  - if [ "x${ADAPTER_VERSION}" != "x" ]; then composer require "alcaeus/mongo-php-adapter=${ADAPTER_VERSION}" --ignore-platform-reqs; fi
-
 install:
-  - composer update $COMPOSER_FLAGS
+  - composer self-update
+  - if [[ ${TRAVIS_PHP_VERSION:0:2} == "5." ]]; then yes '' | pecl -q install -f mongo-${DRIVER_VERSION}; fi
+  - if [[ ${TRAVIS_PHP_VERSION:0:2} == "7." ]]; then pecl install -f mongodb-${DRIVER_VERSION}; fi
+  - if [[ ${TRAVIS_PHP_VERSION:0:2} == "7." ]]; then composer require "alcaeus/mongo-php-adapter=${ADAPTER_VERSION}" --ignore-platform-reqs; fi
+  - composer update ${PREFER_LOWEST}
 
 script:
     - ./vendor/bin/phpunit --coverage-clover=coverage.clover

--- a/Command/DoctrineODMCommand.php
+++ b/Command/DoctrineODMCommand.php
@@ -55,7 +55,7 @@ abstract class DoctrineODMCommand extends ContainerAwareCommand
     protected function getBundleMetadatas(Bundle $bundle)
     {
         $namespace = $bundle->getNamespace();
-        $bundleMetadatas = array();
+        $bundleMetadatas = [];
         $documentManagers = $this->getDoctrineDocumentManagers();
         foreach ($documentManagers as $dm) {
             $cmf = new DisconnectedClassMetadataFactory();

--- a/Command/GenerateDocumentsDoctrineODMCommand.php
+++ b/Command/GenerateDocumentsDoctrineODMCommand.php
@@ -81,7 +81,7 @@ EOT
                 }
 
                 $output->writeln(sprintf('  > generating <comment>%s</comment>', $metadata->name));
-                $documentGenerator->generate(array($metadata), $this->findBasePathForBundle($foundBundle));
+                $documentGenerator->generate([$metadata], $this->findBasePathForBundle($foundBundle));
             }
         } else {
             throw new \RuntimeException(

--- a/Command/LoadDataFixturesDoctrineODMCommand.php
+++ b/Command/LoadDataFixturesDoctrineODMCommand.php
@@ -15,6 +15,7 @@
 namespace Doctrine\Bundle\MongoDBBundle\Command;
 
 use Doctrine\Common\DataFixtures\Executor\MongoDBExecutor;
+use Doctrine\Common\DataFixtures\Loader;
 use Doctrine\Common\DataFixtures\Purger\MongoDBPurger;
 use Symfony\Bridge\Doctrine\DataFixtures\ContainerAwareLoader;
 use Symfony\Component\Console\Input\InputInterface;
@@ -35,7 +36,7 @@ class LoadDataFixturesDoctrineODMCommand extends DoctrineODMCommand
      */
     public function isEnabled()
     {
-        return parent::isEnabled() && class_exists('Doctrine\Common\DataFixtures\Loader');
+        return parent::isEnabled() && class_exists(Loader::class);
     }
 
     protected function configure()

--- a/Command/LoadDataFixturesDoctrineODMCommand.php
+++ b/Command/LoadDataFixturesDoctrineODMCommand.php
@@ -84,7 +84,7 @@ EOT
         }
 
         if ($dirOrFile) {
-            $paths = is_array($dirOrFile) ? $dirOrFile : array($dirOrFile);
+            $paths = is_array($dirOrFile) ? $dirOrFile : [$dirOrFile];
         } elseif ($bundles) {
             $kernel = $this->getContainer()->get('kernel');
             foreach ($bundles as $bundle) {
@@ -92,7 +92,7 @@ EOT
             }
         } else {
             $paths = $this->getContainer()->getParameter('doctrine_mongodb.odm.fixtures_dirs');
-            $paths = is_array($paths) ? $paths : array($paths);
+            $paths = is_array($paths) ? $paths : [$paths];
             foreach ($this->getContainer()->get('kernel')->getBundles() as $bundle) {
                 $paths[] = $bundle->getPath().'/DataFixtures/MongoDB';
             }

--- a/DataCollector/PrettyDataCollector.php
+++ b/DataCollector/PrettyDataCollector.php
@@ -34,15 +34,15 @@ class PrettyDataCollector extends StandardDataCollector
 
     public function collect(Request $request, Response $response, \Exception $exception = null)
     {
-        $this->data['queries'] = array();
+        $this->data['queries'] = [];
         $this->data['nb_queries'] = 0;
 
-        $grouped = array();
-        $ordered = array();
+        $grouped = [];
+        $ordered = [];
         foreach ($this->queries as $query) {
             if (!isset($query['query']) || !isset($query['fields'])) {
                 // no grouping necessary
-                $ordered[] = array($query);
+                $ordered[] = [$query];
                 continue;
             }
 
@@ -53,7 +53,7 @@ class PrettyDataCollector extends StandardDataCollector
                 unset($query['query'], $query['fields']);
                 $grouped[$cursor][count($grouped[$cursor]) - 1][] = $query;
             } else {
-                $grouped[$cursor][] = array($query);
+                $grouped[$cursor][] = [$query];
                 $ordered[] =& $grouped[$cursor][count($grouped[$cursor]) - 1];
             }
         }
@@ -149,11 +149,11 @@ class PrettyDataCollector extends StandardDataCollector
                 } elseif (isset($log['getDBRef'])) {
                     $query .= '.getDBRef()';
                 } elseif (isset($log['group'])) {
-                    $query .= '.group('.$this->bsonEncode(array(
+                    $query .= '.group('.$this->bsonEncode([
                         'key'    => $log['keys'],
                         'initial' => $log['initial'],
                         'reduce'  => $log['reduce'],
-                    )).')';
+                        ]).')';
                 } elseif (isset($log['insert'])) {
                     $query .= '.insert('.$this->bsonEncode($log['document']).')';
                 } elseif (isset($log['remove'])) {
@@ -186,7 +186,7 @@ class PrettyDataCollector extends StandardDataCollector
      */
     private function bsonEncode($query, $array = true)
     {
-        $parts = array();
+        $parts = [];
 
         foreach ($query as $key => $value) {
             if (!is_numeric($key)) {

--- a/DataCollector/StandardDataCollector.php
+++ b/DataCollector/StandardDataCollector.php
@@ -30,7 +30,7 @@ class StandardDataCollector extends DataCollector implements LoggerInterface
 
     public function __construct()
     {
-        $this->queries = array();
+        $this->queries = [];
     }
 
     public function logQuery(array $query)

--- a/DependencyInjection/Compiler/DoctrineMongoDBMappingsPass.php
+++ b/DependencyInjection/Compiler/DoctrineMongoDBMappingsPass.php
@@ -12,6 +12,12 @@
 
 namespace Doctrine\Bundle\MongoDBBundle\DependencyInjection\Compiler;
 
+use Doctrine\Common\Persistence\Mapping\Driver\PHPDriver;
+use Doctrine\Common\Persistence\Mapping\Driver\StaticPHPDriver;
+use Doctrine\Common\Persistence\Mapping\Driver\SymfonyFileLocator;
+use Doctrine\ODM\MongoDB\Mapping\Driver\AnnotationDriver;
+use Doctrine\ODM\MongoDB\Mapping\Driver\XmlDriver;
+use Doctrine\ODM\MongoDB\Mapping\Driver\YamlDriver;
 use Symfony\Bridge\Doctrine\DependencyInjection\CompilerPass\RegisterMappingsPass;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Reference;
@@ -68,8 +74,8 @@ class DoctrineMongoDBMappingsPass extends RegisterMappingsPass
     public static function createXmlMappingDriver(array $mappings, array $managerParameters, $enabledParameter = false, array $aliasMap = array())
     {
         $arguments = array($mappings, '.mongodb.xml');
-        $locator = new Definition('Doctrine\Common\Persistence\Mapping\Driver\SymfonyFileLocator', $arguments);
-        $driver = new Definition('Doctrine\ODM\MongoDB\Mapping\Driver\XmlDriver', array($locator));
+        $locator = new Definition(SymfonyFileLocator::class, $arguments);
+        $driver = new Definition(XmlDriver::class, array($locator));
 
         return new DoctrineMongoDBMappingsPass($driver, $mappings, $managerParameters, $enabledParameter, $aliasMap);
     }
@@ -88,8 +94,8 @@ class DoctrineMongoDBMappingsPass extends RegisterMappingsPass
     public static function createYamlMappingDriver(array $mappings, array $managerParameters, $enabledParameter = false, array $aliasMap = array())
     {
         $arguments = array($mappings, '.mongodb.yml');
-        $locator = new Definition('Doctrine\Common\Persistence\Mapping\Driver\SymfonyFileLocator', $arguments);
-        $driver = new Definition('Doctrine\ODM\MongoDB\Mapping\Driver\YamlDriver', array($locator));
+        $locator = new Definition(SymfonyFileLocator::class, $arguments);
+        $driver = new Definition(YamlDriver::class, array($locator));
 
         return new DoctrineMongoDBMappingsPass($driver, $mappings, $managerParameters, $enabledParameter, $aliasMap);
     }
@@ -108,8 +114,8 @@ class DoctrineMongoDBMappingsPass extends RegisterMappingsPass
     public static function createPhpMappingDriver(array $mappings, array $managerParameters = array(), $enabledParameter = false, array $aliasMap = array())
     {
         $arguments = array($mappings, '.php');
-        $locator = new Definition('Doctrine\Common\Persistence\Mapping\Driver\SymfonyFileLocator', $arguments);
-        $driver = new Definition('Doctrine\Common\Persistence\Mapping\Driver\PHPDriver', array($locator));
+        $locator = new Definition(SymfonyFileLocator::class, $arguments);
+        $driver = new Definition(PHPDriver::class, array($locator));
 
         return new DoctrineMongoDBMappingsPass($driver, $mappings, $managerParameters, $enabledParameter, $aliasMap);
     }
@@ -128,7 +134,7 @@ class DoctrineMongoDBMappingsPass extends RegisterMappingsPass
      */
     public static function createAnnotationMappingDriver(array $namespaces, array $directories, array $managerParameters, $enabledParameter = false, array $aliasMap = array())
     {
-        $driver = new Definition('Doctrine\ODM\MongoDB\Mapping\Driver\AnnotationDriver', array(new Reference('annotation_reader'), $directories));
+        $driver = new Definition(AnnotationDriver::class, array(new Reference('annotation_reader'), $directories));
 
         return new DoctrineMongoDBMappingsPass($driver, $namespaces, $managerParameters, $enabledParameter, $aliasMap);
     }
@@ -147,7 +153,7 @@ class DoctrineMongoDBMappingsPass extends RegisterMappingsPass
      */
     public static function createStaticPhpMappingDriver(array $namespaces, array $directories, array $managerParameters = array(), $enabledParameter = false, array $aliasMap = array())
     {
-        $driver = new Definition('Doctrine\Common\Persistence\Mapping\Driver\StaticPHPDriver', array($directories));
+        $driver = new Definition(StaticPHPDriver::class, array($directories));
 
         return new DoctrineMongoDBMappingsPass($driver, $namespaces, $managerParameters, $enabledParameter, $aliasMap);
     }

--- a/DependencyInjection/Compiler/DoctrineMongoDBMappingsPass.php
+++ b/DependencyInjection/Compiler/DoctrineMongoDBMappingsPass.php
@@ -43,7 +43,7 @@ class DoctrineMongoDBMappingsPass extends RegisterMappingsPass
      *                                                executes if this parameter exists in the service container.
      * @param string[]             $aliasMap          Map of alias to namespace.
      */
-    public function __construct($driver, array $namespaces, array $managerParameters, $enabledParameter = false, array $aliasMap = array())
+    public function __construct($driver, array $namespaces, array $managerParameters, $enabledParameter = false, array $aliasMap = [])
     {
         $managerParameters[] = 'doctrine_mongodb.odm.default_document_manager';
         parent::__construct(
@@ -71,11 +71,11 @@ class DoctrineMongoDBMappingsPass extends RegisterMappingsPass
      *                                    optional.
      * @param string[] $aliasMap          Map of alias to namespace.
      */
-    public static function createXmlMappingDriver(array $mappings, array $managerParameters, $enabledParameter = false, array $aliasMap = array())
+    public static function createXmlMappingDriver(array $mappings, array $managerParameters, $enabledParameter = false, array $aliasMap = [])
     {
-        $arguments = array($mappings, '.mongodb.xml');
+        $arguments = [$mappings, '.mongodb.xml'];
         $locator = new Definition(SymfonyFileLocator::class, $arguments);
-        $driver = new Definition(XmlDriver::class, array($locator));
+        $driver = new Definition(XmlDriver::class, [$locator]);
 
         return new DoctrineMongoDBMappingsPass($driver, $mappings, $managerParameters, $enabledParameter, $aliasMap);
     }
@@ -91,11 +91,11 @@ class DoctrineMongoDBMappingsPass extends RegisterMappingsPass
      *                                    optional.
      * @param string[] $aliasMap          Map of alias to namespace.
      */
-    public static function createYamlMappingDriver(array $mappings, array $managerParameters, $enabledParameter = false, array $aliasMap = array())
+    public static function createYamlMappingDriver(array $mappings, array $managerParameters, $enabledParameter = false, array $aliasMap = [])
     {
-        $arguments = array($mappings, '.mongodb.yml');
+        $arguments = [$mappings, '.mongodb.yml'];
         $locator = new Definition(SymfonyFileLocator::class, $arguments);
-        $driver = new Definition(YamlDriver::class, array($locator));
+        $driver = new Definition(YamlDriver::class, [$locator]);
 
         return new DoctrineMongoDBMappingsPass($driver, $mappings, $managerParameters, $enabledParameter, $aliasMap);
     }
@@ -111,11 +111,11 @@ class DoctrineMongoDBMappingsPass extends RegisterMappingsPass
      *                                    optional.
      * @param string[] $aliasMap          Map of alias to namespace.
      */
-    public static function createPhpMappingDriver(array $mappings, array $managerParameters = array(), $enabledParameter = false, array $aliasMap = array())
+    public static function createPhpMappingDriver(array $mappings, array $managerParameters = [], $enabledParameter = false, array $aliasMap = [])
     {
-        $arguments = array($mappings, '.php');
+        $arguments = [$mappings, '.php'];
         $locator = new Definition(SymfonyFileLocator::class, $arguments);
-        $driver = new Definition(PHPDriver::class, array($locator));
+        $driver = new Definition(PHPDriver::class, [$locator]);
 
         return new DoctrineMongoDBMappingsPass($driver, $mappings, $managerParameters, $enabledParameter, $aliasMap);
     }
@@ -132,9 +132,9 @@ class DoctrineMongoDBMappingsPass extends RegisterMappingsPass
      *                                    optional.
      * @param string[] $aliasMap          Map of alias to namespace.
      */
-    public static function createAnnotationMappingDriver(array $namespaces, array $directories, array $managerParameters, $enabledParameter = false, array $aliasMap = array())
+    public static function createAnnotationMappingDriver(array $namespaces, array $directories, array $managerParameters, $enabledParameter = false, array $aliasMap = [])
     {
-        $driver = new Definition(AnnotationDriver::class, array(new Reference('annotation_reader'), $directories));
+        $driver = new Definition(AnnotationDriver::class, [new Reference('annotation_reader'), $directories]);
 
         return new DoctrineMongoDBMappingsPass($driver, $namespaces, $managerParameters, $enabledParameter, $aliasMap);
     }
@@ -151,9 +151,9 @@ class DoctrineMongoDBMappingsPass extends RegisterMappingsPass
      *                                    optional.
      * @param string[] $aliasMap          Map of alias to namespace.
      */
-    public static function createStaticPhpMappingDriver(array $namespaces, array $directories, array $managerParameters = array(), $enabledParameter = false, array $aliasMap = array())
+    public static function createStaticPhpMappingDriver(array $namespaces, array $directories, array $managerParameters = [], $enabledParameter = false, array $aliasMap = [])
     {
-        $driver = new Definition(StaticPHPDriver::class, array($directories));
+        $driver = new Definition(StaticPHPDriver::class, [$directories]);
 
         return new DoctrineMongoDBMappingsPass($driver, $namespaces, $managerParameters, $enabledParameter, $aliasMap);
     }

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -16,6 +16,8 @@ namespace Doctrine\Bundle\MongoDBBundle\DependencyInjection;
 
 use Doctrine\Common\Proxy\AbstractProxyFactory;
 use Doctrine\ODM\MongoDB\Configuration as ODMConfiguration;
+use Doctrine\ODM\MongoDB\DocumentRepository;
+use Symfony\Bridge\Doctrine\DataFixtures\ContainerAwareLoader;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
@@ -77,9 +79,9 @@ class Configuration implements ConfigurationInterface
                 ->scalarNode('persistent_collection_dir')->defaultValue('%kernel.cache_dir%/doctrine/odm/mongodb/PersistentCollections')->end()
                 ->scalarNode('auto_generate_persistent_collection_classes')->defaultValue(ODMConfiguration::AUTOGENERATE_NEVER)->end()
                 ->scalarNode('fixture_loader')
-                    ->defaultValue('Symfony\Bridge\Doctrine\DataFixtures\ContainerAwareLoader')
+                    ->defaultValue(ContainerAwareLoader::class)
                     ->beforeNormalization()
-                        ->ifTrue(function($v) {return !($v == 'Symfony\Bridge\Doctrine\DataFixtures\ContainerAwareLoader' || in_array('Symfony\Bridge\Doctrine\DataFixtures\ContainerAwareLoader', class_parents($v)));})
+                        ->ifTrue(function($v) {return !($v == ContainerAwareLoader::class || in_array(ContainerAwareLoader::class, class_parents($v)));})
                         ->then(function($v) { throw new \LogicException(sprintf("The %s class is not a subclass of the ContainerAwareLoader", $v));})
                     ->end()
                 ->end()
@@ -133,7 +135,7 @@ class Configuration implements ConfigurationInterface
                                     ->booleanNode('pretty')->defaultValue('%kernel.debug%')->end()
                                 ->end()
                             ->end()
-                            ->scalarNode('default_repository_class')->defaultValue('Doctrine\ODM\MongoDB\DocumentRepository')->end()
+                            ->scalarNode('default_repository_class')->defaultValue(DocumentRepository::class)->end()
                             ->scalarNode('repository_factory')->defaultNull()->end()
                             ->scalarNode('persistent_collection_factory')->defaultNull()->end()
                             ->booleanNode('auto_mapping')->defaultFalse()->end()

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -120,7 +120,7 @@ class Configuration implements ConfigurationInterface
                     ->useAttributeAsKey('id')
                     ->requiresAtLeastOneElement()
                     ->prototype('array')
-                        ->treatNullLike(array())
+                        ->treatNullLike([])
                         ->fixXmlConfig('filter')
                         ->children()
                             ->scalarNode('connection')->end()
@@ -128,8 +128,8 @@ class Configuration implements ConfigurationInterface
                             ->booleanNode('logging')->defaultValue('%kernel.debug%')->end()
                             ->arrayNode('profiler')
                                 ->addDefaultsIfNotSet()
-                                ->treatTrueLike(array('enabled' => true))
-                                ->treatFalseLike(array('enabled' => false))
+                                ->treatTrueLike(['enabled' => true])
+                                ->treatFalseLike(['enabled' => false])
                                 ->children()
                                     ->booleanNode('enabled')->defaultValue('%kernel.debug%')->end()
                                     ->booleanNode('pretty')->defaultValue('%kernel.debug%')->end()
@@ -145,7 +145,7 @@ class Configuration implements ConfigurationInterface
                                     ->fixXmlConfig('parameter')
                                     ->beforeNormalization()
                                         ->ifString()
-                                        ->then(function($v) { return array('class' => $v); })
+                                        ->then(function($v) { return ['class' => $v]; })
                                     ->end()
                                     ->beforeNormalization()
                                         // The content of the XML node is returned as the "value" key so we need to rename it
@@ -161,7 +161,7 @@ class Configuration implements ConfigurationInterface
                                         ->scalarNode('class')->isRequired()->end()
                                         ->booleanNode('enabled')->defaultFalse()->end()
                                         ->arrayNode('parameters')
-                                            ->treatNullLike(array())
+                                            ->treatNullLike([])
                                             ->useAttributeAsKey('name')
                                             ->prototype('variable')
                                                 ->beforeNormalization()
@@ -181,7 +181,7 @@ class Configuration implements ConfigurationInterface
                                 ->addDefaultsIfNotSet()
                                 ->beforeNormalization()
                                     ->ifString()
-                                    ->then(function($v) { return array('type' => $v); })
+                                    ->then(function($v) { return ['type' => $v]; })
                                 ->end()
                                 ->children()
                                     ->scalarNode('type')->defaultValue('array')->end()
@@ -201,10 +201,10 @@ class Configuration implements ConfigurationInterface
                                 ->prototype('array')
                                     ->beforeNormalization()
                                         ->ifString()
-                                        ->then(function($v) { return array ('type' => $v); })
+                                        ->then(function($v) { return ['type' => $v]; })
                                     ->end()
-                                    ->treatNullLike(array())
-                                    ->treatFalseLike(array('mapping' => false))
+                                    ->treatNullLike([])
+                                    ->treatFalseLike(['mapping' => false])
                                     ->performNoDeepMerging()
                                     ->children()
                                         ->scalarNode('mapping')->defaultValue(true)->end()
@@ -244,7 +244,7 @@ class Configuration implements ConfigurationInterface
                                 ->performNoDeepMerging()
                                 ->children()
                                     ->enumNode('authMechanism')
-                                        ->values(array('SCRAM-SHA-1', 'MONGODB-CR', 'X509', 'PLAIN', 'GSSAPI'))
+                                        ->values(['SCRAM-SHA-1', 'MONGODB-CR', 'X509', 'PLAIN', 'GSSAPI'])
                                     ->end()
                                     ->booleanNode('connect')->end()
                                     ->integerNode('connectTimeoutMS')->end()
@@ -254,7 +254,7 @@ class Configuration implements ConfigurationInterface
                                         ->validate()->ifNull()->thenUnset()->end()
                                     ->end()
                                     ->enumNode('readPreference')
-                                        ->values(array('primary', 'primaryPreferred', 'secondary', 'secondaryPreferred', 'nearest'))
+                                        ->values(['primary', 'primaryPreferred', 'secondary', 'secondaryPreferred', 'nearest'])
                                     ->end()
                                     ->arrayNode('readPreferenceTags')
                                         ->performNoDeepMerging()
@@ -265,7 +265,7 @@ class Configuration implements ConfigurationInterface
                                                 ->then(function($v) {
                                                     // Equivalent of fixXmlConfig() for inner node
                                                     if (isset($v['readPreferenceTag']['name'])) {
-                                                        $v['readPreferenceTag'] = array($v['readPreferenceTag']);
+                                                        $v['readPreferenceTag'] = [$v['readPreferenceTag']];
                                                     }
 
                                                     return $v['readPreferenceTag'];

--- a/DoctrineMongoDBBundle.php
+++ b/DoctrineMongoDBBundle.php
@@ -81,7 +81,7 @@ class DoctrineMongoDBBundle extends Bundle
 
                                 foreach ($classes as $classMetadata) {
                                     if ($classMetadata->name == $originalClassName) {
-                                        $dm->getProxyFactory()->generateProxyClasses(array($classMetadata));
+                                        $dm->getProxyFactory()->generateProxyClasses([$classMetadata]);
                                     }
                                 }
                             }

--- a/Form/ChoiceList/MongoDBQueryBuilderLoader.php
+++ b/Form/ChoiceList/MongoDBQueryBuilderLoader.php
@@ -47,14 +47,14 @@ class MongoDBQueryBuilderLoader implements EntityLoaderInterface
         // If a query builder was passed, it must be a closure or QueryBuilder
         // instance
         if (!($queryBuilder instanceof Builder || $queryBuilder instanceof \Closure)) {
-            throw new UnexpectedTypeException($queryBuilder, 'Doctrine\ODM\MongoDB\Query\Builder or \Closure');
+            throw new UnexpectedTypeException($queryBuilder, Builder::class .'  or ' . \Closure::class);
         }
 
         if ($queryBuilder instanceof \Closure) {
             $queryBuilder = $queryBuilder($manager->getRepository($class));
 
             if (!$queryBuilder instanceof Builder) {
-                throw new UnexpectedTypeException($queryBuilder, 'Doctrine\ODM\MongoDB\Query\Builder');
+                throw new UnexpectedTypeException($queryBuilder, Builder::class);
             }
         }
 

--- a/Form/DoctrineMongoDBExtension.php
+++ b/Form/DoctrineMongoDBExtension.php
@@ -34,9 +34,9 @@ class DoctrineMongoDBExtension extends AbstractExtension
 
     protected function loadTypes()
     {
-        return array(
+        return [
             new Type\DocumentType($this->registry),
-        );
+        ];
     }
 
     protected function loadTypeGuesser()

--- a/Form/DoctrineMongoDBTypeGuesser.php
+++ b/Form/DoctrineMongoDBTypeGuesser.php
@@ -17,6 +17,7 @@ namespace Doctrine\Bundle\MongoDBBundle\Form;
 use Doctrine\Bundle\MongoDBBundle\Form\Type\DocumentType;
 use Doctrine\Common\Persistence\ManagerRegistry;
 use Doctrine\Common\Persistence\Mapping\MappingException;
+use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\Extension\Core\Type\CollectionType;
 use Symfony\Component\Form\Extension\Core\Type\DateTimeType;
@@ -45,7 +46,7 @@ class DoctrineMongoDBTypeGuesser implements FormTypeGuesserInterface
     public function __construct(ManagerRegistry $registry)
     {
         $this->registry = $registry;
-        $this->typeFQCN = method_exists('\Symfony\Component\Form\AbstractType', 'getBlockPrefix');
+        $this->typeFQCN = method_exists(AbstractType::class, 'getBlockPrefix');
     }
 
     /**

--- a/Form/DoctrineMongoDBTypeGuesser.php
+++ b/Form/DoctrineMongoDBTypeGuesser.php
@@ -39,7 +39,7 @@ class DoctrineMongoDBTypeGuesser implements FormTypeGuesserInterface
 {
     protected $registry;
 
-    private $cache = array();
+    private $cache = [];
 
     private $typeFQCN;
 
@@ -55,7 +55,7 @@ class DoctrineMongoDBTypeGuesser implements FormTypeGuesserInterface
     public function guessType($class, $property)
     {
         if (!$ret = $this->getMetadata($class)) {
-            return new TypeGuess($this->typeFQCN ? TextType::class : 'text', array(), Guess::LOW_CONFIDENCE);
+            return new TypeGuess($this->typeFQCN ? TextType::class : 'text', [], Guess::LOW_CONFIDENCE);
         }
 
         list($metadata, $name) = $ret;
@@ -66,11 +66,11 @@ class DoctrineMongoDBTypeGuesser implements FormTypeGuesserInterface
 
             return new TypeGuess(
                 $this->typeFQCN ? DocumentType::class : 'document',
-                array(
+                [
                     'class' => $mapping['targetDocument'],
                     'multiple' => $multiple,
                     'expanded' => $multiple
-                ),
+                ],
                 Guess::HIGH_CONFIDENCE
             );
         }
@@ -81,38 +81,38 @@ class DoctrineMongoDBTypeGuesser implements FormTypeGuesserInterface
             case 'collection':
                 return new TypeGuess(
                     $this->typeFQCN ? CollectionType::class : 'collection',
-                    array(),
+                    [],
                     Guess::MEDIUM_CONFIDENCE
                 );
             case 'boolean':
                 return new TypeGuess(
                     $this->typeFQCN ? CheckboxType::class : 'checkbox',
-                    array(),
+                    [],
                     Guess::HIGH_CONFIDENCE
                 );
             case 'date':
             case 'timestamp':
                 return new TypeGuess(
                     $this->typeFQCN ? DateTimeType::class : 'datetime',
-                    array(),
+                    [],
                     Guess::HIGH_CONFIDENCE
                 );
             case 'float':
                 return new TypeGuess(
                     $this->typeFQCN ? NumberType::class : 'number',
-                    array(),
+                    [],
                     Guess::MEDIUM_CONFIDENCE
                 );
             case 'int':
                 return new TypeGuess(
                     $this->typeFQCN ? IntegerType::class : 'integer',
-                    array(),
+                    [],
                     Guess::MEDIUM_CONFIDENCE
                 );
             case 'string':
                 return new TypeGuess(
                     $this->typeFQCN ? TextType::class : 'text',
-                    array(),
+                    [],
                     Guess::MEDIUM_CONFIDENCE
                 );
         }
@@ -189,7 +189,7 @@ class DoctrineMongoDBTypeGuesser implements FormTypeGuesserInterface
         $this->cache[$class] = null;
         foreach ($this->registry->getManagers() as $name => $dm) {
             try {
-                return $this->cache[$class] = array($dm->getClassMetadata($class), $name);
+                return $this->cache[$class] = [$dm->getClassMetadata($class), $name];
             } catch (MappingException $e) {
                 // not an entity or mapped super class
             }

--- a/Form/Type/DocumentType.php
+++ b/Form/Type/DocumentType.php
@@ -16,6 +16,7 @@ namespace Doctrine\Bundle\MongoDBBundle\Form\Type;
 
 use Doctrine\Bundle\MongoDBBundle\Form\ChoiceList\MongoDBQueryBuilderLoader;
 use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\ODM\MongoDB\DocumentManager;
 use Symfony\Bridge\Doctrine\Form\Type\DoctrineType;
 use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -72,7 +73,7 @@ class DocumentType extends DoctrineType
 
         $resolver->setNormalizer('em', $normalizer);
 
-        $resolver->setAllowedTypes('document_manager', array('null', 'string', 'Doctrine\ODM\MongoDB\DocumentManager'));
+        $resolver->setAllowedTypes('document_manager', array('null', 'string', DocumentManager::class));
     }
 
     /**

--- a/Form/Type/DocumentType.php
+++ b/Form/Type/DocumentType.php
@@ -48,9 +48,9 @@ class DocumentType extends DoctrineType
     {
         parent::configureOptions($resolver);
 
-        $resolver->setDefaults(array(
+        $resolver->setDefaults([
             'document_manager' => null,
-        ));
+        ]);
 
         $registry = $this->registry;
         $normalizer = function (Options $options, $manager) use ($registry) {
@@ -73,7 +73,7 @@ class DocumentType extends DoctrineType
 
         $resolver->setNormalizer('em', $normalizer);
 
-        $resolver->setAllowedTypes('document_manager', array('null', 'string', DocumentManager::class));
+        $resolver->setAllowedTypes('document_manager', ['null', 'string', DocumentManager::class]);
     }
 
     /**

--- a/ManagerConfigurator.php
+++ b/ManagerConfigurator.php
@@ -18,7 +18,7 @@ use Doctrine\ODM\MongoDB\DocumentManager;
  */
 class ManagerConfigurator
 {
-    private $enabledFilters = array();
+    private $enabledFilters = [];
 
     /**
      * Construct.

--- a/Tests/Command/LoadDataFixturesDoctrineODMCommandTest.php
+++ b/Tests/Command/LoadDataFixturesDoctrineODMCommandTest.php
@@ -3,6 +3,7 @@
 namespace Doctrine\Bundle\MongoDBBundle\Tests\Command;
 
 use Doctrine\Bundle\MongoDBBundle\Command\LoadDataFixturesDoctrineODMCommand;
+use Doctrine\Common\DataFixtures\Loader;
 
 /**
  * @author Henrik Bjornskov <henrik@bjrnskov.dk>
@@ -16,7 +17,7 @@ class LoadDataFixturesDoctrineODMCommandTest extends \PHPUnit_Framework_TestCase
 
     public function testCommandIsNotEnabledWithMissingDependency()
     {
-        if (class_exists('Doctrine\Common\DataFixtures\Loader')) {
+        if (class_exists(Loader::class)) {
             $this->markTestSkipped();
         }
 
@@ -25,7 +26,7 @@ class LoadDataFixturesDoctrineODMCommandTest extends \PHPUnit_Framework_TestCase
 
     public function testCommandIsEnabledWithDependency()
     {
-        if (!class_exists('Doctrine\Common\DataFixtures\Loader')) {
+        if (!class_exists(Loader::class)) {
             $this->markTestSkipped();
         }
 

--- a/Tests/ContainerTest.php
+++ b/Tests/ContainerTest.php
@@ -27,13 +27,13 @@ class ContainerTest extends TestCase
 
     protected function setUp()
     {
-        $this->container = new ContainerBuilder(new ParameterBag(array(
-            'kernel.bundles'   => array(),
+        $this->container = new ContainerBuilder(new ParameterBag([
+            'kernel.bundles'   => [],
             'kernel.cache_dir' => sys_get_temp_dir(),
             'kernel.root_dir'  => sys_get_temp_dir(),
             'kernel.environment'  => 'test',
             'kernel.debug'     => true,
-        )));
+        ]));
 
         $this->container->setDefinition('annotation_reader', new Definition(AnnotationReader::class));
         $this->extension = new DoctrineMongoDBExtension();
@@ -45,7 +45,7 @@ class ContainerTest extends TestCase
     public function testLoggerConfig($config, $logger, $debug)
     {
         $this->container->setParameter('kernel.debug', $debug);
-        $this->extension->load(array($config), $this->container);
+        $this->extension->load([$config], $this->container);
 
         $def = $this->container->getDefinition('doctrine_mongodb.odm.default_configuration');
         if (false === $logger) {
@@ -64,41 +64,41 @@ class ContainerTest extends TestCase
 
     public function provideLoggerConfigs()
     {
-        $config = array('connections' => array('default' => array()));
+        $config = ['connections' => ['default' => []]];
 
-        return array(
-            array(
+        return [
+            [
                 // logging and profiler default to true when in debug mode
-                array('document_managers' => array('default' => array())) + $config,
+                ['document_managers' => ['default' => []]] + $config,
                 'doctrine_mongodb.odm.logger.aggregate',
                 true,
-            ),
-            array(
+            ],
+            [
                 // logging and profiler default to false when not in debug mode
-                array('document_managers' => array('default' => array())) + $config,
+                ['document_managers' => ['default' => []]] + $config,
                 false,
                 false,
-            ),
-            array(
-                array('document_managers' => array('default' => array('logging' => true, 'profiler' => true))) + $config,
+            ],
+            [
+                ['document_managers' => ['default' => ['logging' => true, 'profiler' => true]]] + $config,
                 'doctrine_mongodb.odm.logger.aggregate',
                 true,
-            ),
-            array(
-                array('document_managers' => array('default' => array('logging' => false, 'profiler' => true))) + $config,
+            ],
+            [
+                ['document_managers' => ['default' => ['logging' => false, 'profiler' => true]]] + $config,
                 'doctrine_mongodb.odm.data_collector.pretty',
                 true,
-            ),
-            array(
-                array('document_managers' => array('default' => array('logging' => true, 'profiler' => false))) + $config,
+            ],
+            [
+                ['document_managers' => ['default' => ['logging' => true, 'profiler' => false]]] + $config,
                 'doctrine_mongodb.odm.logger',
                 true,
-            ),
-            array(
-                array('document_managers' => array('default' => array('logging' => false, 'profiler' => false))) + $config,
+            ],
+            [
+                ['document_managers' => ['default' => ['logging' => false, 'profiler' => false]]] + $config,
                 false,
                 true,
-            ),
-        );
+            ],
+        ];
     }
 }

--- a/Tests/ContainerTest.php
+++ b/Tests/ContainerTest.php
@@ -15,6 +15,7 @@
 namespace Doctrine\Bundle\MongoDBBundle\Tests;
 
 use Doctrine\Bundle\MongoDBBundle\DependencyInjection\DoctrineMongoDBExtension;
+use Doctrine\Common\Annotations\AnnotationReader;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
@@ -34,7 +35,7 @@ class ContainerTest extends TestCase
             'kernel.debug'     => true,
         )));
 
-        $this->container->setDefinition('annotation_reader', new Definition('Doctrine\Common\Annotations\AnnotationReader'));
+        $this->container->setDefinition('annotation_reader', new Definition(AnnotationReader::class));
         $this->extension = new DoctrineMongoDBExtension();
     }
 

--- a/Tests/DataCollector/PrettyDataCollectorTest.php
+++ b/Tests/DataCollector/PrettyDataCollectorTest.php
@@ -35,85 +35,85 @@ class PrettyDataCollectorTest extends \PHPUnit_Framework_TestCase
 
     public function getQueries()
     {
-        return array(
-            'batch insert' => array(
-                array('db' => 'foo', 'collection' => 'bar', 'batchInsert' => true, 'num' => 1, 'data' => array('foo' => 'bar'), 'options' => array()),
-                array('use foo;', 'db.bar.insert({ "foo": "bar" });'),
-            ),
-            'find' => array(
-                array('db' => 'foo', 'collection' => 'bar', 'find' => true, 'query' => array('foo' => null), 'fields' => array()),
-                array('use foo;', 'db.bar.find({ "foo": null });'),
-            ),
-            'bin data' => array(
-                array('db' => 'foo', 'collection' => 'bar', 'update' => true, 'query' => array('_id' => 'foo'), 'newObj' => array('foo' => new \MongoBinData('junk data', \MongoBinData::BYTE_ARRAY))),
-                arraY('use foo;', 'db.bar.update({ "_id": "foo" }, { "foo": new BinData(2, "' . base64_encode('junk data') . '") });'),
-            )
-        );
+        return [
+            'batch insert' => [
+                ['db' => 'foo', 'collection' => 'bar', 'batchInsert' => true, 'num' => 1, 'data' => ['foo' => 'bar'], 'options' => []],
+                ['use foo;', 'db.bar.insert({ "foo": "bar" });'],
+            ],
+            'find' => [
+                ['db' => 'foo', 'collection' => 'bar', 'find' => true, 'query' => ['foo' => null], 'fields' => []],
+                ['use foo;', 'db.bar.find({ "foo": null });'],
+            ],
+            'bin data' => [
+                ['db' => 'foo', 'collection' => 'bar', 'update' => true, 'query' => ['_id' => 'foo'], 'newObj' => ['foo' => new \MongoBinData('junk data', \MongoBinData::BYTE_ARRAY)]],
+                ['use foo;', 'db.bar.update({ "_id": "foo" }, { "foo": new BinData(2, "' . base64_encode('junk data') . '") });'],
+            ]
+        ];
     }
 
     public function testCollectLimit()
     {
-        $queries = array(
-            array(
+        $queries = [
+            [
                 'find' => true,
-                'query' => array(
+                'query' => [
                     'path' => '/',
-                ),
-                'fields' => array(),
+                ],
+                'fields' => [],
                 'db' => 'foo',
                 'collection' => 'Route',
-            ),
-            array(
+            ],
+            [
                 'find' => true,
-                'query' => array('_id' => 'foo'),
-                'fields' => array(),
+                'query' => ['_id' => 'foo'],
+                'fields' => [],
                 'db' => 'foo',
                 'collection' => 'User',
-            ),
-            array(
+            ],
+            [
                 'limit' => true,
                 'limitNum' => 1,
-                'query' => array('_id' => 'foo'),
-                'fields' => array(),
-            ),
-            array(
+                'query' => ['_id' => 'foo'],
+                'fields' => [],
+            ],
+            [
                 'limit' => true,
                 'limitNum' => NULL,
-                'query' => array('_id' => 'foo'),
-                'fields' => array(),
-            ),
-            array(
+                'query' => ['_id' => 'foo'],
+                'fields' => [],
+            ],
+            [
                 'find' => true,
-                'query' => array(
+                'query' => [
                     '_id' => '5506fa1580c7e1ee3c8b4c60',
-                ),
-                'fields' => array(),
+                ],
+                'fields' => [],
                 'db' => 'foo',
                 'collection' => 'Group',
-            ),
-            array(
+            ],
+            [
                 'limit' => true,
                 'limitNum' => 1,
-                'query' => array(
+                'query' => [
                     '_id' => '5506fa1580c7e1ee3c8b4c60',
-                ),
-                'fields' => array(),
-            ),
-            array(
+                ],
+                'fields' => [],
+            ],
+            [
                 'limit' => true,
                 'limitNum' => NULL,
-                'query' => array(
+                'query' => [
                     '_id' => '5506fa1580c7e1ee3c8b4c60',
-                ),
-                'fields' => array(),
-            ),
-        );
-        $formatted = array(
+                ],
+                'fields' => [],
+            ],
+        ];
+        $formatted = [
             'use foo;',
             'db.Route.find({ "path": "/" });',
             'db.User.find({ "_id": "foo" }).limit(1);',
             'db.Group.find({ "_id": "5506fa1580c7e1ee3c8b4c60" }).limit(1);'
-        );
+        ];
 
         $collector = new PrettyDataCollector();
         foreach ($queries as $query) {

--- a/Tests/DataCollector/StandardDataCollectorTest.php
+++ b/Tests/DataCollector/StandardDataCollectorTest.php
@@ -23,10 +23,10 @@ class StandardDataCollectorTest extends \PHPUnit_Framework_TestCase
     public function testCollect()
     {
         $collector = new StandardDataCollector();
-        $collector->logQuery(array('foo' => 'bar'));
+        $collector->logQuery(['foo' => 'bar']);
         $collector->collect(new Request(), new Response());
 
         $this->assertEquals(1, $collector->getQueryCount());
-        $this->assertEquals(array('{"foo":"bar"}'), $collector->getQueries());
+        $this->assertEquals(['{"foo":"bar"}'], $collector->getQueries());
     }
 }

--- a/Tests/DependencyInjection/AbstractMongoDBExtensionTest.php
+++ b/Tests/DependencyInjection/AbstractMongoDBExtensionTest.php
@@ -16,11 +16,25 @@ namespace Doctrine\Bundle\MongoDBBundle\Tests\DependencyInjection;
 
 use Doctrine\Bundle\MongoDBBundle\DependencyInjection\Compiler\AddValidatorNamespaceAliasPass;
 use Doctrine\Bundle\MongoDBBundle\DependencyInjection\DoctrineMongoDBExtension;
+use Doctrine\Bundle\MongoDBBundle\Mapping\Driver\XmlDriver;
+use Doctrine\Bundle\MongoDBBundle\Mapping\Driver\YamlDriver;
 use Doctrine\Bundle\MongoDBBundle\Tests\TestCase;
+use Doctrine\Common\Cache\ApcCache;
+use Doctrine\Common\Cache\ArrayCache;
+use Doctrine\Common\Cache\MemcacheCache;
+use Doctrine\Common\Cache\XcacheCache;
+use Doctrine\Common\Persistence\Mapping\Driver\MappingDriverChain;
+use Doctrine\MongoDB\Connection;
+use Doctrine\ODM\MongoDB\Configuration;
+use Doctrine\ODM\MongoDB\DocumentManager;
+use Doctrine\ODM\MongoDB\Mapping\Driver\AnnotationDriver;
+use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntityValidator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
 use PHPUnit_Framework_AssertionFailedError;
+use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\Security\Core\User\UserInterface;
 
 abstract class AbstractMongoDBExtensionTest extends TestCase
 {
@@ -33,24 +47,24 @@ abstract class AbstractMongoDBExtensionTest extends TestCase
 
         $loader->load(DoctrineMongoDBExtensionTest::buildConfiguration(), $container);
 
-        $this->assertEquals('Doctrine\MongoDB\Connection', $container->getParameter('doctrine_mongodb.odm.connection.class'));
-        $this->assertEquals('Doctrine\ODM\MongoDB\Configuration', $container->getParameter('doctrine_mongodb.odm.configuration.class'));
-        $this->assertEquals('Doctrine\ODM\MongoDB\DocumentManager', $container->getParameter('doctrine_mongodb.odm.document_manager.class'));
+        $this->assertEquals(Connection::class, $container->getParameter('doctrine_mongodb.odm.connection.class'));
+        $this->assertEquals(Configuration::class, $container->getParameter('doctrine_mongodb.odm.configuration.class'));
+        $this->assertEquals(DocumentManager::class, $container->getParameter('doctrine_mongodb.odm.document_manager.class'));
         $this->assertEquals('MongoDBODMProxies', $container->getParameter('doctrine_mongodb.odm.proxy_namespace'));
         $this->assertEquals(false, $container->getParameter('doctrine_mongodb.odm.auto_generate_proxy_classes'));
-        $this->assertEquals('Doctrine\Common\Cache\ArrayCache', $container->getParameter('doctrine_mongodb.odm.cache.array.class'));
-        $this->assertEquals('Doctrine\Common\Cache\ApcCache', $container->getParameter('doctrine_mongodb.odm.cache.apc.class'));
-        $this->assertEquals('Doctrine\Common\Cache\MemcacheCache', $container->getParameter('doctrine_mongodb.odm.cache.memcache.class'));
+        $this->assertEquals(ArrayCache::class, $container->getParameter('doctrine_mongodb.odm.cache.array.class'));
+        $this->assertEquals(ApcCache::class, $container->getParameter('doctrine_mongodb.odm.cache.apc.class'));
+        $this->assertEquals(MemcacheCache::class, $container->getParameter('doctrine_mongodb.odm.cache.memcache.class'));
         $this->assertEquals('localhost', $container->getParameter('doctrine_mongodb.odm.cache.memcache_host'));
         $this->assertEquals('11211', $container->getParameter('doctrine_mongodb.odm.cache.memcache_port'));
         $this->assertEquals('Memcache', $container->getParameter('doctrine_mongodb.odm.cache.memcache_instance.class'));
-        $this->assertEquals('Doctrine\Common\Cache\XcacheCache', $container->getParameter('doctrine_mongodb.odm.cache.xcache.class'));
-        $this->assertEquals('Doctrine\Common\Persistence\Mapping\Driver\MappingDriverChain', $container->getParameter('doctrine_mongodb.odm.metadata.driver_chain.class'));
-        $this->assertEquals('Doctrine\ODM\MongoDB\Mapping\Driver\AnnotationDriver', $container->getParameter('doctrine_mongodb.odm.metadata.annotation.class'));
-        $this->assertEquals('Doctrine\Bundle\MongoDBBundle\Mapping\Driver\XmlDriver', $container->getParameter('doctrine_mongodb.odm.metadata.xml.class'));
-        $this->assertEquals('Doctrine\Bundle\MongoDBBundle\Mapping\Driver\YamlDriver', $container->getParameter('doctrine_mongodb.odm.metadata.yml.class'));
+        $this->assertEquals(XcacheCache::class, $container->getParameter('doctrine_mongodb.odm.cache.xcache.class'));
+        $this->assertEquals(MappingDriverChain::class, $container->getParameter('doctrine_mongodb.odm.metadata.driver_chain.class'));
+        $this->assertEquals(AnnotationDriver::class, $container->getParameter('doctrine_mongodb.odm.metadata.annotation.class'));
+        $this->assertEquals(XmlDriver::class, $container->getParameter('doctrine_mongodb.odm.metadata.xml.class'));
+        $this->assertEquals(YamlDriver::class, $container->getParameter('doctrine_mongodb.odm.metadata.yml.class'));
 
-        $this->assertEquals('Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntityValidator', $container->getParameter('doctrine_odm.mongodb.validator.unique.class'));
+        $this->assertEquals(UniqueEntityValidator::class, $container->getParameter('doctrine_odm.mongodb.validator.unique.class'));
 
         $config = DoctrineMongoDBExtensionTest::buildConfiguration(array(
             'proxy_namespace' => 'MyProxies',
@@ -69,9 +83,9 @@ abstract class AbstractMongoDBExtensionTest extends TestCase
         $arguments = $definition->getArguments();
         $this->assertEquals(null, $arguments[0]);
         $this->assertEquals(array(), $arguments[1]);
-        $this->assertInstanceOf('Symfony\Component\DependencyInjection\Reference', $arguments[2]);
+        $this->assertInstanceOf(Reference::class, $arguments[2]);
         $this->assertEquals('doctrine_mongodb.odm.default_configuration', (string) $arguments[2]);
-        $this->assertInstanceOf('Symfony\Component\DependencyInjection\Reference', $arguments[3]);
+        $this->assertInstanceOf(Reference::class, $arguments[3]);
         $this->assertEquals('doctrine_mongodb.odm.default_connection.event_manager', (string) $arguments[3]);
 
         $definition = $container->getDefinition('doctrine_mongodb.odm.default_document_manager');
@@ -80,9 +94,9 @@ abstract class AbstractMongoDBExtensionTest extends TestCase
         $this->assertArrayHasKey('doctrine_mongodb.odm.document_manager', $definition->getTags());
 
         $arguments = $definition->getArguments();
-        $this->assertInstanceOf('Symfony\Component\DependencyInjection\Reference', $arguments[0]);
+        $this->assertInstanceOf(Reference::class, $arguments[0]);
         $this->assertEquals('doctrine_mongodb.odm.default_connection', (string) $arguments[0]);
-        $this->assertInstanceOf('Symfony\Component\DependencyInjection\Reference', $arguments[1]);
+        $this->assertInstanceOf(Reference::class, $arguments[1]);
         $this->assertEquals('doctrine_mongodb.odm.default_configuration', (string) $arguments[1]);
     }
 
@@ -108,9 +122,9 @@ abstract class AbstractMongoDBExtensionTest extends TestCase
         $arguments = $definition->getArguments();
         $this->assertEquals('mongodb://localhost:27017', $arguments[0]);
         $this->assertEquals(array('connect' => true), $arguments[1]);
-        $this->assertInstanceOf('Symfony\Component\DependencyInjection\Reference', $arguments[2]);
+        $this->assertInstanceOf(Reference::class, $arguments[2]);
         $this->assertEquals('doctrine_mongodb.odm.default_configuration', (string) $arguments[2]);
-        $this->assertInstanceOf('Symfony\Component\DependencyInjection\Reference', $arguments[3]);
+        $this->assertInstanceOf(Reference::class, $arguments[3]);
         $this->assertEquals('doctrine_mongodb.odm.default_connection.event_manager', (string) $arguments[3]);
 
         $definition = $container->getDefinition('doctrine_mongodb.odm.default_document_manager');
@@ -119,9 +133,9 @@ abstract class AbstractMongoDBExtensionTest extends TestCase
         $this->assertArrayHasKey('doctrine_mongodb.odm.document_manager', $definition->getTags());
 
         $arguments = $definition->getArguments();
-        $this->assertInstanceOf('Symfony\Component\DependencyInjection\Reference', $arguments[0]);
+        $this->assertInstanceOf(Reference::class, $arguments[0]);
         $this->assertEquals('doctrine_mongodb.odm.default_connection', (string) $arguments[0]);
-        $this->assertInstanceOf('Symfony\Component\DependencyInjection\Reference', $arguments[1]);
+        $this->assertInstanceOf(Reference::class, $arguments[1]);
         $this->assertEquals('doctrine_mongodb.odm.default_configuration', (string) $arguments[1]);
     }
 
@@ -143,9 +157,9 @@ abstract class AbstractMongoDBExtensionTest extends TestCase
         $arguments = $definition->getArguments();
         $this->assertEquals('mongodb://localhost:27017', $arguments[0]);
         $this->assertEquals(array('connect' => true), $arguments[1]);
-        $this->assertInstanceOf('Symfony\Component\DependencyInjection\Reference', $arguments[2]);
+        $this->assertInstanceOf(Reference::class, $arguments[2]);
         $this->assertEquals('doctrine_mongodb.odm.default_configuration', (string) $arguments[2]);
-        $this->assertInstanceOf('Symfony\Component\DependencyInjection\Reference', $arguments[3]);
+        $this->assertInstanceOf(Reference::class, $arguments[3]);
         $this->assertEquals('doctrine_mongodb.odm.default_connection.event_manager', (string) $arguments[3]);
 
         $definition = $container->getDefinition('doctrine_mongodb.odm.default_configuration');
@@ -160,9 +174,9 @@ abstract class AbstractMongoDBExtensionTest extends TestCase
         $this->assertArrayHasKey('doctrine_mongodb.odm.document_manager', $definition->getTags());
 
         $arguments = $definition->getArguments();
-        $this->assertInstanceOf('Symfony\Component\DependencyInjection\Reference', $arguments[0]);
+        $this->assertInstanceOf(Reference::class, $arguments[0]);
         $this->assertEquals('doctrine_mongodb.odm.default_connection', (string) $arguments[0]);
-        $this->assertInstanceOf('Symfony\Component\DependencyInjection\Reference', $arguments[1]);
+        $this->assertInstanceOf(Reference::class, $arguments[1]);
         $this->assertEquals('doctrine_mongodb.odm.default_configuration', (string) $arguments[1]);
 
         $this->assertEquals('doctrine_mongodb.odm.default_document_manager', (string) $container->getAlias('doctrine_mongodb.odm.document_manager'));
@@ -187,9 +201,9 @@ abstract class AbstractMongoDBExtensionTest extends TestCase
         $arguments = $definition->getArguments();
         $this->assertEquals('mongodb://localhost:27017', $arguments[0]);
         $this->assertEquals(array('connect' => true), $arguments[1]);
-        $this->assertInstanceOf('Symfony\Component\DependencyInjection\Reference', $arguments[2]);
+        $this->assertInstanceOf(Reference::class, $arguments[2]);
         $this->assertEquals('doctrine_mongodb.odm.default_configuration', (string) $arguments[2]);
-        $this->assertInstanceOf('Symfony\Component\DependencyInjection\Reference', $arguments[3]);
+        $this->assertInstanceOf(Reference::class, $arguments[3]);
         $this->assertEquals('doctrine_mongodb.odm.default_connection.event_manager', (string) $arguments[3]);
 
         $definition = $container->getDefinition('doctrine_mongodb.odm.default_document_manager');
@@ -198,9 +212,9 @@ abstract class AbstractMongoDBExtensionTest extends TestCase
         $this->assertArrayHasKey('doctrine_mongodb.odm.document_manager', $definition->getTags());
 
         $arguments = $definition->getArguments();
-        $this->assertInstanceOf('Symfony\Component\DependencyInjection\Reference', $arguments[0]);
+        $this->assertInstanceOf(Reference::class, $arguments[0]);
         $this->assertEquals('doctrine_mongodb.odm.default_connection', (string) $arguments[0]);
-        $this->assertInstanceOf('Symfony\Component\DependencyInjection\Reference', $arguments[1]);
+        $this->assertInstanceOf(Reference::class, $arguments[1]);
         $this->assertEquals('doctrine_mongodb.odm.default_configuration', (string) $arguments[1]);
 
         $this->assertEquals('doctrine_mongodb.odm.default_document_manager', (string) $container->getAlias('doctrine_mongodb.odm.document_manager'));
@@ -225,9 +239,9 @@ abstract class AbstractMongoDBExtensionTest extends TestCase
         $arguments = $definition->getArguments();
         $this->assertEquals('mongodb://localhost:27017', $arguments[0]);
         $this->assertEquals(array('connect' => true), $arguments[1]);
-        $this->assertInstanceOf('Symfony\Component\DependencyInjection\Reference', $arguments[2]);
+        $this->assertInstanceOf(Reference::class, $arguments[2]);
         $this->assertEquals('doctrine_mongodb.odm.conn1_configuration', (string) $arguments[2]);
-        $this->assertInstanceOf('Symfony\Component\DependencyInjection\Reference', $arguments[3]);
+        $this->assertInstanceOf(Reference::class, $arguments[3]);
         $this->assertEquals('doctrine_mongodb.odm.conn1_connection.event_manager', (string) $arguments[3]);
 
         $definition = $container->getDefinition('doctrine_mongodb.odm.dm1_document_manager');
@@ -236,9 +250,9 @@ abstract class AbstractMongoDBExtensionTest extends TestCase
         $this->assertArrayHasKey('doctrine_mongodb.odm.document_manager', $definition->getTags());
 
         $arguments = $definition->getArguments();
-        $this->assertInstanceOf('Symfony\Component\DependencyInjection\Reference', $arguments[0]);
+        $this->assertInstanceOf(Reference::class, $arguments[0]);
         $this->assertEquals('doctrine_mongodb.odm.conn1_connection', (string) $arguments[0]);
-        $this->assertInstanceOf('Symfony\Component\DependencyInjection\Reference', $arguments[1]);
+        $this->assertInstanceOf(Reference::class, $arguments[1]);
         $this->assertEquals('doctrine_mongodb.odm.dm1_configuration', (string) $arguments[1]);
 
         $definition = $container->getDefinition('doctrine_mongodb.odm.conn2_connection');
@@ -247,9 +261,9 @@ abstract class AbstractMongoDBExtensionTest extends TestCase
         $arguments = $definition->getArguments();
         $this->assertEquals('mongodb://localhost:27017', $arguments[0]);
         $this->assertEquals(array('connect' => true), $arguments[1]);
-        $this->assertInstanceOf('Symfony\Component\DependencyInjection\Reference', $arguments[2]);
+        $this->assertInstanceOf(Reference::class, $arguments[2]);
         $this->assertEquals('doctrine_mongodb.odm.conn2_configuration', (string) $arguments[2]);
-        $this->assertInstanceOf('Symfony\Component\DependencyInjection\Reference', $arguments[3]);
+        $this->assertInstanceOf(Reference::class, $arguments[3]);
         $this->assertEquals('doctrine_mongodb.odm.conn2_connection.event_manager', (string) $arguments[3]);
 
         $definition = $container->getDefinition('doctrine_mongodb.odm.dm2_document_manager');
@@ -258,9 +272,9 @@ abstract class AbstractMongoDBExtensionTest extends TestCase
         $this->assertArrayHasKey('doctrine_mongodb.odm.document_manager', $definition->getTags());
 
         $arguments = $definition->getArguments();
-        $this->assertInstanceOf('Symfony\Component\DependencyInjection\Reference', $arguments[0]);
+        $this->assertInstanceOf(Reference::class, $arguments[0]);
         $this->assertEquals('doctrine_mongodb.odm.conn2_connection', (string) $arguments[0]);
-        $this->assertInstanceOf('Symfony\Component\DependencyInjection\Reference', $arguments[1]);
+        $this->assertInstanceOf(Reference::class, $arguments[1]);
         $this->assertEquals('doctrine_mongodb.odm.dm2_configuration', (string) $arguments[1]);
 
         $this->assertEquals('doctrine_mongodb.odm.dm2_document_manager', (string) $container->getAlias('doctrine_mongodb.odm.document_manager'));
@@ -357,7 +371,7 @@ abstract class AbstractMongoDBExtensionTest extends TestCase
         $container->compile();
 
         $definition = $container->getDefinition('doctrine_mongodb.odm.default_metadata_cache');
-        $this->assertEquals('Doctrine\Common\Cache\MemcacheCache', $definition->getClass());
+        $this->assertEquals(MemcacheCache::class, $definition->getClass());
 
         $calls = $definition->getMethodCalls();
         $this->assertEquals('setMemcache', $calls[0][0]);
@@ -402,7 +416,7 @@ abstract class AbstractMongoDBExtensionTest extends TestCase
         $container->compile();
 
         $definition = $container->getDefinition('doctrine_mongodb.odm.listeners.resolve_target_document');
-        $this->assertDefinitionMethodCallOnce($definition, 'addResolveTargetDocument', array('Symfony\Component\Security\Core\User\UserInterface', 'MyUserClass', array()));
+        $this->assertDefinitionMethodCallOnce($definition, 'addResolveTargetDocument', array(UserInterface::class, 'MyUserClass', array()));
         $this->assertEquals(array('doctrine_mongodb.odm.event_listener' => array(array('event' => 'loadClassMetadata'))), $definition->getTags());
     }
 
@@ -426,9 +440,9 @@ abstract class AbstractMongoDBExtensionTest extends TestCase
         );
 
         $definition = $container->getDefinition('doctrine_mongodb.odm.default_configuration');
-        $this->assertDefinitionMethodCallAny($definition, 'addFilter', array('disabled_filter', 'Vendor\Filter\DisabledFilter', array()));
-        $this->assertDefinitionMethodCallAny($definition, 'addFilter', array('basic_filter', 'Vendor\Filter\BasicFilter', array()));
-        $this->assertDefinitionMethodCallAny($definition, 'addFilter', array('complex_filter', 'Vendor\Filter\ComplexFilter', $complexParameters));
+        $this->assertDefinitionMethodCallAny($definition, 'addFilter', array('disabled_filter', \Vendor\Filter\DisabledFilter::class, array()));
+        $this->assertDefinitionMethodCallAny($definition, 'addFilter', array('basic_filter', \Vendor\Filter\BasicFilter::class, array()));
+        $this->assertDefinitionMethodCallAny($definition, 'addFilter', array('complex_filter', \Vendor\Filter\ComplexFilter::class, $complexParameters));
 
         $enabledFilters = array('basic_filter', 'complex_filter');
 

--- a/Tests/DependencyInjection/AbstractMongoDBExtensionTest.php
+++ b/Tests/DependencyInjection/AbstractMongoDBExtensionTest.php
@@ -66,12 +66,12 @@ abstract class AbstractMongoDBExtensionTest extends TestCase
 
         $this->assertEquals(UniqueEntityValidator::class, $container->getParameter('doctrine_odm.mongodb.validator.unique.class'));
 
-        $config = DoctrineMongoDBExtensionTest::buildConfiguration(array(
+        $config = DoctrineMongoDBExtensionTest::buildConfiguration([
             'proxy_namespace' => 'MyProxies',
             'auto_generate_proxy_classes' => true,
-            'connections' => array('default' => array()),
-            'document_managers' => array('default' => array())
-        ));
+            'connections' => ['default' => []],
+            'document_managers' => ['default' => []]
+        ]);
         $loader->load($config, $container);
 
         $this->assertEquals('MyProxies', $container->getParameter('doctrine_mongodb.odm.proxy_namespace'));
@@ -82,7 +82,7 @@ abstract class AbstractMongoDBExtensionTest extends TestCase
 
         $arguments = $definition->getArguments();
         $this->assertEquals(null, $arguments[0]);
-        $this->assertEquals(array(), $arguments[1]);
+        $this->assertEquals([], $arguments[1]);
         $this->assertInstanceOf(Reference::class, $arguments[2]);
         $this->assertEquals('doctrine_mongodb.odm.default_configuration', (string) $arguments[2]);
         $this->assertInstanceOf(Reference::class, $arguments[3]);
@@ -90,7 +90,7 @@ abstract class AbstractMongoDBExtensionTest extends TestCase
 
         $definition = $container->getDefinition('doctrine_mongodb.odm.default_document_manager');
         $this->assertEquals('%doctrine_mongodb.odm.document_manager.class%', $definition->getClass());
-        $this->assertEquals(array('%doctrine_mongodb.odm.document_manager.class%', 'create'), $definition->getFactory());
+        $this->assertEquals(['%doctrine_mongodb.odm.document_manager.class%', 'create'], $definition->getFactory());
         $this->assertArrayHasKey('doctrine_mongodb.odm.document_manager', $definition->getTags());
 
         $arguments = $definition->getArguments();
@@ -105,23 +105,23 @@ abstract class AbstractMongoDBExtensionTest extends TestCase
         $container = $this->getContainer();
         $loader = new DoctrineMongoDBExtension();
 
-        $config = array(
-            'connections' => array(
-                'default' => array(
+        $config = [
+            'connections' => [
+                'default' => [
                     'server' => 'mongodb://localhost:27017',
-                    'options' => array('connect' => true)
-                )
-            ),
-            'document_managers' => array('default' => array())
-        );
-        $loader->load(array($config), $container);
+                    'options' => ['connect' => true]
+                ]
+            ],
+            'document_managers' => ['default' => []]
+        ];
+        $loader->load([$config], $container);
 
         $definition = $container->getDefinition('doctrine_mongodb.odm.default_connection');
         $this->assertEquals('%doctrine_mongodb.odm.connection.class%', $definition->getClass());
 
         $arguments = $definition->getArguments();
         $this->assertEquals('mongodb://localhost:27017', $arguments[0]);
-        $this->assertEquals(array('connect' => true), $arguments[1]);
+        $this->assertEquals(['connect' => true], $arguments[1]);
         $this->assertInstanceOf(Reference::class, $arguments[2]);
         $this->assertEquals('doctrine_mongodb.odm.default_configuration', (string) $arguments[2]);
         $this->assertInstanceOf(Reference::class, $arguments[3]);
@@ -129,7 +129,7 @@ abstract class AbstractMongoDBExtensionTest extends TestCase
 
         $definition = $container->getDefinition('doctrine_mongodb.odm.default_document_manager');
         $this->assertEquals('%doctrine_mongodb.odm.document_manager.class%', $definition->getClass());
-        $this->assertEquals(array('%doctrine_mongodb.odm.document_manager.class%', 'create'), $definition->getFactory());
+        $this->assertEquals(['%doctrine_mongodb.odm.document_manager.class%', 'create'], $definition->getFactory());
         $this->assertArrayHasKey('doctrine_mongodb.odm.document_manager', $definition->getTags());
 
         $arguments = $definition->getArguments();
@@ -147,8 +147,8 @@ abstract class AbstractMongoDBExtensionTest extends TestCase
 
         $this->loadFromFile($container, 'mongodb_service_simple_single_connection');
 
-        $container->getCompilerPassConfig()->setOptimizationPasses(array());
-        $container->getCompilerPassConfig()->setRemovingPasses(array());
+        $container->getCompilerPassConfig()->setOptimizationPasses([]);
+        $container->getCompilerPassConfig()->setRemovingPasses([]);
         $container->compile();
 
         $definition = $container->getDefinition('doctrine_mongodb.odm.default_connection');
@@ -156,7 +156,7 @@ abstract class AbstractMongoDBExtensionTest extends TestCase
 
         $arguments = $definition->getArguments();
         $this->assertEquals('mongodb://localhost:27017', $arguments[0]);
-        $this->assertEquals(array('connect' => true), $arguments[1]);
+        $this->assertEquals(['connect' => true], $arguments[1]);
         $this->assertInstanceOf(Reference::class, $arguments[2]);
         $this->assertEquals('doctrine_mongodb.odm.default_configuration', (string) $arguments[2]);
         $this->assertInstanceOf(Reference::class, $arguments[3]);
@@ -170,7 +170,7 @@ abstract class AbstractMongoDBExtensionTest extends TestCase
 
         $definition = $container->getDefinition('doctrine_mongodb.odm.default_document_manager');
         $this->assertEquals('%doctrine_mongodb.odm.document_manager.class%', $definition->getClass());
-        $this->assertEquals(array('%doctrine_mongodb.odm.document_manager.class%', 'create'), $definition->getFactory());
+        $this->assertEquals(['%doctrine_mongodb.odm.document_manager.class%', 'create'], $definition->getFactory());
         $this->assertArrayHasKey('doctrine_mongodb.odm.document_manager', $definition->getTags());
 
         $arguments = $definition->getArguments();
@@ -191,8 +191,8 @@ abstract class AbstractMongoDBExtensionTest extends TestCase
 
         $this->loadFromFile($container, 'mongodb_service_single_connection');
 
-        $container->getCompilerPassConfig()->setOptimizationPasses(array());
-        $container->getCompilerPassConfig()->setRemovingPasses(array());
+        $container->getCompilerPassConfig()->setOptimizationPasses([]);
+        $container->getCompilerPassConfig()->setRemovingPasses([]);
         $container->compile();
 
         $definition = $container->getDefinition('doctrine_mongodb.odm.default_connection');
@@ -200,7 +200,7 @@ abstract class AbstractMongoDBExtensionTest extends TestCase
 
         $arguments = $definition->getArguments();
         $this->assertEquals('mongodb://localhost:27017', $arguments[0]);
-        $this->assertEquals(array('connect' => true), $arguments[1]);
+        $this->assertEquals(['connect' => true], $arguments[1]);
         $this->assertInstanceOf(Reference::class, $arguments[2]);
         $this->assertEquals('doctrine_mongodb.odm.default_configuration', (string) $arguments[2]);
         $this->assertInstanceOf(Reference::class, $arguments[3]);
@@ -208,7 +208,7 @@ abstract class AbstractMongoDBExtensionTest extends TestCase
 
         $definition = $container->getDefinition('doctrine_mongodb.odm.default_document_manager');
         $this->assertEquals('%doctrine_mongodb.odm.document_manager.class%', $definition->getClass());
-        $this->assertEquals(array('%doctrine_mongodb.odm.document_manager.class%', 'create'), $definition->getFactory());
+        $this->assertEquals(['%doctrine_mongodb.odm.document_manager.class%', 'create'], $definition->getFactory());
         $this->assertArrayHasKey('doctrine_mongodb.odm.document_manager', $definition->getTags());
 
         $arguments = $definition->getArguments();
@@ -229,8 +229,8 @@ abstract class AbstractMongoDBExtensionTest extends TestCase
 
         $this->loadFromFile($container, 'mongodb_service_multiple_connections');
 
-        $container->getCompilerPassConfig()->setOptimizationPasses(array());
-        $container->getCompilerPassConfig()->setRemovingPasses(array());
+        $container->getCompilerPassConfig()->setOptimizationPasses([]);
+        $container->getCompilerPassConfig()->setRemovingPasses([]);
         $container->compile();
 
         $definition = $container->getDefinition('doctrine_mongodb.odm.conn1_connection');
@@ -238,7 +238,7 @@ abstract class AbstractMongoDBExtensionTest extends TestCase
 
         $arguments = $definition->getArguments();
         $this->assertEquals('mongodb://localhost:27017', $arguments[0]);
-        $this->assertEquals(array('connect' => true), $arguments[1]);
+        $this->assertEquals(['connect' => true], $arguments[1]);
         $this->assertInstanceOf(Reference::class, $arguments[2]);
         $this->assertEquals('doctrine_mongodb.odm.conn1_configuration', (string) $arguments[2]);
         $this->assertInstanceOf(Reference::class, $arguments[3]);
@@ -246,7 +246,7 @@ abstract class AbstractMongoDBExtensionTest extends TestCase
 
         $definition = $container->getDefinition('doctrine_mongodb.odm.dm1_document_manager');
         $this->assertEquals('%doctrine_mongodb.odm.document_manager.class%', $definition->getClass());
-        $this->assertEquals(array('%doctrine_mongodb.odm.document_manager.class%', 'create'), $definition->getFactory());
+        $this->assertEquals(['%doctrine_mongodb.odm.document_manager.class%', 'create'], $definition->getFactory());
         $this->assertArrayHasKey('doctrine_mongodb.odm.document_manager', $definition->getTags());
 
         $arguments = $definition->getArguments();
@@ -260,7 +260,7 @@ abstract class AbstractMongoDBExtensionTest extends TestCase
 
         $arguments = $definition->getArguments();
         $this->assertEquals('mongodb://localhost:27017', $arguments[0]);
-        $this->assertEquals(array('connect' => true), $arguments[1]);
+        $this->assertEquals(['connect' => true], $arguments[1]);
         $this->assertInstanceOf(Reference::class, $arguments[2]);
         $this->assertEquals('doctrine_mongodb.odm.conn2_configuration', (string) $arguments[2]);
         $this->assertInstanceOf(Reference::class, $arguments[3]);
@@ -268,7 +268,7 @@ abstract class AbstractMongoDBExtensionTest extends TestCase
 
         $definition = $container->getDefinition('doctrine_mongodb.odm.dm2_document_manager');
         $this->assertEquals('%doctrine_mongodb.odm.document_manager.class%', $definition->getClass());
-        $this->assertEquals(array('%doctrine_mongodb.odm.document_manager.class%', 'create'), $definition->getFactory());
+        $this->assertEquals(['%doctrine_mongodb.odm.document_manager.class%', 'create'], $definition->getFactory());
         $this->assertArrayHasKey('doctrine_mongodb.odm.document_manager', $definition->getTags());
 
         $arguments = $definition->getArguments();
@@ -287,7 +287,7 @@ abstract class AbstractMongoDBExtensionTest extends TestCase
         $loader = new DoctrineMongoDBExtension();
 
         $config = DoctrineMongoDBExtensionTest::buildConfiguration(
-            array('document_managers' => array('default' => array('mappings' => array('YamlBundle' => array()))))
+            ['document_managers' => ['default' => ['mappings' => ['YamlBundle' => []]]]]
         );
         $loader->load($config, $container);
 
@@ -302,7 +302,7 @@ abstract class AbstractMongoDBExtensionTest extends TestCase
         $container = $this->getContainer('YamlBundle');
         $loader = new DoctrineMongoDBExtension();
         $config = DoctrineMongoDBExtensionTest::buildConfiguration(
-            array('document_managers' => array('default' => array('mappings' => array('YamlBundle' => array()))))
+            ['document_managers' => ['default' => ['mappings' => ['YamlBundle' => []]]]]
         );
         $loader->load($config, $container);
 
@@ -316,7 +316,7 @@ abstract class AbstractMongoDBExtensionTest extends TestCase
         $container = $this->getContainer('XmlBundle');
         $loader = new DoctrineMongoDBExtension();
         $config = DoctrineMongoDBExtensionTest::buildConfiguration(
-            array('document_managers' => array('default' => array('mappings' => array('XmlBundle' => array()))))
+            ['document_managers' => ['default' => ['mappings' => ['XmlBundle' => []]]]]
         );
         $loader->load($config, $container);
 
@@ -330,7 +330,7 @@ abstract class AbstractMongoDBExtensionTest extends TestCase
         $container = $this->getContainer('AnnotationsBundle');
         $loader = new DoctrineMongoDBExtension();
         $config = DoctrineMongoDBExtensionTest::buildConfiguration(
-            array('document_managers' => array('default' => array('mappings' => array('AnnotationsBundle' => array()))))
+            ['document_managers' => ['default' => ['mappings' => ['AnnotationsBundle' => []]]]]
         );
         $loader->load($config, $container);
 
@@ -347,8 +347,8 @@ abstract class AbstractMongoDBExtensionTest extends TestCase
 
         $this->loadFromFile($container, 'mongodb_service_multiple_connections');
 
-        $container->getCompilerPassConfig()->setOptimizationPasses(array());
-        $container->getCompilerPassConfig()->setRemovingPasses(array());
+        $container->getCompilerPassConfig()->setOptimizationPasses([]);
+        $container->getCompilerPassConfig()->setRemovingPasses([]);
         $container->compile();
 
         $definition = $container->getDefinition('doctrine_mongodb.odm.dm1_metadata_cache');
@@ -366,8 +366,8 @@ abstract class AbstractMongoDBExtensionTest extends TestCase
 
         $this->loadFromFile($container, 'mongodb_service_simple_single_connection');
 
-        $container->getCompilerPassConfig()->setOptimizationPasses(array());
-        $container->getCompilerPassConfig()->setRemovingPasses(array());
+        $container->getCompilerPassConfig()->setOptimizationPasses([]);
+        $container->getCompilerPassConfig()->setRemovingPasses([]);
         $container->compile();
 
         $definition = $container->getDefinition('doctrine_mongodb.odm.default_metadata_cache');
@@ -396,8 +396,8 @@ abstract class AbstractMongoDBExtensionTest extends TestCase
 
         $this->loadFromFile($container, 'odm_imports');
 
-        $container->getCompilerPassConfig()->setOptimizationPasses(array());
-        $container->getCompilerPassConfig()->setRemovingPasses(array());
+        $container->getCompilerPassConfig()->setOptimizationPasses([]);
+        $container->getCompilerPassConfig()->setRemovingPasses([]);
         $container->compile();
 
         $this->assertTrue((bool) $container->getParameter('doctrine_mongodb.odm.auto_generate_proxy_classes'));
@@ -411,13 +411,13 @@ abstract class AbstractMongoDBExtensionTest extends TestCase
 
         $this->loadFromFile($container, 'odm_resolve_target_document');
 
-        $container->getCompilerPassConfig()->setOptimizationPasses(array());
-        $container->getCompilerPassConfig()->setRemovingPasses(array());
+        $container->getCompilerPassConfig()->setOptimizationPasses([]);
+        $container->getCompilerPassConfig()->setRemovingPasses([]);
         $container->compile();
 
         $definition = $container->getDefinition('doctrine_mongodb.odm.listeners.resolve_target_document');
-        $this->assertDefinitionMethodCallOnce($definition, 'addResolveTargetDocument', array(UserInterface::class, 'MyUserClass', array()));
-        $this->assertEquals(array('doctrine_mongodb.odm.event_listener' => array(array('event' => 'loadClassMetadata'))), $definition->getTags());
+        $this->assertDefinitionMethodCallOnce($definition, 'addResolveTargetDocument', [UserInterface::class, 'MyUserClass', []]);
+        $this->assertEquals(['doctrine_mongodb.odm.event_listener' => [['event' => 'loadClassMetadata']]], $definition->getTags());
     }
 
     public function testFilters()
@@ -428,23 +428,23 @@ abstract class AbstractMongoDBExtensionTest extends TestCase
 
         $this->loadFromFile($container, 'odm_filters');
 
-        $container->getCompilerPassConfig()->setOptimizationPasses(array());
-        $container->getCompilerPassConfig()->setRemovingPasses(array());
+        $container->getCompilerPassConfig()->setOptimizationPasses([]);
+        $container->getCompilerPassConfig()->setRemovingPasses([]);
         $container->compile();
 
-        $complexParameters = array(
+        $complexParameters = [
             'integer' => 1,
             'string' => 'foo',
-            'object' => array('key' => 'value'),
-            'array' => array(1, 2, 3),
-        );
+            'object' => ['key' => 'value'],
+            'array' => [1, 2, 3],
+        ];
 
         $definition = $container->getDefinition('doctrine_mongodb.odm.default_configuration');
-        $this->assertDefinitionMethodCallAny($definition, 'addFilter', array('disabled_filter', \Vendor\Filter\DisabledFilter::class, array()));
-        $this->assertDefinitionMethodCallAny($definition, 'addFilter', array('basic_filter', \Vendor\Filter\BasicFilter::class, array()));
-        $this->assertDefinitionMethodCallAny($definition, 'addFilter', array('complex_filter', \Vendor\Filter\ComplexFilter::class, $complexParameters));
+        $this->assertDefinitionMethodCallAny($definition, 'addFilter', ['disabled_filter', \Vendor\Filter\DisabledFilter::class, []]);
+        $this->assertDefinitionMethodCallAny($definition, 'addFilter', ['basic_filter', \Vendor\Filter\BasicFilter::class, []]);
+        $this->assertDefinitionMethodCallAny($definition, 'addFilter', ['complex_filter', \Vendor\Filter\ComplexFilter::class, $complexParameters]);
 
-        $enabledFilters = array('basic_filter', 'complex_filter');
+        $enabledFilters = ['basic_filter', 'complex_filter'];
 
         $definition = $container->getDefinition('doctrine_mongodb.odm.default_manager_configurator');
         $this->assertEquals($enabledFilters, $definition->getArgument(0), 'Only enabled filters are passed to the ManagerConfigurator.');
@@ -524,14 +524,14 @@ abstract class AbstractMongoDBExtensionTest extends TestCase
     {
         require_once __DIR__.'/Fixtures/Bundles/'.$bundle.'/'.$bundle.'.php';
 
-        return new ContainerBuilder(new ParameterBag(array(
-            'kernel.bundles'          => array($bundle => 'DoctrineMongoDBBundle\\Tests\\DependencyInjection\\Fixtures\\Bundles\\'.$bundle.'\\'.$bundle),
+        return new ContainerBuilder(new ParameterBag([
+            'kernel.bundles'          => [$bundle => 'DoctrineMongoDBBundle\\Tests\\DependencyInjection\\Fixtures\\Bundles\\'.$bundle.'\\'.$bundle],
             'kernel.cache_dir'        => __DIR__,
-            'kernel.compiled_classes' => array(),
+            'kernel.compiled_classes' => [],
             'kernel.debug'            => false,
             'kernel.environment'      => 'test',
             'kernel.name'             => 'kernel',
             'kernel.root_dir'         => __DIR__,
-        )));
+        ]));
     }
 }

--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -28,25 +28,25 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
     {
         $processor = new Processor();
         $configuration = new Configuration(false);
-        $options = $processor->processConfiguration($configuration, array());
+        $options = $processor->processConfiguration($configuration, []);
 
-        $defaults = array(
+        $defaults = [
             'fixture_loader'                 => ContainerAwareLoader::class,
             'auto_generate_hydrator_classes' => false,
             'auto_generate_proxy_classes'    => false,
             'auto_generate_persistent_collection_classes' => ODMConfiguration::AUTOGENERATE_NEVER,
             'default_database'               => 'default',
-            'document_managers'              => array(),
-            'connections'                    => array(),
+            'document_managers'              => [],
+            'connections'                    => [],
             'proxy_dir'                      => '%kernel.cache_dir%/doctrine/odm/mongodb/Proxies',
-            'resolve_target_documents'       => array(),
+            'resolve_target_documents'       => [],
             'proxy_namespace'                => 'MongoDBODMProxies',
             'hydrator_dir'                   => '%kernel.cache_dir%/doctrine/odm/mongodb/Hydrators',
             'hydrator_namespace'             => 'Hydrators',
-            'default_commit_options'         => array(),
+            'default_commit_options'         => [],
             'persistent_collection_dir'      => '%kernel.cache_dir%/doctrine/odm/mongodb/PersistentCollections',
             'persistent_collection_namespace'=> 'PersistentCollections',
-        );
+        ];
 
         $this->assertEquals($defaults, $options);
     }
@@ -58,9 +58,9 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
     {
         $processor = new Processor();
         $configuration = new Configuration(false);
-        $options = $processor->processConfiguration($configuration, array($config));
+        $options = $processor->processConfiguration($configuration, [$config]);
 
-        $expected = array(
+        $expected = [
             'fixture_loader'                 => ContainerAwareLoader::class,
             'auto_generate_hydrator_classes' => true,
             'auto_generate_proxy_classes'    => true,
@@ -74,29 +74,29 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
             'proxy_namespace'                => 'Test_Proxies',
             'persistent_collection_dir'      => '%kernel.cache_dir%/doctrine/odm/mongodb/Test_Pcolls',
             'persistent_collection_namespace'=> 'Test_Pcolls',
-            'default_commit_options' => array(
+            'default_commit_options' => [
                 'j' => false,
                 'timeout' => 10,
                 'w' => 'majority',
                 'wtimeout' => 10,
                 'fsync' => false,
                 'safe' => 2,
-            ),
-            'connections' => array(
-                'conn1' => array(
+            ],
+            'connections' => [
+                'conn1' => [
                     'server'  => 'mongodb://localhost',
-                    'options' => array(
+                    'options' => [
                         'connect'           => true,
                         'connectTimeoutMS'  => 500,
                         'db'                => 'database_val',
                         'journal'           => true,
                         'password'          => 'password_val',
                         'readPreference'    => 'secondaryPreferred',
-                        'readPreferenceTags' => array(
-                            array('dc' => 'east', 'use' => 'reporting'),
-                            array('dc' => 'west'),
-                            array(),
-                        ),
+                        'readPreferenceTags' => [
+                            ['dc' => 'east', 'use' => 'reporting'],
+                            ['dc' => 'west'],
+                            [],
+                        ],
                         'replicaSet'        => 'foo',
                         'slaveOkay'         => true,
                         'socketTimeoutMS'   => 1000,
@@ -105,62 +105,62 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
                         'username'          => 'username_val',
                         'w'                 => 'majority',
                         'wTimeoutMS'        => 1000,
-                    ),
-                ),
-                'conn2' => array(
+                    ],
+                ],
+                'conn2' => [
                     'server'  => 'mongodb://otherhost',
-                ),
-            ),
-            'document_managers' => array(
-                'dm1' => array(
+                ],
+            ],
+            'document_managers' => [
+                'dm1' => [
                     'default_repository_class' => DocumentRepository::class,
                     'repository_factory' => null,
                     'persistent_collection_factory' => null,
                     'logging'      => '%kernel.debug%',
                     'auto_mapping' => false,
-                    'filters' => array(
-                        'disabled_filter' => array(
+                    'filters' => [
+                        'disabled_filter' => [
                             'class' => \Vendor\Filter\DisabledFilter::class,
                             'enabled' => false,
-                            'parameters' => array(),
-                        ),
-                        'basic_filter' => array(
+                            'parameters' => [],
+                        ],
+                        'basic_filter' => [
                             'class' => \Vendor\Filter\BasicFilter::class,
                             'enabled' => true,
-                            'parameters' => array(),
-                        ),
-                        'complex_filter' => array(
+                            'parameters' => [],
+                        ],
+                        'complex_filter' => [
                             'class' => \Vendor\Filter\ComplexFilter::class,
                             'enabled' => true,
-                            'parameters' => array(
+                            'parameters' => [
                                 'integer' => 1,
                                 'string' => 'foo',
-                                'object' => array('key' => 'value'),
-                                'array' => array(1, 2, 3),
-                            ),
-                        ),
-                    ),
-                    'metadata_cache_driver' => array(
+                                'object' => ['key' => 'value'],
+                                'array' => [1, 2, 3],
+                            ],
+                        ],
+                    ],
+                    'metadata_cache_driver' => [
                         'type'           => 'memcache',
                         'class'          => 'fooClass',
                         'host'           => 'host_val',
                         'port'           => 1234,
                         'instance_class' => 'instance_val',
-                    ),
-                    'mappings' => array(
-                        'FooBundle' => array(
+                    ],
+                    'mappings' => [
+                        'FooBundle' => [
                             'type'    => 'annotation',
                             'mapping' => true,
-                        ),
-                    ),
-                    'profiler' => array(
+                        ],
+                    ],
+                    'profiler' => [
                         'enabled' => true,
                         'pretty'  => false,
-                    ),
+                    ],
                     'retry_connect' => 0,
                     'retry_query' => 0,
-                ),
-                'dm2' => array(
+                ],
+                'dm2' => [
                     'connection'   => 'dm2_connection',
                     'database'     => 'db1',
                     'logging'      => true,
@@ -168,32 +168,32 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
                     'repository_factory' => null,
                     'persistent_collection_factory' => null,
                     'auto_mapping' => false,
-                    'filters'      => array(),
-                    'metadata_cache_driver' => array(
+                    'filters'      => [],
+                    'metadata_cache_driver' => [
                         'type' => 'apc',
-                    ),
-                    'mappings' => array(
-                        'BarBundle' => array(
+                    ],
+                    'mappings' => [
+                        'BarBundle' => [
                             'type'      => 'yml',
                             'dir'       => '%kernel.cache_dir%',
                             'prefix'    => 'prefix_val',
                             'alias'     => 'alias_val',
                             'is_bundle' => false,
                             'mapping'   => true,
-                        ),
-                    ),
-                    'profiler' => array(
+                        ],
+                    ],
+                    'profiler' => [
                         'enabled' => '%kernel.debug%',
                         'pretty'  => '%kernel.debug%',
-                    ),
+                    ],
                     'retry_connect' => 0,
                     'retry_query' => 0,
-                ),
-            ),
-            'resolve_target_documents' => array(
+                ],
+            ],
+            'resolve_target_documents' => [
                 'Foo\BarInterface' => 'Bar\FooClass'
-            ),
-        );
+            ],
+        ];
 
         $this->assertEquals($expected, $options);
     }
@@ -206,10 +206,10 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
         $xml = XmlUtils::loadFile(__DIR__.'/Fixtures/config/xml/full.xml');
         $xml = XmlUtils::convertDomElementToArray($xml->getElementsByTagName('config')->item(0));
 
-        return array(
-            array($yaml),
-            array($xml),
-        );
+        return [
+            [$yaml],
+            [$xml],
+        ];
     }
 
     /**
@@ -230,96 +230,96 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
 
     public function provideMergeOptions()
     {
-        $cases = array();
+        $cases = [];
 
         // single config, testing normal option setting
-        $cases[] = array(
-            array(
-                array('default_document_manager' => 'foo'),
-            ),
-            array('default_document_manager' => 'foo')
-        );
+        $cases[] = [
+            [
+                ['default_document_manager' => 'foo'],
+            ],
+            ['default_document_manager' => 'foo']
+        ];
 
         // single config, testing normal option setting with dashes
-        $cases[] = array(
-            array(
-                array('default-document-manager' => 'bar'),
-            ),
-            array('default_document_manager' => 'bar')
-        );
+        $cases[] = [
+            [
+                ['default-document-manager' => 'bar'],
+            ],
+            ['default_document_manager' => 'bar']
+        ];
 
         // testing the normal override merging - the later config array wins
-        $cases[] = array(
-            array(
-                array('default_document_manager' => 'foo'),
-                array('default_document_manager' => 'baz'),
-            ),
-            array('default_document_manager' => 'baz')
-        );
+        $cases[] = [
+            [
+                ['default_document_manager' => 'foo'],
+                ['default_document_manager' => 'baz'],
+            ],
+            ['default_document_manager' => 'baz']
+        ];
 
         // the "options" array is totally replaced
-        $cases[] = array(
-            array(
-                array('connections' => array('default' => array('options' => array('timeout' => 2000)))),
-                array('connections' => array('default' => array('options' => array('username' => 'foo')))),
-            ),
-            array('connections' => array('default' => array('options' => array('username' => 'foo')))),
-        );
+        $cases[] = [
+            [
+                ['connections' => ['default' => ['options' => ['timeout' => 2000]]]],
+                ['connections' => ['default' => ['options' => ['username' => 'foo']]]],
+            ],
+            ['connections' => ['default' => ['options' => ['username' => 'foo']]]],
+        ];
 
         // mappings are merged non-recursively.
-        $cases[] = array(
-            array(
-                array('document_managers' => array('default' => array('mappings' => array('foomap' => array('type' => 'val1'), 'barmap' => array('dir' => 'val2'))))),
-                array('document_managers' => array('default' => array('mappings' => array('barmap' => array('prefix' => 'val3'))))),
-            ),
-            array('document_managers' => array('default' => array('metadata_cache_driver' => array('type' => 'array'), 'logging' => '%kernel.debug%', 'profiler' => array('enabled' => '%kernel.debug%', 'pretty' => '%kernel.debug%'), 'auto_mapping' => false, 'default_repository_class' =>  'Doctrine\ODM\MongoDB\DocumentRepository', 'repository_factory' => null, 'persistent_collection_factory' => null, 'filters' => array(), 'mappings' => array('foomap' => array('type' => 'val1', 'mapping' => true), 'barmap' => array('prefix' => 'val3', 'mapping' => true)), 'retry_connect' => 0, 'retry_query' => 0))),
-        );
+        $cases[] = [
+            [
+                ['document_managers' => ['default' => ['mappings' => ['foomap' => ['type' => 'val1'], 'barmap' => ['dir' => 'val2']]]]],
+                ['document_managers' => ['default' => ['mappings' => ['barmap' => ['prefix' => 'val3']]]]],
+            ],
+            ['document_managers' => ['default' => ['metadata_cache_driver' => ['type' => 'array'], 'logging' => '%kernel.debug%', 'profiler' => ['enabled' => '%kernel.debug%', 'pretty' => '%kernel.debug%'], 'auto_mapping' => false, 'default_repository_class' =>  'Doctrine\ODM\MongoDB\DocumentRepository', 'repository_factory' => null, 'persistent_collection_factory' => null, 'filters' => [], 'mappings' => ['foomap' => ['type' => 'val1', 'mapping' => true], 'barmap' => ['prefix' => 'val3', 'mapping' => true]], 'retry_connect' => 0, 'retry_query' => 0]]],
+        ];
 
         // connections are merged non-recursively.
-        $cases[] = array(
-            array(
-                array('connections' => array('foocon' => array('server' => 'val1'), 'barcon' => array('options' => array('username' => 'val2')))),
-                array('connections' => array('barcon' => array('server' => 'val3'))),
-            ),
-            array('connections' => array(
-                'foocon' => array('server' => 'val1'),
-                'barcon' => array('server' => 'val3'),
-            )),
-        );
+        $cases[] = [
+            [
+                ['connections' => ['foocon' => ['server' => 'val1'], 'barcon' => ['options' => ['username' => 'val2']]]],
+                ['connections' => ['barcon' => ['server' => 'val3']]],
+            ],
+            ['connections' => [
+                'foocon' => ['server' => 'val1'],
+                'barcon' => ['server' => 'val3'],
+            ]],
+        ];
 
         // connection options are merged non-recursively.
-        $cases[] = array(
-            array(
-                array('connections' => array('foocon' => array('options' => array('db' => 'val1')))),
-                array('connections' => array('foocon' => array('options' => array('replicaSet' => 'val2')))),
-            ),
-            array('connections' => array(
-                'foocon' => array('options' => array('replicaSet' => 'val2')),
-            )),
-        );
+        $cases[] = [
+            [
+                ['connections' => ['foocon' => ['options' => ['db' => 'val1']]]],
+                ['connections' => ['foocon' => ['options' => ['replicaSet' => 'val2']]]],
+            ],
+            ['connections' => [
+                'foocon' => ['options' => ['replicaSet' => 'val2']],
+            ]],
+        ];
 
         // connection option readPreferenceTags are merged non-recursively.
-        $cases[] = array(
-            array(
-                array('connections' => array('foocon' => array('options' => array('readPreferenceTags' => array(array('dc' => 'east', 'use' => 'reporting')))))),
-                array('connections' => array('foocon' => array('options' => array('readPreferenceTags' => array(array('dc' => 'west'), array()))))),
-            ),
-            array('connections' => array(
-                'foocon' => array('options' => array('readPreferenceTags' => array(array('dc' => 'west'), array()))),
-            )),
-        );
+        $cases[] = [
+            [
+                ['connections' => ['foocon' => ['options' => ['readPreferenceTags' => [['dc' => 'east', 'use' => 'reporting']]]]]],
+                ['connections' => ['foocon' => ['options' => ['readPreferenceTags' => [['dc' => 'west'], []]]]]],
+            ],
+            ['connections' => [
+                'foocon' => ['options' => ['readPreferenceTags' => [['dc' => 'west'], []]]],
+            ]],
+        ];
 
         // managers are merged non-recursively.
-        $cases[] = array(
-            array(
-                array('document_managers' => array('foodm' => array('database' => 'val1'), 'bardm' => array('database' => 'val2'))),
-                array('document_managers' => array('bardm' => array('database' => 'val3'))),
-            ),
-            array('document_managers' => array(
-                'foodm' => array('database' => 'val1', 'metadata_cache_driver' => array('type' => 'array'), 'logging' => '%kernel.debug%', 'profiler' => array('enabled' => '%kernel.debug%', 'pretty' => '%kernel.debug%'), 'auto_mapping' => false, 'default_repository_class' =>  'Doctrine\ODM\MongoDB\DocumentRepository', 'repository_factory' => null, 'persistent_collection_factory' => null, 'filters' => array(), 'mappings' => array(), 'retry_connect' => 0, 'retry_query' => 0),
-                'bardm' => array('database' => 'val3', 'metadata_cache_driver' => array('type' => 'array'), 'logging' => '%kernel.debug%', 'profiler' => array('enabled' => '%kernel.debug%', 'pretty' => '%kernel.debug%'), 'auto_mapping' => false, 'default_repository_class' =>  'Doctrine\ODM\MongoDB\DocumentRepository', 'repository_factory' => null, 'persistent_collection_factory' => null, 'filters' => array(), 'mappings' => array(), 'retry_connect' => 0, 'retry_query' => 0),
-            )),
-        );
+        $cases[] = [
+            [
+                ['document_managers' => ['foodm' => ['database' => 'val1'], 'bardm' => ['database' => 'val2']]],
+                ['document_managers' => ['bardm' => ['database' => 'val3']]],
+            ],
+            ['document_managers' => [
+                'foodm' => ['database' => 'val1', 'metadata_cache_driver' => ['type' => 'array'], 'logging' => '%kernel.debug%', 'profiler' => ['enabled' => '%kernel.debug%', 'pretty' => '%kernel.debug%'], 'auto_mapping' => false, 'default_repository_class' =>  'Doctrine\ODM\MongoDB\DocumentRepository', 'repository_factory' => null, 'persistent_collection_factory' => null, 'filters' => [], 'mappings' => [], 'retry_connect' => 0, 'retry_query' => 0],
+                'bardm' => ['database' => 'val3', 'metadata_cache_driver' => ['type' => 'array'], 'logging' => '%kernel.debug%', 'profiler' => ['enabled' => '%kernel.debug%', 'pretty' => '%kernel.debug%'], 'auto_mapping' => false, 'default_repository_class' =>  'Doctrine\ODM\MongoDB\DocumentRepository', 'repository_factory' => null, 'persistent_collection_factory' => null, 'filters' => [], 'mappings' => [], 'retry_connect' => 0, 'retry_query' => 0],
+            ]],
+        ];
 
         return $cases;
     }
@@ -333,7 +333,7 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
     {
         $processor = new Processor();
         $configuration = new Configuration(false);
-        $options = $processor->processConfiguration($configuration, array($config));
+        $options = $processor->processConfiguration($configuration, [$config]);
 
         foreach ($expected as $key => $value) {
             $this->assertEquals($value, $options[$key]);
@@ -342,95 +342,95 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
 
     public function provideNormalizeOptions()
     {
-        $cases = array();
+        $cases = [];
 
         // connection versus connections (id is the identifier)
-        $cases[] = array(
-            array('connection' => array(
-                array('server' => 'mongodb://abc', 'id' => 'foo'),
-                array('server' => 'mongodb://def', 'id' => 'bar'),
-            )),
-            array('connections' => array(
-                'foo' => array('server' => 'mongodb://abc'),
-                'bar' => array('server' => 'mongodb://def'),
-            )),
-        );
+        $cases[] = [
+            ['connection' => [
+                ['server' => 'mongodb://abc', 'id' => 'foo'],
+                ['server' => 'mongodb://def', 'id' => 'bar'],
+            ]],
+            ['connections' => [
+                'foo' => ['server' => 'mongodb://abc'],
+                'bar' => ['server' => 'mongodb://def'],
+            ]],
+        ];
 
         // document_manager versus document_managers (id is the identifier)
-        $cases[] = array(
-            array('document_manager' => array(
-                array('connection' => 'conn1', 'id' => 'foo'),
-                array('connection' => 'conn2', 'id' => 'bar'),
-            )),
-            array('document_managers' => array(
-                'foo' => array('connection' => 'conn1', 'metadata_cache_driver' => array('type' => 'array'), 'logging' => '%kernel.debug%', 'profiler' => array('enabled' => '%kernel.debug%', 'pretty' => '%kernel.debug%'), 'auto_mapping' => false, 'default_repository_class' => 'Doctrine\ODM\MongoDB\DocumentRepository', 'repository_factory' => null, 'persistent_collection_factory' => null, 'filters' => array(), 'mappings' => array(), 'retry_connect' => 0, 'retry_query' => 0),
-                'bar' => array('connection' => 'conn2', 'metadata_cache_driver' => array('type' => 'array'), 'logging' => '%kernel.debug%', 'profiler' => array('enabled' => '%kernel.debug%', 'pretty' => '%kernel.debug%'), 'auto_mapping' => false, 'default_repository_class' =>  'Doctrine\ODM\MongoDB\DocumentRepository', 'repository_factory' => null, 'persistent_collection_factory' => null,'filters' => array(), 'mappings' => array(), 'retry_connect' => 0, 'retry_query' => 0),
-            )),
-        );
+        $cases[] = [
+            ['document_manager' => [
+                ['connection' => 'conn1', 'id' => 'foo'],
+                ['connection' => 'conn2', 'id' => 'bar'],
+            ]],
+            ['document_managers' => [
+                'foo' => ['connection' => 'conn1', 'metadata_cache_driver' => ['type' => 'array'], 'logging' => '%kernel.debug%', 'profiler' => ['enabled' => '%kernel.debug%', 'pretty' => '%kernel.debug%'], 'auto_mapping' => false, 'default_repository_class' => 'Doctrine\ODM\MongoDB\DocumentRepository', 'repository_factory' => null, 'persistent_collection_factory' => null, 'filters' => [], 'mappings' => [], 'retry_connect' => 0, 'retry_query' => 0],
+                'bar' => ['connection' => 'conn2', 'metadata_cache_driver' => ['type' => 'array'], 'logging' => '%kernel.debug%', 'profiler' => ['enabled' => '%kernel.debug%', 'pretty' => '%kernel.debug%'], 'auto_mapping' => false, 'default_repository_class' =>  'Doctrine\ODM\MongoDB\DocumentRepository', 'repository_factory' => null, 'persistent_collection_factory' => null,'filters' => [], 'mappings' => [], 'retry_connect' => 0, 'retry_query' => 0],
+            ]],
+        ];
 
         // mapping configuration that's beneath a specific document manager
-        $cases[] = array(
-            array('document_manager' => array(
-                array('id' => 'foo', 'connection' => 'conn1', 'mapping' => array(
+        $cases[] = [
+            ['document_manager' => [
+                ['id' => 'foo', 'connection' => 'conn1', 'mapping' => [
                     'type' => 'xml', 'name' => 'foo-mapping'
-                )),
-            )),
-            array('document_managers' => array(
-                'foo' => array(
+                ]],
+            ]],
+            ['document_managers' => [
+                'foo' => [
                     'connection'   => 'conn1',
-                    'metadata_cache_driver' => array('type' => 'array'),
+                    'metadata_cache_driver' => ['type' => 'array'],
                     'default_repository_class' =>  DocumentRepository::class,
                     'repository_factory' => null,
                     'persistent_collection_factory' => null,
-                    'mappings'     => array('foo-mapping' => array('type' => 'xml', 'mapping' => true)),
+                    'mappings'     => ['foo-mapping' => ['type' => 'xml', 'mapping' => true]],
                     'logging'      => '%kernel.debug%',
-                    'profiler'     => array('enabled' => '%kernel.debug%', 'pretty' => '%kernel.debug%'),
+                    'profiler'     => ['enabled' => '%kernel.debug%', 'pretty' => '%kernel.debug%'],
                     'auto_mapping' => false,
-                    'filters'      => array(),
+                    'filters'      => [],
                     'retry_connect' => 0,
                     'retry_query' => 0,
-                ),
-            )),
-        );
+                ],
+            ]],
+        ];
 
         return $cases;
     }
 
     public function testPasswordAndUsernameShouldBeUnsetIfNull()
     {
-        $config = array(
-            'connections' => array(
-                'conn1' => array(
+        $config = [
+            'connections' => [
+                'conn1' => [
                     'server' => 'mongodb://localhost',
-                    'options' => array(
+                    'options' => [
                         'username' => null,
                         'password' => 'bar',
-                    ),
-                ),
-                'conn2' => array(
+                    ],
+                ],
+                'conn2' => [
                     'server' => 'mongodb://localhost',
-                    'options' => array(
+                    'options' => [
                         'username' => 'foo',
                         'password' => null,
-                    ),
-                ),
-                'conn3' => array(
+                    ],
+                ],
+                'conn3' => [
                     'server' => 'mongodb://localhost',
-                    'options' => array(
+                    'options' => [
                         'username' => null,
                         'password' => null,
-                    ),
-                ),
-            ),
-        );
+                    ],
+                ],
+            ],
+        ];
 
         $processor = new Processor();
         $configuration = new Configuration(false);
-        $options = $processor->processConfiguration($configuration, array($config));
+        $options = $processor->processConfiguration($configuration, [$config]);
 
-        $this->assertEquals(array('password' => 'bar'), $options['connections']['conn1']['options']);
-        $this->assertEquals(array('username' => 'foo'), $options['connections']['conn2']['options']);
-        $this->assertEquals(array(), $options['connections']['conn3']['options']);
+        $this->assertEquals(['password' => 'bar'], $options['connections']['conn1']['options']);
+        $this->assertEquals(['username' => 'foo'], $options['connections']['conn2']['options']);
+        $this->assertEquals([], $options['connections']['conn3']['options']);
     }
 
     /**
@@ -439,20 +439,20 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
      */
     public function testInvalidReplicaSetValue()
     {
-        $config = array(
-            'connections' => array(
-                'conn1' => array(
+        $config = [
+            'connections' => [
+                'conn1' => [
                     'server'  => 'mongodb://localhost',
-                    'options' => array(
+                    'options' => [
                         'replicaSet' => true
-                    )
-                )
-            )
-        );
+                    ]
+                ]
+            ]
+        ];
 
         $processor = new Processor();
         $configuration = new Configuration(false);
-        $processor->processConfiguration($configuration, array($config));
+        $processor->processConfiguration($configuration, [$config]);
     }
 
     /**
@@ -463,7 +463,7 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
         $processor = new Processor();
         $configuration = new Configuration(false);
         $this->setExpectedException(\LogicException::class);
-        $processor->processConfiguration($configuration, array($config));
+        $processor->processConfiguration($configuration, [$config]);
     }
 
     public function provideExceptionConfiguration()
@@ -474,9 +474,9 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
         $xml = XmlUtils::loadFile(__DIR__.'/Fixtures/config/xml/exception.xml');
         $xml = XmlUtils::convertDomElementToArray($xml->getElementsByTagName('config')->item(0));
 
-        return array(
-            array($yaml),
-            array($xml),
-        );
+        return [
+            [$yaml],
+            [$xml],
+        ];
     }
 }

--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -16,6 +16,8 @@ namespace Doctrine\Bundle\MongoDBBundle\Tests\DependencyInjection;
 
 use Doctrine\Bundle\MongoDBBundle\DependencyInjection\Configuration;
 use Doctrine\ODM\MongoDB\Configuration as ODMConfiguration;
+use Doctrine\ODM\MongoDB\DocumentRepository;
+use Symfony\Bridge\Doctrine\DataFixtures\ContainerAwareLoader;
 use Symfony\Component\Config\Definition\Processor;
 use Symfony\Component\Config\Util\XmlUtils;
 use Symfony\Component\Yaml\Yaml;
@@ -29,7 +31,7 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
         $options = $processor->processConfiguration($configuration, array());
 
         $defaults = array(
-            'fixture_loader'                 => 'Symfony\Bridge\Doctrine\DataFixtures\ContainerAwareLoader',
+            'fixture_loader'                 => ContainerAwareLoader::class,
             'auto_generate_hydrator_classes' => false,
             'auto_generate_proxy_classes'    => false,
             'auto_generate_persistent_collection_classes' => ODMConfiguration::AUTOGENERATE_NEVER,
@@ -59,7 +61,7 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
         $options = $processor->processConfiguration($configuration, array($config));
 
         $expected = array(
-            'fixture_loader'                 => 'Symfony\Bridge\Doctrine\DataFixtures\ContainerAwareLoader',
+            'fixture_loader'                 => ContainerAwareLoader::class,
             'auto_generate_hydrator_classes' => true,
             'auto_generate_proxy_classes'    => true,
             'auto_generate_persistent_collection_classes' => ODMConfiguration::AUTOGENERATE_EVAL,
@@ -111,24 +113,24 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
             ),
             'document_managers' => array(
                 'dm1' => array(
-                    'default_repository_class' => 'Doctrine\ODM\MongoDB\DocumentRepository',
+                    'default_repository_class' => DocumentRepository::class,
                     'repository_factory' => null,
                     'persistent_collection_factory' => null,
                     'logging'      => '%kernel.debug%',
                     'auto_mapping' => false,
                     'filters' => array(
                         'disabled_filter' => array(
-                            'class' => 'Vendor\Filter\DisabledFilter',
+                            'class' => \Vendor\Filter\DisabledFilter::class,
                             'enabled' => false,
                             'parameters' => array(),
                         ),
                         'basic_filter' => array(
-                            'class' => 'Vendor\Filter\BasicFilter',
+                            'class' => \Vendor\Filter\BasicFilter::class,
                             'enabled' => true,
                             'parameters' => array(),
                         ),
                         'complex_filter' => array(
-                            'class' => 'Vendor\Filter\ComplexFilter',
+                            'class' => \Vendor\Filter\ComplexFilter::class,
                             'enabled' => true,
                             'parameters' => array(
                                 'integer' => 1,
@@ -162,7 +164,7 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
                     'connection'   => 'dm2_connection',
                     'database'     => 'db1',
                     'logging'      => true,
-                    'default_repository_class' => 'Foo\Bar\CustomRepository',
+                    'default_repository_class' => \Foo\Bar\CustomRepository::class,
                     'repository_factory' => null,
                     'persistent_collection_factory' => null,
                     'auto_mapping' => false,
@@ -377,7 +379,7 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
                 'foo' => array(
                     'connection'   => 'conn1',
                     'metadata_cache_driver' => array('type' => 'array'),
-                    'default_repository_class' =>  'Doctrine\ODM\MongoDB\DocumentRepository',
+                    'default_repository_class' =>  DocumentRepository::class,
                     'repository_factory' => null,
                     'persistent_collection_factory' => null,
                     'mappings'     => array('foo-mapping' => array('type' => 'xml', 'mapping' => true)),
@@ -460,7 +462,7 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
     {
         $processor = new Processor();
         $configuration = new Configuration(false);
-        $this->setExpectedException('\LogicException');
+        $this->setExpectedException(\LogicException::class);
         $processor->processConfiguration($configuration, array($config));
     }
 

--- a/Tests/DependencyInjection/DoctrineMongoDBExtensionTest.php
+++ b/Tests/DependencyInjection/DoctrineMongoDBExtensionTest.php
@@ -21,25 +21,25 @@ use Symfony\Component\DependencyInjection\Reference;
 
 class DoctrineMongoDBExtensionTest extends \PHPUnit_Framework_TestCase
 {
-    public static function buildConfiguration(array $settings = array())
+    public static function buildConfiguration(array $settings = [])
     {
-        return array(array_merge(
-            array(
-                'connections' => array('dummy' => array()),
-                'document_managers' => array('dummy' => array()),
-            ),
+        return [array_merge(
+            [
+                'connections' => ['dummy' => []],
+                'document_managers' => ['dummy' => []],
+            ],
             $settings
-        ));
+        )];
     }
 
     public function buildMinimalContainer()
     {
-        $container = new ContainerBuilder(new ParameterBag(array(
+        $container = new ContainerBuilder(new ParameterBag([
             'kernel.root_dir'    => __DIR__,
             'kernel.environment' => 'test',
             'kernel.debug'       => 'true',
-            'kernel.bundles'     => array(),
-        )));
+            'kernel.bundles'     => [],
+        ]));
         return $container;
     }
 
@@ -58,9 +58,9 @@ class DoctrineMongoDBExtensionTest extends \PHPUnit_Framework_TestCase
     {
         $container = $this->buildMinimalContainer();
         $container->setParameter('kernel.debug', false);
-        $container->setParameter('kernel.bundles', array());
+        $container->setParameter('kernel.bundles', []);
         $loader = new DoctrineMongoDBExtension();
-        $loader->load(self::buildConfiguration(array($option => $value)), $container);
+        $loader->load(self::buildConfiguration([$option => $value]), $container);
 
         $this->assertEquals($value, $container->getParameter('doctrine_mongodb.odm.'.$parameter));
     }
@@ -69,75 +69,75 @@ class DoctrineMongoDBExtensionTest extends \PHPUnit_Framework_TestCase
     {
         $bundles = (array) $bundles;
 
-        $map = array();
+        $map = [];
         foreach ($bundles as $bundle) {
             require_once __DIR__.'/Fixtures/Bundles/'.$bundle.'/'.$bundle.'.php';
 
             $map[$bundle] = 'DoctrineMongoDBBundle\Tests\DependencyInjection\Fixtures\Bundles\\'.$bundle.'\\'.$bundle;
         }
 
-        return new ContainerBuilder(new ParameterBag(array(
+        return new ContainerBuilder(new ParameterBag([
             'kernel.debug'       => false,
             'kernel.bundles'     => $map,
             'kernel.cache_dir'   => sys_get_temp_dir(),
             'kernel.environment' => 'test',
             'kernel.root_dir'    => __DIR__.'/../../' // src dir
-        )));
+        ]));
     }
 
     public function parameterProvider()
     {
-        return array(
-            array('proxy_namespace', 'proxy_namespace', 'foo'),
-            array('proxy-namespace', 'proxy_namespace', 'bar'),
-        );
+        return [
+            ['proxy_namespace', 'proxy_namespace', 'foo'],
+            ['proxy-namespace', 'proxy_namespace', 'bar'],
+        ];
     }
 
     public function getAutomappingConfigurations()
     {
-        return array(
-            array(
-                array(
-                    'dm1' => array(
-                        'mappings' => array(
+        return [
+            [
+                [
+                    'dm1' => [
+                        'mappings' => [
                             'YamlBundle' => null
-                        )
-                    ),
-                    'dm2' => array(
-                        'mappings' => array(
+                        ]
+                    ],
+                    'dm2' => [
+                        'mappings' => [
                             'XmlBundle' => null
-                        )
-                    )
-                )
-            ),
-            array(
-                array(
-                    'dm1' => array(
+                        ]
+                    ]
+                ]
+            ],
+            [
+                [
+                    'dm1' => [
                         'auto_mapping' => true
-                    ),
-                    'dm2' => array(
-                        'mappings' => array(
+                    ],
+                    'dm2' => [
+                        'mappings' => [
                             'XmlBundle' => null
-                        )
-                    )
-                )
-            ),
-            array(
-                array(
-                    'dm1' => array(
+                        ]
+                    ]
+                ]
+            ],
+            [
+                [
+                    'dm1' => [
                         'auto_mapping' => true,
-                        'mappings' => array(
+                        'mappings' => [
                             'YamlBundle' => null
-                        )
-                    ),
-                    'dm2' => array(
-                        'mappings' => array(
+                        ]
+                    ],
+                    'dm2' => [
+                        'mappings' => [
                             'XmlBundle' => null
-                        )
-                    )
-                )
-            )
-        );
+                        ]
+                    ]
+                ]
+            ]
+        ];
     }
 
     /**
@@ -145,47 +145,47 @@ class DoctrineMongoDBExtensionTest extends \PHPUnit_Framework_TestCase
      */
     public function testAutomapping(array $documentManagers)
     {
-        $container = $this->getContainer(array(
+        $container = $this->getContainer([
             'YamlBundle',
             'XmlBundle'
-        ));
+        ]);
 
         $loader = new DoctrineMongoDBExtension();
 
         $loader->load(
-            array(
-                array(
+            [
+                [
                     'default_database' => 'test_database',
-                    'connections' => array(
-                        'cn1' => array(),
-                        'cn2' => array()
-                    ),
+                    'connections' => [
+                        'cn1' => [],
+                        'cn2' => []
+                    ],
                     'document_managers' => $documentManagers
-                )
-            ), $container);
+                ]
+            ], $container);
 
         $configDm1 = $container->getDefinition('doctrine_mongodb.odm.dm1_configuration');
         $configDm2 = $container->getDefinition('doctrine_mongodb.odm.dm2_configuration');
 
         $this->assertContains(
-            array(
+            [
                 'setDocumentNamespaces',
-                array(
-                    array(
+                [
+                    [
                         'YamlBundle' => 'DoctrineMongoDBBundle\Tests\DependencyInjection\Fixtures\Bundles\YamlBundle\Document'
-                    )
-                )
-            ), $configDm1->getMethodCalls());
+                    ]
+                ]
+            ], $configDm1->getMethodCalls());
 
         $this->assertContains(
-            array(
+            [
                 'setDocumentNamespaces',
-                array(
-                    array(
+                [
+                    [
                         'XmlBundle' => 'DoctrineMongoDBBundle\Tests\DependencyInjection\Fixtures\Bundles\XmlBundle\Document'
-                    )
-                )
-            ), $configDm2->getMethodCalls());
+                    ]
+                ]
+            ], $configDm2->getMethodCalls());
     }
 
     public function testFactoriesAreRegistered()
@@ -194,32 +194,32 @@ class DoctrineMongoDBExtensionTest extends \PHPUnit_Framework_TestCase
 
         $loader = new DoctrineMongoDBExtension();
         $loader->load(
-            array(
-                array(
+            [
+                [
                     'default_database' => 'test_database',
-                    'connections' => array(
-                        'cn1' => array(),
-                        'cn2' => array()
-                    ),
-                    'document_managers' => array(
-                        'dm1' => array(
+                    'connections' => [
+                        'cn1' => [],
+                        'cn2' => []
+                    ],
+                    'document_managers' => [
+                        'dm1' => [
                             'repository_factory' => 'repository_factory_service',
                             'persistent_collection_factory' => 'persistent_collection_factory_service',
-                        )
-                    )
-                )
-            ), $container);
+                        ]
+                    ]
+                ]
+            ], $container);
 
         $configDm1 = $container->getDefinition('doctrine_mongodb.odm.dm1_configuration');
         $this->assertContains(
-            array(
+            [
                 'setRepositoryFactory',
-                array(new Reference('repository_factory_service'))
-            ), $configDm1->getMethodCalls());
+                [new Reference('repository_factory_service')]
+            ], $configDm1->getMethodCalls());
         $this->assertContains(
-            array(
+            [
                 'setPersistentCollectionFactory',
-                array(new Reference('persistent_collection_factory_service'))
-            ), $configDm1->getMethodCalls());
+                [new Reference('persistent_collection_factory_service')]
+            ], $configDm1->getMethodCalls());
     }
 }

--- a/Tests/Fixtures/Validator/Document.php
+++ b/Tests/Fixtures/Validator/Document.php
@@ -26,7 +26,7 @@ class Document
     public $embedOne;
 
     /** @ODM\EmbedMany(targetDocument="Doctrine\Bundle\MongoDBBundle\Tests\Fixtures\Validator\EmbeddedDocument") */
-    public $embedMany = array();
+    public $embedMany = [];
 
     public function __construct($id) {
         $this->id = $id;

--- a/Tests/Form/Type/DocumentTypeTest.php
+++ b/Tests/Form/Type/DocumentTypeTest.php
@@ -117,7 +117,7 @@ class DocumentTypeTest extends TypeTestCase
 
     protected function createRegistryMock($name, $dm)
     {
-        $registry = $this->getMock('Doctrine\Common\Persistence\ManagerRegistry');
+        $registry = $this->createMock('Doctrine\Common\Persistence\ManagerRegistry');
         $registry->expects($this->any())
                  ->method('getManager')
                  ->with($this->equalTo($name))

--- a/Tests/Form/Type/DocumentTypeTest.php
+++ b/Tests/Form/Type/DocumentTypeTest.php
@@ -32,9 +32,9 @@ class DocumentTypeTest extends TypeTestCase
     {
         $this->typeFQCN = method_exists(AbstractType::class, 'getBlockPrefix');
 
-        $this->dm = TestCase::createTestDocumentManager(array(
+        $this->dm = TestCase::createTestDocumentManager([
             __DIR__ . '/../../Fixtures/Form/Document',
-        ));
+        ]);
         $this->dmRegistry = $this->createRegistryMock('default', $this->dm);
 
         parent::setUp();
@@ -42,10 +42,10 @@ class DocumentTypeTest extends TypeTestCase
 
     protected function tearDown()
     {
-        $documentClasses = array(
+        $documentClasses = [
             Document::class,
             Category::class,
-        );
+        ];
 
         foreach ($documentClasses as $class) {
             $this->dm->getDocumentCollection($class)->drop();
@@ -57,20 +57,20 @@ class DocumentTypeTest extends TypeTestCase
 
     public function testDocumentManagerOptionSetsEmOption()
     {
-        $field = $this->factory->createNamed('name', $this->typeFQCN ? DocumentType::CLASS : 'document', null, array(
+        $field = $this->factory->createNamed('name', $this->typeFQCN ? DocumentType::CLASS : 'document', null, [
             'class' => Document::class,
             'document_manager' => 'default',
-        ));
+        ]);
 
         $this->assertSame($this->dm, $field->getConfig()->getOption('em'));
     }
 
     public function testDocumentManagerInstancePassedAsOption()
     {
-        $field = $this->factory->createNamed('name', $this->typeFQCN ? DocumentType::CLASS : 'document', null, array(
+        $field = $this->factory->createNamed('name', $this->typeFQCN ? DocumentType::CLASS : 'document', null, [
             'class' => Document::class,
             'document_manager' => $this->dm,
-        ));
+        ]);
 
         $this->assertSame($this->dm, $field->getConfig()->getOption('em'));
     }
@@ -80,10 +80,10 @@ class DocumentTypeTest extends TypeTestCase
      */
     public function testSettingDocumentManagerAndEmOptionShouldThrowException()
     {
-        $field = $this->factory->createNamed('name', $this->typeFQCN ? DocumentType::CLASS : 'document', null, array(
+        $field = $this->factory->createNamed('name', $this->typeFQCN ? DocumentType::CLASS : 'document', null, [
             'document_manager' => 'default',
             'em' => 'default',
-        ));
+        ]);
     }
 
     public function testManyToManyReferences()
@@ -101,12 +101,12 @@ class DocumentTypeTest extends TypeTestCase
 
         $form = $this->factory->create($this->typeFQCN ? FormType::CLASS : 'form', $document)
             ->add(
-                'categories', $this->typeFQCN ? DocumentType::CLASS : 'document', array(
+                'categories', $this->typeFQCN ? DocumentType::CLASS : 'document', [
                     'class' => Category::class,
                     'multiple' => true,
                     'expanded' => true,
                     'document_manager' => 'default'
-                )
+                ]
             );
 
         $view = $form->createView();
@@ -134,8 +134,8 @@ class DocumentTypeTest extends TypeTestCase
      */
     protected function getExtensions()
     {
-        return array_merge(parent::getExtensions(), array(
+        return array_merge(parent::getExtensions(), [
             new DoctrineMongoDBExtension($this->dmRegistry),
-        ));
+        ]);
     }
 }

--- a/Tests/Form/Type/DocumentTypeTest.php
+++ b/Tests/Form/Type/DocumentTypeTest.php
@@ -7,7 +7,10 @@ use Doctrine\Bundle\MongoDBBundle\Tests\Fixtures\Form\Category;
 use Doctrine\Bundle\MongoDBBundle\Tests\Fixtures\Form\Document;
 use Doctrine\Bundle\MongoDBBundle\Tests\TestCase;
 use Doctrine\Bundle\MongoDBBundle\Form\DoctrineMongoDBExtension;
+use Doctrine\Common\Persistence\ManagerRegistry;
+use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\FormType;
+use Symfony\Component\Form\FormView;
 use Symfony\Component\Form\Test\TypeTestCase;
 use Symfony\Component\HttpKernel\Kernel;
 
@@ -27,7 +30,7 @@ class DocumentTypeTest extends TypeTestCase
 
     public function setUp()
     {
-        $this->typeFQCN = method_exists('\Symfony\Component\Form\AbstractType', 'getBlockPrefix');
+        $this->typeFQCN = method_exists(AbstractType::class, 'getBlockPrefix');
 
         $this->dm = TestCase::createTestDocumentManager(array(
             __DIR__ . '/../../Fixtures/Form/Document',
@@ -40,8 +43,8 @@ class DocumentTypeTest extends TypeTestCase
     protected function tearDown()
     {
         $documentClasses = array(
-            'Doctrine\Bundle\MongoDBBundle\Tests\Fixtures\Form\Document',
-            'Doctrine\Bundle\MongoDBBundle\Tests\Fixtures\Form\Category',
+            Document::class,
+            Category::class,
         );
 
         foreach ($documentClasses as $class) {
@@ -55,7 +58,7 @@ class DocumentTypeTest extends TypeTestCase
     public function testDocumentManagerOptionSetsEmOption()
     {
         $field = $this->factory->createNamed('name', $this->typeFQCN ? DocumentType::CLASS : 'document', null, array(
-            'class' => 'Doctrine\Bundle\MongoDBBundle\Tests\Fixtures\Form\Document',
+            'class' => Document::class,
             'document_manager' => 'default',
         ));
 
@@ -65,7 +68,7 @@ class DocumentTypeTest extends TypeTestCase
     public function testDocumentManagerInstancePassedAsOption()
     {
         $field = $this->factory->createNamed('name', $this->typeFQCN ? DocumentType::CLASS : 'document', null, array(
-            'class' => 'Doctrine\Bundle\MongoDBBundle\Tests\Fixtures\Form\Document',
+            'class' => Document::class,
             'document_manager' => $this->dm,
         ));
 
@@ -99,7 +102,7 @@ class DocumentTypeTest extends TypeTestCase
         $form = $this->factory->create($this->typeFQCN ? FormType::CLASS : 'form', $document)
             ->add(
                 'categories', $this->typeFQCN ? DocumentType::CLASS : 'document', array(
-                    'class' => 'Doctrine\Bundle\MongoDBBundle\Tests\Fixtures\Form\Category',
+                    'class' => Category::class,
                     'multiple' => true,
                     'expanded' => true,
                     'document_manager' => 'default'
@@ -108,7 +111,7 @@ class DocumentTypeTest extends TypeTestCase
 
         $view = $form->createView();
         $categoryView = $view['categories'];
-        $this->assertInstanceOf('Symfony\Component\Form\FormView', $categoryView);
+        $this->assertInstanceOf(FormView::class, $categoryView);
 
         $this->assertCount(2, $categoryView->children);
         $this->assertTrue($categoryView->children[0]->vars['checked']);
@@ -117,7 +120,7 @@ class DocumentTypeTest extends TypeTestCase
 
     protected function createRegistryMock($name, $dm)
     {
-        $registry = $this->createMock('Doctrine\Common\Persistence\ManagerRegistry');
+        $registry = $this->createMock(ManagerRegistry::class);
         $registry->expects($this->any())
                  ->method('getManager')
                  ->with($this->equalTo($name))
@@ -127,7 +130,7 @@ class DocumentTypeTest extends TypeTestCase
     }
 
     /**
-     * @see Symfony\Component\Form\Tests\FormIntegrationTestCase::getExtensions()
+     * @see \Symfony\Component\Form\Tests\FormIntegrationTestCase::getExtensions()
      */
     protected function getExtensions()
     {

--- a/Tests/Form/Type/TypeGuesserTest.php
+++ b/Tests/Form/Type/TypeGuesserTest.php
@@ -33,9 +33,9 @@ class TypeGuesserTest extends TypeTestCase
     {
         $this->typeFQCN = method_exists(AbstractType::class, 'getBlockPrefix');
 
-        $this->dm = TestCase::createTestDocumentManager(array(
+        $this->dm = TestCase::createTestDocumentManager([
             __DIR__ . '/../../Fixtures/Form/Guesser',
-        ));
+        ]);
         $this->dmRegistry = $this->createRegistryMock('default', $this->dm);
 
         parent::setUp();
@@ -43,11 +43,11 @@ class TypeGuesserTest extends TypeTestCase
 
     protected function tearDown()
     {
-        $documentClasses = array(
+        $documentClasses = [
             Document::class,
             Category::class,
             Guesser::class,
-        );
+        ];
 
         foreach ($documentClasses as $class) {
             $this->dm->getDocumentCollection($class)->drop();
@@ -94,8 +94,8 @@ class TypeGuesserTest extends TypeTestCase
      */
     protected function getExtensions()
     {
-        return array_merge(parent::getExtensions(), array(
+        return array_merge(parent::getExtensions(), [
             new DoctrineMongoDBExtension($this->dmRegistry),
-        ));
+        ]);
     }
 }

--- a/Tests/Form/Type/TypeGuesserTest.php
+++ b/Tests/Form/Type/TypeGuesserTest.php
@@ -72,7 +72,7 @@ class TypeGuesserTest extends TypeTestCase
 
     protected function createRegistryMock($name, $dm)
     {
-        $registry = $this->getMock('Doctrine\Common\Persistence\ManagerRegistry');
+        $registry = $this->createMock('Doctrine\Common\Persistence\ManagerRegistry');
         $registry->expects($this->any())
             ->method('getManager')
             ->with($this->equalTo($name))

--- a/Tests/Form/Type/TypeGuesserTest.php
+++ b/Tests/Form/Type/TypeGuesserTest.php
@@ -2,8 +2,13 @@
 
 namespace Doctrine\Bundle\MongoDBBundle\Tests\Form\Type;
 
+use Doctrine\Bundle\MongoDBBundle\Tests\Fixtures\Form\Category;
+use Doctrine\Bundle\MongoDBBundle\Tests\Fixtures\Form\Document;
+use Doctrine\Bundle\MongoDBBundle\Tests\Fixtures\Form\Guesser;
 use Doctrine\Bundle\MongoDBBundle\Tests\TestCase;
 use Doctrine\Bundle\MongoDBBundle\Form\DoctrineMongoDBExtension;
+use Doctrine\Common\Persistence\ManagerRegistry;
+use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Test\TypeTestCase;
 use Symfony\Component\HttpKernel\Kernel;
 
@@ -26,7 +31,7 @@ class TypeGuesserTest extends TypeTestCase
 
     public function setUp()
     {
-        $this->typeFQCN = method_exists('\Symfony\Component\Form\AbstractType', 'getBlockPrefix');
+        $this->typeFQCN = method_exists(AbstractType::class, 'getBlockPrefix');
 
         $this->dm = TestCase::createTestDocumentManager(array(
             __DIR__ . '/../../Fixtures/Form/Guesser',
@@ -39,9 +44,9 @@ class TypeGuesserTest extends TypeTestCase
     protected function tearDown()
     {
         $documentClasses = array(
-            'Doctrine\Bundle\MongoDBBundle\Tests\Fixtures\Form\Document',
-            'Doctrine\Bundle\MongoDBBundle\Tests\Fixtures\Form\Category',
-            'Doctrine\Bundle\MongoDBBundle\Tests\Fixtures\Form\Guesser',
+            Document::class,
+            Category::class,
+            Guesser::class,
         );
 
         foreach ($documentClasses as $class) {
@@ -72,7 +77,7 @@ class TypeGuesserTest extends TypeTestCase
 
     protected function createRegistryMock($name, $dm)
     {
-        $registry = $this->createMock('Doctrine\Common\Persistence\ManagerRegistry');
+        $registry = $this->createMock(ManagerRegistry::class);
         $registry->expects($this->any())
             ->method('getManager')
             ->with($this->equalTo($name))

--- a/Tests/Logger/LoggerTest.php
+++ b/Tests/Logger/LoggerTest.php
@@ -15,6 +15,7 @@
 namespace Doctrine\Bundle\MongoDBBundle\Tests\Logger;
 
 use Doctrine\Bundle\MongoDBBundle\Logger\Logger;
+use Psr\Log\LoggerInterface;
 
 class LoggerTest extends \PHPUnit_Framework_TestCase
 {
@@ -22,7 +23,7 @@ class LoggerTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        $this->logger = $this->createMock('Psr\Log\LoggerInterface');
+        $this->logger = $this->createMock(LoggerInterface::class);
     }
 
     protected function tearDown()

--- a/Tests/Logger/LoggerTest.php
+++ b/Tests/Logger/LoggerTest.php
@@ -33,7 +33,7 @@ class LoggerTest extends \PHPUnit_Framework_TestCase
 
     public function testLogQuery()
     {
-        $query = array('foo' => 'bar');
+        $query = ['foo' => 'bar'];
         $log = json_encode($query);
 
         $this->logger->expects($this->once())
@@ -41,14 +41,14 @@ class LoggerTest extends \PHPUnit_Framework_TestCase
             ->with('MongoDB query: '.$log);
 
         $logger = new Logger($this->logger);
-        $logger->logQuery(array('foo' => 'bar'));
+        $logger->logQuery(['foo' => 'bar']);
     }
 
     public function testMongoBinDataBase64Encoded()
     {
         $binData = new \MongoBinData('data', \MongoBinData::BYTE_ARRAY);
-        $query = array('foo' => array('binData' => $binData));
-        $log = json_encode(array('foo' => array('binData' => base64_encode($binData->bin))));
+        $query = ['foo' => ['binData' => $binData]];
+        $log = json_encode(['foo' => ['binData' => base64_encode($binData->bin)]]);
 
         $this->logger->expects($this->once())
             ->method('debug')
@@ -60,21 +60,21 @@ class LoggerTest extends \PHPUnit_Framework_TestCase
 
     public function testInfinityAndNanEncoded()
     {
-        $query = array(
-            'foo' => array(
+        $query = [
+            'foo' => [
                 'posInf' => INF,
                 'negInf' => -INF,
                 'nan' => NAN,
-            ),
-        );
+            ],
+        ];
 
-        $log = json_encode(array(
-            'foo' => array(
+        $log = json_encode([
+            'foo' => [
                 'posInf' => 'Infinity',
                 'negInf' => '-Infinity',
                 'nan' => 'NaN',
-            ),
-        ));
+            ],
+        ]);
 
         $this->logger->expects($this->once())
             ->method('debug')

--- a/Tests/Logger/LoggerTest.php
+++ b/Tests/Logger/LoggerTest.php
@@ -22,7 +22,7 @@ class LoggerTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        $this->logger = $this->getMock('Psr\Log\LoggerInterface');
+        $this->logger = $this->createMock('Psr\Log\LoggerInterface');
     }
 
     protected function tearDown()

--- a/Tests/Mapping/Driver/AbstractDriverTest.php
+++ b/Tests/Mapping/Driver/AbstractDriverTest.php
@@ -20,10 +20,10 @@ abstract class AbstractDriverTest extends \PHPUnit_Framework_TestCase
 {
     public function testFindMappingFile()
     {
-        $driver = $this->getDriver(array(
+        $driver = $this->getDriver([
             'foo' => 'MyNamespace\MyBundle\DocumentFoo',
             $this->getFixtureDir() => 'MyNamespace\MyBundle\Document',
-        ));
+        ]);
 
         $locator = $this->getDriverLocator($driver);
 
@@ -35,9 +35,9 @@ abstract class AbstractDriverTest extends \PHPUnit_Framework_TestCase
 
     public function testFindMappingFileInSubnamespace()
     {
-        $driver = $this->getDriver(array(
+        $driver = $this->getDriver([
             $this->getFixtureDir() => 'MyNamespace\MyBundle\Document',
-        ));
+        ]);
 
         $locator = $this->getDriverLocator($driver);
 
@@ -52,9 +52,9 @@ abstract class AbstractDriverTest extends \PHPUnit_Framework_TestCase
      */
     public function testFindMappingFileNamespacedFoundFileNotFound()
     {
-        $driver = $this->getDriver(array(
+        $driver = $this->getDriver([
             $this->getFixtureDir() => 'MyNamespace\MyBundle\Document',
-        ));
+        ]);
 
         $locator = $this->getDriverLocator($driver);
         $locator->findMappingFile('MyNamespace\MyBundle\Document\Missing');
@@ -65,9 +65,9 @@ abstract class AbstractDriverTest extends \PHPUnit_Framework_TestCase
      */
     public function testFindMappingNamespaceNotFound()
     {
-        $driver = $this->getDriver(array(
+        $driver = $this->getDriver([
             $this->getFixtureDir() => 'MyNamespace\MyBundle\Document',
-        ));
+        ]);
 
         $locator = $this->getDriverLocator($driver);
         $locator->findMappingFile('MyOtherNamespace\MyBundle\Document\Foo');
@@ -75,7 +75,7 @@ abstract class AbstractDriverTest extends \PHPUnit_Framework_TestCase
 
     abstract protected function getFileExtension();
     abstract protected function getFixtureDir();
-    abstract protected function getDriver(array $paths = array());
+    abstract protected function getDriver(array $paths = []);
 
     private function getDriverLocator(FileDriver $driver)
     {

--- a/Tests/Mapping/Driver/XmlDriverTest.php
+++ b/Tests/Mapping/Driver/XmlDriverTest.php
@@ -28,7 +28,7 @@ class XmlDriverTest extends AbstractDriverTest
         return __DIR__ . '/Fixtures/xml';
     }
 
-    protected function getDriver(array $prefixes = array())
+    protected function getDriver(array $prefixes = [])
     {
         return new XmlDriver($prefixes, $this->getFileExtension());
     }

--- a/Tests/Mapping/Driver/YamlDriverTest.php
+++ b/Tests/Mapping/Driver/YamlDriverTest.php
@@ -28,7 +28,7 @@ class YamlDriverTest extends AbstractDriverTest
         return __DIR__ . '/Fixtures/yml';
     }
 
-    protected function getDriver(array $prefixes = array())
+    protected function getDriver(array $prefixes = [])
     {
         return new YamlDriver($prefixes, $this->getFileExtension());
     }

--- a/Tests/TestCase.php
+++ b/Tests/TestCase.php
@@ -24,7 +24,7 @@ class TestCase extends \PHPUnit_Framework_TestCase
     /**
      * @return DocumentManager
      */
-    public static function createTestDocumentManager($paths = array())
+    public static function createTestDocumentManager($paths = [])
     {
         $config = new \Doctrine\ODM\MongoDB\Configuration();
         $config->setAutoGenerateProxyClasses(true);

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,8 @@
         "doctrine/data-fixtures": "@dev",
         "symfony/form": "^2.7 || ^3.0",
         "symfony/yaml": "^2.7 || ^3.0",
-        "symfony/phpunit-bridge": "^2.7 || ^3.0"
+        "symfony/phpunit-bridge": "^2.7 || ^3.0",
+        "phpunit/phpunit": "^5.6"
     },
     "suggest": {
         "doctrine/data-fixtures": "Load data fixtures"


### PR DESCRIPTION
This PR cleans up code since we're using PHP 5.6 and newer:
* PHPUnit is now included in the dev dependencies, this should make development easier
* Instead of having classes as string literals, we use the `::class` constant
* Arrays have been converted to short syntax
* With PHP 7.1 coming up, it's time to add it to the build matrix