### PR TITLE
Add missing authSource parameter to config

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -251,6 +251,7 @@ class Configuration implements ConfigurationInterface
                                     ->scalarNode('db')->end()
                                     ->scalarNode('authSource')
                                         ->validate()->ifNull()->thenUnset()->end()
+                                    ->end()
                                     ->booleanNode('journal')->end()
                                     ->scalarNode('password')
                                         ->validate()->ifNull()->thenUnset()->end()

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -249,6 +249,8 @@ class Configuration implements ConfigurationInterface
                                     ->booleanNode('connect')->end()
                                     ->integerNode('connectTimeoutMS')->end()
                                     ->scalarNode('db')->end()
+                                    ->scalarNode('authSource')
+                                        ->validate()->ifNull()->thenUnset()->end()
                                     ->booleanNode('journal')->end()
                                     ->scalarNode('password')
                                         ->validate()->ifNull()->thenUnset()->end()

--- a/Resources/config/schema/mongodb-1.0.xsd
+++ b/Resources/config/schema/mongodb-1.0.xsd
@@ -59,6 +59,7 @@
       <xsd:element name="readPreferenceTags" type="read-preference-tag-set" minOccurs="0" maxOccurs="unbounded" />
     </xsd:sequence>
     <xsd:attribute name="authMechanism" type="auth-mechanism" />
+    <xsd:attribute name="authSource" type="xsd:string" />
     <xsd:attribute name="connect" type="xsd:boolean" />
     <xsd:attribute name="connectTimeoutMS" type="xsd:integer" />
     <xsd:attribute name="db" type="xsd:string" />

--- a/Resources/doc/config.rst
+++ b/Resources/doc/config.rst
@@ -387,6 +387,50 @@ string as a comma separated list.
 Where mongodb-01, mongodb-02 and mongodb-03 are the machine hostnames. You
 can also use IP addresses if you prefer.
 
+Using Authentication on a Database Level
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+MongoDB supports authentication and authorisation on a database-level. This is mandatory if you have
+e.g. a publicly accessible MongoDB Server. To make use of this feature you need to configure credentials
+for each of your connections. Also every connection needs a database set to authenticate against. The setting is
+represented by the *authSource* `connection string <https://docs.mongodb.com/manual/reference/connection-string/#urioption.authSource>`_.
+Otherwise you will get a *auth failed* exception.
+
+.. configuration-block::
+
+    .. code-block:: yaml
+
+        doctrine_mongodb:
+            # ...
+            connections:
+                default:
+                    server: "mongodb://localhost:27017"
+                    username: someuser
+                    password: somepass
+                    authSource: db_you_have_access_to
+
+    .. code-block:: xml
+
+        <?xml version="1.0" ?>
+
+        <container xmlns="http://symfony.com/schema/dic/services"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xmlns:doctrine="http://symfony.com/schema/dic/doctrine/odm/mongodb"
+                   xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd
+                                http://symfony.com/schema/dic/doctrine/odm/mongodb http://symfony.com/schema/dic/doctrine/odm/mongodb/mongodb-1.0.xsd">
+
+            <doctrine:mongodb>
+                <doctrine:connection id="default" server="mongodb://localhost:27017"/>
+                    <doctrine:options
+                            username="someuser"
+                            password="somepass"
+                            authSource="db_you_have_access_to"
+                    >
+                    </doctrine:options>
+                </doctrine:connection>
+            </doctrine:mongodb>
+        </container>
+
 Retrying Connections and Queries
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -446,6 +490,7 @@ Full Default Configuration
                         connect:              ~
                         connectTimeoutMS:     ~
                         db:                   ~
+                        authSource:           ~
                         journal:              ~
                         password:             ~
                         readPreference:       ~
@@ -524,6 +569,7 @@ Full Default Configuration
                             connect=""
                             connectTimeoutMS=""
                             db=""
+                            authSource=""
                             journal=""
                             password=""
                             readPreference=""

--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -102,6 +102,7 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
                         'socketTimeoutMS'   => 1000,
                         'ssl'               => true,
                         'authMechanism'     => 'X509',
+                        'authSource'        => 'some_db',
                         'username'          => 'username_val',
                         'w'                 => 'majority',
                         'wTimeoutMS'        => 1000,

--- a/Tests/DependencyInjection/Fixtures/config/xml/full.xml
+++ b/Tests/DependencyInjection/Fixtures/config/xml/full.xml
@@ -36,6 +36,7 @@
                 connect="true"
                 connectTimeoutMS="500"
                 db="database_val"
+                authSource="some_db"
                 journal="true"
                 password="password_val"
                 readPreference="secondaryPreferred"

--- a/Tests/DependencyInjection/Fixtures/config/yml/full.yml
+++ b/Tests/DependencyInjection/Fixtures/config/yml/full.yml
@@ -30,6 +30,7 @@ doctrine_mongodb:
             options:
                 connect:          true
                 connectTimeoutMS: 500
+                authSource:       some_db
                 db:               database_val
                 journal:          true
                 password:         password_val


### PR DESCRIPTION
If you use authentication on db-level, you need to specifiy a database name for the authentication. From MDB 2.6.x on it's this URI string parameter you need to set: https://docs.mongodb.com/manual/reference/connection-string/#urioption.authSource
Tested with:
mongodb/mongodb 1.0.1
doctrine/mongodb 1.4.0
doctrine/mongodb-odm 1.1.2

on PHP7 PHP 7.0.8-0ubuntu0.16.04.3 with MongoDB 2.6.10