### PR TITLE
Add Shard command from DoctrineODM

### DIFF
--- a/Command/ShardDoctrineODMCommand.php
+++ b/Command/ShardDoctrineODMCommand.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * This file is part of the Doctrine MongoDBBundle
+ *
+ * The code was originally distributed inside the Symfony framework.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ * (c) Doctrine Project
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace DoctrineMongoDBBundle\Command;
+
+use Doctrine\ODM\MongoDB\Tools\Console\Command\Schema\ShardCommand;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Command to shard database collections for a set of classes based on their
+ * mappings.
+ *
+ * @author Paul Niedzielski <pawel@niedzielski.biz.pl>
+ */
+class ShardDoctrineODMCommand extends ShardCommand
+{
+    protected function configure()
+    {
+        parent::configure();
+
+        $this
+            ->setName('doctrine:mongodb:schema:shard')
+            ->addOption('dm', null, InputOption::VALUE_REQUIRED, 'The document manager to use for this command.')
+            ->setHelp(<<<EOT
+The <info>doctrine:mongodb:schema:shard</info> command shards collections based on their metadata:
+
+  <info>./app/console doctrine:mongodb:schema:shard</info>
+
+You can also optionally specify the name of a document manager to shard collections for:
+
+  <info>./app/console doctrine:mongodb:schema:shard --dm=default</info>
+EOT
+        );
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        DoctrineODMCommand::setApplicationDocumentManager($this->getApplication(), $input->getOption('dm'));
+
+        return parent::execute($input, $output);
+    }
+}


### PR DESCRIPTION
This patch adds `odm:schema:shard` command from DoctrineODM library.

See: http://docs.doctrine-project.org/projects/doctrine-mongodb-odm/en/latest/reference/sharding.html