### PR TITLE
meta_cache_driver list update

### DIFF
--- a/Resources/doc/config.rst
+++ b/Resources/doc/config.rst
@@ -23,7 +23,7 @@ Sample Configuration
                         filter-name:
                             class: Class\Example\Filter\ODM\ExampleFilter
                             enabled: true
-                    metadata_cache_driver: array # array, apc, xcache, memcache
+                    metadata_cache_driver: array # array, apc, apcu, memcache, memcached, redis, wincache, zenddata, xcache
 
     .. code-block:: xml
 


### PR DESCRIPTION
According to this doc :
http://symfony.com/doc/current/reference/configuration/doctrine.html#caching-drivers

The full list of caching driver is :
`array`, `apc`, `apcu`, `memcache`, `memcached`, `redis`, `wincache`, `zenddata` and `xcache`.