### PR TITLE
Change Twig notation for the templates

### DIFF
--- a/DependencyInjection/DoctrineMongoDBExtension.php
+++ b/DependencyInjection/DoctrineMongoDBExtension.php
@@ -209,7 +209,7 @@ class DoctrineMongoDBExtension extends AbstractDoctrineExtension
             $loggers[] = new Reference($dataCollectorId);
             $container
                 ->getDefinition($dataCollectorId)
-                ->addTag('data_collector', ['id' => 'mongodb', 'template' => 'DoctrineMongoDBBundle:Collector:mongodb'])
+                ->addTag('data_collector', ['id' => 'mongodb', 'template' => '@DoctrineMongoDB/Collector/mongodb.html.twig'])
             ;
         }
 

--- a/Resources/views/Collector/mongodb.html.twig
+++ b/Resources/views/Collector/mongodb.html.twig
@@ -1,4 +1,4 @@
-{% extends 'WebProfilerBundle:Profiler:layout.html.twig' %}
+{% extends '@WebProfiler/Profiler/layout.html.twig' %}
 
 {% block toolbar %}
     {% if collector.queryCount > 0 %}
@@ -19,7 +19,7 @@
                 <span class="sf-toolbar-status">{{ collector.queryCount }}</span>
             </div>
         {% endset %}
-        {% include 'WebProfilerBundle:Profiler:toolbar_item.html.twig' with { 'link': profiler_url } %}
+        {% include '@WebProfiler/Profiler/toolbar_item.html.twig' with { 'link': profiler_url } %}
     {% endif %}
 {% endblock %}
 


### PR DESCRIPTION
Playing around with a Symfony project created with Symfony Flex, I noticed that I got the error below everytime I try to access a profile in the profiler.

`The profiler template "DoctrineMongoDBBundle:Collector:mongodb.html.twig" for data collector "mongodb" does not exist.`

Changing the Twig notation fixed the problem.