### PR TITLE
Exclude embedded documents from proxy generation

### DIFF
--- a/Tests/CacheWarmer/ProxyCacheWarmerTest.php
+++ b/Tests/CacheWarmer/ProxyCacheWarmerTest.php
@@ -60,7 +60,11 @@ class ProxyCacheWarmerTest extends \Doctrine\Bundle\MongoDBBundle\Tests\TestCase
 
     public function testWarmerExecuted()
     {
-        $this->proxyMock->expects($this->once())->method('generateProxyClasses');
+        $this->proxyMock
+            ->expects($this->once())
+            ->method('generateProxyClasses')
+            ->with($this->countOf(1))
+        ;
         $this->warmer->warmUp('meh');
     }
 


### PR DESCRIPTION
Related to https://github.com/doctrine/mongodb-odm/pull/1628. The ProxyCacheWarmer still generates proxies for embedded documents, which causes errors if these are `final` and `doctrine/common` 2.8 is used.

@malarzm merging this down to `master` would force us to tag 3.4.0 since we've got at least one new feature (sharding command) in `master`. If you think we should fix this in 3.3, I'll create a support branch and backport the fix accordingly.