### PR TITLE
Fix tests when running with Symfony 3.2

### DIFF
--- a/Tests/ContainerTest.php
+++ b/Tests/ContainerTest.php
@@ -28,11 +28,12 @@ class ContainerTest extends TestCase
     protected function setUp()
     {
         $this->container = new ContainerBuilder(new ParameterBag([
-            'kernel.bundles'   => [],
-            'kernel.cache_dir' => sys_get_temp_dir(),
-            'kernel.root_dir'  => sys_get_temp_dir(),
+            'kernel.bundles'      => [],
+            'kernel.cache_dir'    => sys_get_temp_dir(),
+            'kernel.root_dir'     => sys_get_temp_dir(),
             'kernel.environment'  => 'test',
-            'kernel.debug'     => true,
+            'kernel.name'         => 'kernel',
+            'kernel.debug'        => true,
         ]));
 
         $this->container->setDefinition('annotation_reader', new Definition(AnnotationReader::class));

--- a/Tests/DependencyInjection/DoctrineMongoDBExtensionTest.php
+++ b/Tests/DependencyInjection/DoctrineMongoDBExtensionTest.php
@@ -36,6 +36,7 @@ class DoctrineMongoDBExtensionTest extends \PHPUnit_Framework_TestCase
     {
         $container = new ContainerBuilder(new ParameterBag([
             'kernel.root_dir'    => __DIR__,
+            'kernel.name'        => 'kernel',
             'kernel.environment' => 'test',
             'kernel.debug'       => 'true',
             'kernel.bundles'     => [],
@@ -81,6 +82,7 @@ class DoctrineMongoDBExtensionTest extends \PHPUnit_Framework_TestCase
             'kernel.bundles'     => $map,
             'kernel.cache_dir'   => sys_get_temp_dir(),
             'kernel.environment' => 'test',
+            'kernel.name'        => 'kernel',
             'kernel.root_dir'    => __DIR__.'/../../' // src dir
         ]));
     }

--- a/Tests/DependencyInjection/Fixtures/config/yml/full.yml
+++ b/Tests/DependencyInjection/Fixtures/config/yml/full.yml
@@ -10,7 +10,6 @@ doctrine_mongodb:
     hydrator_namespace: Test_Hydrators
     proxy_dir: "%kernel.cache_dir%/doctrine/odm/mongodb/Test_Proxies"
     proxy_namespace: Test_Proxies
-    proxy_namespace: Test_Proxies
     persistent_collection_dir: "%kernel.cache_dir%/doctrine/odm/mongodb/Test_Pcolls"
     persistent_collection_namespace: Test_Pcolls
 


### PR DESCRIPTION
It seems with Symfony 3.2 the `kernel.name` parameter is no longer automagically set in the container. To solve this, we declare it in all containers we're building. This PR also fix a deprecation warning about a duplicate key in the yaml configuration used in the tests.

Note: we might want to backport this PR to the 3.0 branch - might do that later.