### PR TITLE
Fixed empty sort query logging

### DIFF
--- a/DataCollector/PrettyDataCollector.php
+++ b/DataCollector/PrettyDataCollector.php
@@ -163,7 +163,7 @@ class PrettyDataCollector extends StandardDataCollector
                 } elseif (isset($log['save'])) {
                     $query .= '.save('.$this->bsonEncode($log['document']).')';
                 } elseif (isset($log['sort'])) {
-                    $query .= '.sort('.$this->bsonEncode($log['sortFields']).')';
+                    $query .= '.sort('.$this->bsonEncode($log['sortFields'], false).')';
                 } elseif (isset($log['update'])) {
                     // todo: include $log['options']
                     $query .= '.update('.$this->bsonEncode($log['query']).', '.$this->bsonEncode($log['newObj']).')';

--- a/Tests/DataCollector/PrettyDataCollectorTest.php
+++ b/Tests/DataCollector/PrettyDataCollectorTest.php
@@ -162,4 +162,54 @@ class PrettyDataCollectorTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(2, $collector->getQueryCount());
         $this->assertEquals($formatted, $collector->getQueries());
     }
+
+    public function testCollectSort()
+    {
+        $queries = [
+            [
+                'find' => true,
+                'query' => ['_id' => 'foo'],
+                'fields' => [],
+                'db' => 'foo',
+                'collection' => 'User',
+            ],
+            [
+                'sort' => true,
+                'sortFields' => ['name' => 1, 'city' => -1],
+                'query' => ['_id' => 'foo'],
+                'fields' => [],
+            ],
+            [
+                'find' => true,
+                'query' => [
+                    '_id' => '5506fa1580c7e1ee3c8b4c60',
+                ],
+                'fields' => [],
+                'db' => 'foo',
+                'collection' => 'Group',
+            ],
+            [
+                'sort' => true,
+                'sortFields' => [],
+                'query' => [
+                    '_id' => '5506fa1580c7e1ee3c8b4c60',
+                ],
+                'fields' => [],
+            ],
+        ];
+        $formatted = [
+            'use foo;',
+            'db.User.find({ "_id": "foo" }).sort({ "name": 1, "city": -1 });',
+            'db.Group.find({ "_id": "5506fa1580c7e1ee3c8b4c60" }).sort({ });'
+        ];
+
+        $collector = new PrettyDataCollector();
+        foreach ($queries as $query) {
+            $collector->logQuery($query);
+        }
+        $collector->collect(new Request(), new Response());
+
+        $this->assertEquals(2, $collector->getQueryCount());
+        $this->assertEquals($formatted, $collector->getQueries());
+    }
 }


### PR DESCRIPTION
When no sort field was provided, the logged query could not be executed in the mongo shell because of a syntax error.
Before: `db.SomeDoc.find({ "field": "val" }).sort([ ]);`
After: `db.SomeDoc.find({ "field": "val" }).sort({ });`