### PR TITLE
Differentiate profiling count between GridFS and regular-count queries

### DIFF
--- a/DataCollector/PrettyDataCollector.php
+++ b/DataCollector/PrettyDataCollector.php
@@ -95,7 +95,9 @@ class PrettyDataCollector extends StandardDataCollector
                         $query .= '.batchInsert('.$this->bsonEncode($log['data']).')';
                     }
                 } elseif (isset($log['command'])) {
-                    $query .= '.runCommand('.$this->bsonEncode($log['data']).')';
+                    $query .= '.runCommand(' . $this->bsonEncode($log['data']) . ')';
+                } elseif (isset($log['storeFile'])) {
+                    $query .= '.storeFile('.$log['count'].', '.$this->bsonEncode($log['options']).')';
                 } elseif (isset($log['count'])) {
                     $query .= '.count(';
                     if ($log['query'] || $log['limit'] || $log['skip']) {

--- a/Tests/DataCollector/PrettyDataCollectorTest.php
+++ b/Tests/DataCollector/PrettyDataCollectorTest.php
@@ -124,4 +124,42 @@ class PrettyDataCollectorTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(3, $collector->getQueryCount());
         $this->assertEquals($formatted, $collector->getQueries());
     }
+
+    public function testQueryCountVsGridFsStoreFile()
+    {
+        $queries = [
+            [
+                'count' => true,
+                'query' => [
+                    'path' => '/',
+                ],
+                'limit' => ['limit' => true, 'limitNum' => 5],
+                'skip' => ['skip' => true, 'limitSkip' => 0],
+                'options' => [],
+                'db' => 'foo',
+                'collection' => 'Route',
+            ],
+            [
+                'storeFile' => true,
+                'count' => 5,
+                'options' => [],
+                'db' => 'foo',
+                'collection' => 'User.files',
+            ],
+        ];
+        $formatted = [
+            'use foo;',
+            'db.Route.count({ "path": "/" }, { "limit": true, "limitNum": 5 }, { "skip": true, "limitSkip": 0 });',
+            'db.User.files.storeFile(5, [ ]);',
+        ];
+
+        $collector = new PrettyDataCollector();
+        foreach ($queries as $query) {
+            $collector->logQuery($query);
+        }
+        $collector->collect(new Request(), new Response());
+
+        $this->assertEquals(2, $collector->getQueryCount());
+        $this->assertEquals($formatted, $collector->getQueries());
+    }
 }


### PR DESCRIPTION
The newly introduced loggable GridFS collection in doctrine/mongodb#274 is causing problems with the `PrettyDataCollector` as the data collector is not differentiating between the field `count` for a regular query and `count` (as number of affected documents) for a `storeFile`-query.

This PR aims to fix this issue and differentiate when building the log data.