### PR TITLE
Note explaining confunding drivers error for php7

### DIFF
--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -57,6 +57,13 @@ command from the directory where your ``composer.json`` file is located:
 Now, Composer will automatically download all required files, and install them
 for you.
 
+.. note::
+
+    There are two drivers of Mongo Database for Php: mongo (older, not maintained,
+    compatible with php 5), and mongodb (current version). If you have problems with
+    lacking ext-mongo ^1.5, then install `alcaeus/mongo-php-adapter` before these 
+    two packages.
+
 Register the annotations and the bundle
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
Sources:

> https://docs.mongodb.com/ecosystem/drivers/php/

> http://stackoverflow.com/questions/36984973/php70-mongo-install-doctrine-mongodb-odm-fails

I lost a lot of time looking for hint like this. So I hope that this note will help other programmers.