### PR TITLE
Fix driver option inconsistencies

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -303,7 +303,7 @@ class Configuration implements ConfigurationInterface
                                     })
                                 ->end()
                             ->end()
-                            ->arrayNode('driverOptions')
+                            ->arrayNode('driver_options')
                                 ->performNoDeepMerging()
                                 ->children()
                                     ->scalarNode('context')->defaultNull()->end()

--- a/DependencyInjection/DoctrineMongoDBExtension.php
+++ b/DependencyInjection/DoctrineMongoDBExtension.php
@@ -312,15 +312,15 @@ class DoctrineMongoDBExtension extends AbstractDoctrineExtension
      */
     private function normalizeDriverOptions(array $connection)
     {
-        if (! isset($connection['driverOptions'])) {
+        if (! isset($connection['driver_options'])) {
             return [];
         }
 
-        if (isset($connection['driverOptions']['context'])) {
-            $connection['driverOptions']['context'] = new Reference($connection['driverOptions']['context']);
+        if (isset($connection['driver_options']['context'])) {
+            $connection['driver_options']['context'] = new Reference($connection['driver_options']['context']);
         }
 
-        return $connection['driverOptions'];
+        return $connection['driver_options'];
     }
 
     /**

--- a/DependencyInjection/DoctrineMongoDBExtension.php
+++ b/DependencyInjection/DoctrineMongoDBExtension.php
@@ -313,7 +313,7 @@ class DoctrineMongoDBExtension extends AbstractDoctrineExtension
     private function normalizeDriverOptions(array $connection)
     {
         if (! isset($connection['driverOptions'])) {
-            return null;
+            return [];
         }
 
         if (isset($connection['driverOptions']['context'])) {

--- a/Resources/config/schema/mongodb-1.0.xsd
+++ b/Resources/config/schema/mongodb-1.0.xsd
@@ -49,7 +49,7 @@
   <xsd:complexType name="connection">
     <xsd:sequence>
       <xsd:element name="options" type="connection-options" minOccurs="0" maxOccurs="1" />
-      <xsd:element name="driverOptions" type="connection-driver-options" minOccurs="0" maxOccurs="1" />
+      <xsd:element name="driver-options" type="connection-driver-options" minOccurs="0" maxOccurs="1" />
     </xsd:sequence>
     <xsd:attribute name="id" type="xsd:string" use="required" />
     <xsd:attribute name="server" type="xsd:string" />

--- a/Resources/doc/config.rst
+++ b/Resources/doc/config.rst
@@ -479,8 +479,8 @@ You can then use this service in your configuration:
 
             <doctrine:mongodb>
                 <doctrine:connection id="default" server="mongodb://localhost:27017"/>
-                    <doctrine:driverOptions
-                            context="app.mongodb.context_service"
+                    <doctrine:driver-options
+                        context="app.mongodb.context_service"
                     >
                     </doctrine:options>
                 </doctrine:connection>

--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -107,7 +107,7 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
                         'w'                 => 'majority',
                         'wTimeoutMS'        => 1000,
                     ],
-                    'driverOptions' => [
+                    'driver_options' => [
                         'context' => 'conn1_context_service',
                     ],
                 ],

--- a/Tests/DependencyInjection/Fixtures/config/xml/full.xml
+++ b/Tests/DependencyInjection/Fixtures/config/xml/full.xml
@@ -58,7 +58,7 @@
                 </doctrine:readPreferenceTags>
                 <doctrine:readPreferenceTags />
             </doctrine:options>
-            <doctrine:driverOptions
+            <doctrine:driver-options
                 context="conn1_context_service"
             />
         </doctrine:connection>

--- a/Tests/DependencyInjection/Fixtures/config/yml/full.yml
+++ b/Tests/DependencyInjection/Fixtures/config/yml/full.yml
@@ -47,7 +47,7 @@ doctrine_mongodb:
                 username:         username_val
                 w:                majority
                 wTimeoutMS:       1000
-            driverOptions:
+            driver_options:
                 context:          conn1_context_service
         conn2:
             server: mongodb://otherhost


### PR DESCRIPTION
Fixes #402.

This fixes an error when driver options were omitted in the configuration. For consistency with other options, this PR also renames the option to `driver_options` and `driver-options` in the Yaml and XML mappings respectively.