### PR TITLE
Add missing type names to type guesser

### DIFF
--- a/Form/DoctrineMongoDBTypeGuesser.php
+++ b/Form/DoctrineMongoDBTypeGuesser.php
@@ -84,6 +84,7 @@ class DoctrineMongoDBTypeGuesser implements FormTypeGuesserInterface
                     [],
                     Guess::MEDIUM_CONFIDENCE
                 );
+            case 'bool':
             case 'boolean':
                 return new TypeGuess(
                     $this->typeFQCN ? CheckboxType::class : 'checkbox',
@@ -104,6 +105,7 @@ class DoctrineMongoDBTypeGuesser implements FormTypeGuesserInterface
                     Guess::MEDIUM_CONFIDENCE
                 );
             case 'int':
+            case 'integer':
                 return new TypeGuess(
                     $this->typeFQCN ? IntegerType::class : 'integer',
                     [],

--- a/Tests/Fixtures/Form/Guesser.php
+++ b/Tests/Fixtures/Form/Guesser.php
@@ -30,14 +30,20 @@ class Guesser
      */
     public $categories;
 
-    /** @ODM\Field(type="boolean") */
+    /** @ODM\Field(type="bool") */
     public $boolField;
+
+    /** @ODM\Field(type="boolean") */
+    public $booleanField;
 
     /** @ODM\Field(type="float") */
     public $floatField;
 
     /** @ODM\Field(type="int") */
     public $intField;
+
+    /** @ODM\Field(type="integer") */
+    public $integerField;
 
     /** @ODM\Field(type="collection") */
     public $collectionField;

--- a/Tests/Form/Type/GuesserTestType.php
+++ b/Tests/Form/Type/GuesserTestType.php
@@ -21,8 +21,10 @@ class GuesserTestType extends AbstractType
             ->add('ts')
             ->add('categories', null, ['document_manager' => $options['dm']])
             ->add('boolField')
+            ->add('booleanField')
             ->add('floatField')
             ->add('intField')
+            ->add('integerField')
             ->add('collectionField')
         ;
     }

--- a/Tests/Form/Type/TypeGuesserTest.php
+++ b/Tests/Form/Type/TypeGuesserTest.php
@@ -65,8 +65,10 @@ class TypeGuesserTest extends TypeTestCase
         $this->assertType('datetime', $form->get('date'));
         $this->assertType('datetime', $form->get('ts'));
         $this->assertType('checkbox', $form->get('boolField'));
+        $this->assertType('checkbox', $form->get('booleanField'));
         $this->assertType('number', $form->get('floatField'));
         $this->assertType('integer', $form->get('intField'));
+        $this->assertType('integer', $form->get('integerField'));
         $this->assertType('collection', $form->get('collectionField'));
     }
 


### PR DESCRIPTION
https://github.com/doctrine/mongodb-odm/pull/1073 added the `integer` and `bool` types, but these were not added to the type guesser. So, mapping a field with type `boolean` will yield a checkbox while using `bool` (which seems more logical especially when using scalar type hints) would yield a text input.