### PR TITLE
Fix count queries in data collector

### DIFF
--- a/DataCollector/PrettyDataCollector.php
+++ b/DataCollector/PrettyDataCollector.php
@@ -100,13 +100,19 @@ class PrettyDataCollector extends StandardDataCollector
                     $query .= '.storeFile('.$log['count'].', '.$this->bsonEncode($log['options']).')';
                 } elseif (isset($log['count'])) {
                     $query .= '.count(';
-                    if ($log['query'] || $log['limit'] || $log['skip']) {
-                        $query .= $this->bsonEncode($log['query']);
-                        if ($log['limit'] || $log['skip']) {
-                            $query .= ', '.$this->bsonEncode($log['limit']);
-                            if ($log['skip']) {
-                                $query .= ', '.$this->bsonEncode($log['skip']);
-                            }
+                    if (isset($log['query']) || isset($log['limit']) || isset($log['skip'])) {
+                        $query .= $this->bsonEncode(isset($log['query']) ? $log['query'] : [], false);
+
+                        $options = [];
+                        if (isset($log['limit'])) {
+                            $options['limit'] = $log['limit']['limitNum'];
+                        }
+                        if (isset($log['skip'])) {
+                            $options['skip'] = $log['skip']['limitSkip'];
+                        }
+
+                        if (! empty($options)) {
+                            $query .= ', '.$this->bsonEncode($options, false);
                         }
                     }
                     $query .= ')';
@@ -132,18 +138,18 @@ class PrettyDataCollector extends StandardDataCollector
                     $query .= '.execute()';
                 } elseif (isset($log['find'])) {
                     $query .= '.find(';
-                    if ($log['query'] || $log['fields']) {
-                        $query .= $this->bsonEncode($log['query']);
-                        if ($log['fields']) {
+                    if (isset($log['query']) || isset($log['fields'])) {
+                        $query .= $this->bsonEncode(isset($log['query']) ? $log['query'] : [], false);
+                        if (!empty($log['fields'])) {
                             $query .= ', '.$this->bsonEncode($log['fields']);
                         }
                     }
                     $query .= ')';
                 } elseif (isset($log['findOne'])) {
                     $query .= '.findOne(';
-                    if ($log['query'] || $log['fields']) {
-                        $query .= $this->bsonEncode($log['query']);
-                        if ($log['fields']) {
+                    if (isset($log['query']) || isset($log['fields'])) {
+                        $query .= $this->bsonEncode(isset($log['query']) ? $log['query'] : [], false);
+                        if (!empty($log['fields'])) {
                             $query .= ', '.$this->bsonEncode($log['fields']);
                         }
                     }

--- a/Tests/DataCollector/PrettyDataCollectorTest.php
+++ b/Tests/DataCollector/PrettyDataCollectorTest.php
@@ -47,7 +47,31 @@ class PrettyDataCollectorTest extends \PHPUnit_Framework_TestCase
             'bin data' => [
                 ['db' => 'foo', 'collection' => 'bar', 'update' => true, 'query' => ['_id' => 'foo'], 'newObj' => ['foo' => new \MongoBinData('junk data', \MongoBinData::BYTE_ARRAY)]],
                 ['use foo;', 'db.bar.update({ "_id": "foo" }, { "foo": new BinData(2, "' . base64_encode('junk data') . '") });'],
-            ]
+            ],
+            'findWithoutQuery' => [
+                ['db' => 'foo', 'collection' => 'bar', 'find' => true, 'fields' => []],
+                ['use foo;', 'db.bar.find({ });'],
+            ],
+            'findWithoutFields' => [
+                ['db' => 'foo', 'collection' => 'bar', 'find' => true, 'query' => ['foo' => null]],
+                ['use foo;', 'db.bar.find({ "foo": null });'],
+            ],
+            'count' => [
+                ['db' => 'foo', 'collection' => 'bar', 'count' => true],
+                ['use foo;', 'db.bar.count();'],
+            ],
+            'countWithQuery' => [
+                ['db' => 'foo', 'collection' => 'bar', 'count' => true, 'query' => ['foo' => null]],
+                ['use foo;', 'db.bar.count({ "foo": null });'],
+            ],
+            'countWithSkipOnly' => [
+                ['db' => 'foo', 'collection' => 'bar', 'count' => true, 'skip' => ['skip' => true, 'limitSkip' => 5]],
+                ['use foo;', 'db.bar.count({ }, { "skip": 5 });'],
+            ],
+            'countWithLimitOnly' => [
+                ['db' => 'foo', 'collection' => 'bar', 'count' => true, 'limit' => ['limit' => true, 'limitNum' => 3]],
+                ['use foo;', 'db.bar.count({ }, { "limit": 3 });'],
+            ],
         ];
     }
 
@@ -149,7 +173,7 @@ class PrettyDataCollectorTest extends \PHPUnit_Framework_TestCase
         ];
         $formatted = [
             'use foo;',
-            'db.Route.count({ "path": "/" }, { "limit": true, "limitNum": 5 }, { "skip": true, "limitSkip": 0 });',
+            'db.Route.count({ "path": "/" }, { "limit": 5, "skip": 0 });',
             'db.User.files.storeFile(5, [ ]);',
         ];
 


### PR DESCRIPTION
This builds on top of #390 and adds a bunch of `isset` checks around fields that are supposed to be in the `$log` array. In addition to that, it fixes the syntax for the count queries regarding limit and skip options.