### PR TITLE
Doc - Fix compatability with Symfony 3.x

### DIFF
--- a/Resources/doc/form.rst
+++ b/Resources/doc/form.rst
@@ -181,20 +181,15 @@ Next, create the form for this ``Registration`` model::
     namespace Acme\AccountBundle\Form\Type;
 
     use Symfony\Component\Form\AbstractType;
-    use Symfony\Component\Form\Extension\Core\Type\RepeatedType;
+    use Symfony\Component\Form\Extension\Core\Type\CheckboxType
     use Symfony\Component\Form\FormBuilderInterface;
 
     class RegistrationType extends AbstractType
     {
         public function buildForm(FormBuilderInterface $builder, array $options)
         {
-            $builder->add('user', new UserType());
-            $builder->add('terms', 'checkbox', array('property_path' => 'termsAccepted'));
-        }
-
-        public function getName()
-        {
-            return 'registration';
+            $builder->add('user', UserType::class);
+            $builder->add('terms', CheckboxType::class, array('property_path' => 'termsAccepted'));
         }
     }
 
@@ -243,15 +238,15 @@ and its template:
 Finally, create the controller which handles the form submission.  This performs
 the validation and saves the data into MongoDB::
 
-    public function createAction()
+    public function createAction(Request $request)
     {
         $dm = $this->get('doctrine_mongodb')->getManager();
 
         $form = $this->createForm(new RegistrationType(), new Registration());
 
-        $form->bindRequest($this->getRequest());
+        $form->handleRequest($request);
 
-        if ($form->isValid()) {
+        if ($form->isSubmitted() && $form->isValid()) {
             $registration = $form->getData();
 
             $dm->persist($registration->getUser());


### PR DESCRIPTION
The documented example didn't work with Symfony 3.x (leading to a new user who didn't understand why these examples didn't work on the Symfony support slack channel).

I fixed the examples that now work for sure with Symfony 2.8+ and Symfony 3. The removal of the `getName()` method may introduce an incompatibility with Symfony 2.7 (not sure about it), but I don't think this is a problem. Better make it work on Symfony 2.8+ rather than on 2.7 and 2.8 only.