### PR TITLE
Disable code coverage generation for most builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ env:
 matrix:
   include:
     - php: 5.6
-      env: DRIVER_VERSION="1.5.8" COMPOSER_FLAGS="--prefer-dist --prefer-lowest"
+      env: DRIVER_VERSION="1.5.8" COMPOSER_FLAGS="--prefer-dist --prefer-lowest" PHPUNIT_FLAGS="--coverage-clover=coverage.clover"
 
 cache:
   directories:
@@ -31,7 +31,7 @@ install:
   - composer update ${COMPOSER_FLAGS}
 
 script:
-    - ./vendor/bin/phpunit --coverage-clover=coverage.clover
+    - ./vendor/bin/phpunit ${PHPUNIT_FLAGS}
 
 after_script:
   - wget https://scrutinizer-ci.com/ocular.phar


### PR DESCRIPTION
This should fix segmentation faults with PHP 7.1, there's also no need to generate code coverage multiple times for the builds.