### PR TITLE
Fix Symfony 4 BC breaks

### DIFF
--- a/DataCollector/StandardDataCollector.php
+++ b/DataCollector/StandardDataCollector.php
@@ -44,6 +44,14 @@ class StandardDataCollector extends DataCollector implements LoggerInterface
         $this->data['queries'] = array_map('json_encode', $this->queries);
     }
 
+    public function reset()
+    {
+        $this->data = [
+            'nb_queries' => 0,
+            'queries' => [],
+        ];
+    }
+
     public function getQueryCount()
     {
         return $this->data['nb_queries'];

--- a/DataCollector/StandardDataCollector.php
+++ b/DataCollector/StandardDataCollector.php
@@ -46,6 +46,7 @@ class StandardDataCollector extends DataCollector implements LoggerInterface
 
     public function reset()
     {
+        $this->queries = [];
         $this->data = [
             'nb_queries' => 0,
             'queries' => [],

--- a/DependencyInjection/DoctrineMongoDBExtension.php
+++ b/DependencyInjection/DoctrineMongoDBExtension.php
@@ -303,6 +303,7 @@ class DoctrineMongoDBExtension extends AbstractDoctrineExtension
                 $this->normalizeDriverOptions($connection),
             ];
             $odmConnDef = new Definition('%doctrine_mongodb.odm.connection.class%', $odmConnArgs);
+            $odmConnDef->setPublic(true);
             $id = sprintf('doctrine_mongodb.odm.%s_connection', $name);
             $container->setDefinition($id, $odmConnDef);
             $cons[$name] = $id;

--- a/DependencyInjection/DoctrineMongoDBExtension.php
+++ b/DependencyInjection/DoctrineMongoDBExtension.php
@@ -259,6 +259,7 @@ class DoctrineMongoDBExtension extends AbstractDoctrineExtension
         $odmDmDef = new Definition('%doctrine_mongodb.odm.document_manager.class%', $odmDmArgs);
         $odmDmDef->setFactory(['%doctrine_mongodb.odm.document_manager.class%', 'create']);
         $odmDmDef->addTag('doctrine_mongodb.odm.document_manager');
+        $odmDmDef->setPublic(true);
 
         $container
             ->setDefinition(sprintf('doctrine_mongodb.odm.%s_document_manager', $documentManager['name']), $odmDmDef)

--- a/DependencyInjection/DoctrineMongoDBExtension.php
+++ b/DependencyInjection/DoctrineMongoDBExtension.php
@@ -271,6 +271,8 @@ class DoctrineMongoDBExtension extends AbstractDoctrineExtension
                 'doctrine_mongodb.odm.document_manager',
                 new Alias(sprintf('doctrine_mongodb.odm.%s_document_manager', $documentManager['name']))
             );
+            $container->getAlias('doctrine_mongodb.odm.document_manager')->setPublic(true);
+
             $container->setAlias(
                 'doctrine_mongodb.odm.event_manager',
                 new Alias(sprintf('doctrine_mongodb.odm.%s_connection.event_manager', $connectionName))

--- a/ManagerRegistry.php
+++ b/ManagerRegistry.php
@@ -15,16 +15,24 @@
 namespace Doctrine\Bundle\MongoDBBundle;
 
 use Doctrine\ODM\MongoDB\MongoDBException;
-use Psr\Container\ContainerInterface;
 use Symfony\Bridge\Doctrine\ManagerRegistry as BaseManagerRegistry;
+use Symfony\Component\DependencyInjection\ContainerAwareTrait;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 class ManagerRegistry extends BaseManagerRegistry
 {
     public function __construct(ContainerInterface $container, $name, array $connections, array $managers, $defaultConnection, $defaultManager, $proxyInterfaceName)
     {
-        parent::__construct($name, $connections, $managers, $defaultConnection, $defaultManager, $proxyInterfaceName);
+        $parentTraits = class_uses(parent::class);
+        if (isset($parentTraits[ContainerAwareTrait::class])) {
+            // this case should be removed when Symfony 3.4 becomes the lowest supported version
+            // and then also, the constructor should type-hint Psr\Container\ContainerInterface
+            $this->setContainer($container);
+        } else {
+            $this->container = $container;
+        }
 
-        $this->container = $container;
+        parent::__construct($name, $connections, $managers, $defaultConnection, $defaultManager, $proxyInterfaceName);
     }
 
     /**

--- a/ManagerRegistry.php
+++ b/ManagerRegistry.php
@@ -15,10 +15,18 @@
 namespace Doctrine\Bundle\MongoDBBundle;
 
 use Doctrine\ODM\MongoDB\MongoDBException;
+use Psr\Container\ContainerInterface;
 use Symfony\Bridge\Doctrine\ManagerRegistry as BaseManagerRegistry;
 
 class ManagerRegistry extends BaseManagerRegistry
 {
+    public function __construct(ContainerInterface $container, $name, array $connections, array $managers, $defaultConnection, $defaultManager, $proxyInterfaceName)
+    {
+        parent::__construct($name, $connections, $managers, $defaultConnection, $defaultManager, $proxyInterfaceName);
+
+        $this->container = $container;
+    }
+
     /**
      * Resolves a registered namespace alias to the full namespace.
      *

--- a/ManagerRegistry.php
+++ b/ManagerRegistry.php
@@ -21,7 +21,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 
 class ManagerRegistry extends BaseManagerRegistry
 {
-    public function __construct(ContainerInterface $container, $name, array $connections, array $managers, $defaultConnection, $defaultManager, $proxyInterfaceName)
+    public function __construct($name, array $connections, array $managers, $defaultConnection, $defaultManager, $proxyInterfaceName, ContainerInterface $container = null)
     {
         $parentTraits = class_uses(parent::class);
         if (isset($parentTraits[ContainerAwareTrait::class])) {

--- a/Resources/config/mongodb.xml
+++ b/Resources/config/mongodb.xml
@@ -181,13 +181,13 @@
 
         <!-- Registry -->
         <service id="doctrine_mongodb" class="%doctrine_mongodb.odm.class%" public="true">
-            <argument type="service" id="service_container" />
             <argument>MongoDB</argument>
             <argument>%doctrine_mongodb.odm.connections%</argument>
             <argument>%doctrine_mongodb.odm.document_managers%</argument>
             <argument>%doctrine_mongodb.odm.default_connection%</argument>
             <argument>%doctrine_mongodb.odm.default_document_manager%</argument>
             <argument>Doctrine\ODM\MongoDB\Proxy\Proxy</argument>
+            <argument type="service" id="service_container" />
         </service>
 
         <!-- listeners -->

--- a/Resources/config/mongodb.xml
+++ b/Resources/config/mongodb.xml
@@ -180,16 +180,14 @@
         </service>
 
         <!-- Registry -->
-        <service id="doctrine_mongodb" class="%doctrine_mongodb.odm.class%">
+        <service id="doctrine_mongodb" class="%doctrine_mongodb.odm.class%" public="true">
+            <argument type="service" id="service_container" />
             <argument>MongoDB</argument>
             <argument>%doctrine_mongodb.odm.connections%</argument>
             <argument>%doctrine_mongodb.odm.document_managers%</argument>
             <argument>%doctrine_mongodb.odm.default_connection%</argument>
             <argument>%doctrine_mongodb.odm.default_document_manager%</argument>
             <argument>Doctrine\ODM\MongoDB\Proxy\Proxy</argument>
-            <call method="setContainer">
-                <argument type="service" id="service_container" />
-            </call>
         </service>
 
         <!-- listeners -->

--- a/Tests/DataCollector/StandardDataCollectorTest.php
+++ b/Tests/DataCollector/StandardDataCollectorTest.php
@@ -30,4 +30,17 @@ class StandardDataCollectorTest extends TestCase
         $this->assertEquals(1, $collector->getQueryCount());
         $this->assertEquals(['{"foo":"bar"}'], $collector->getQueries());
     }
+
+    public function testReset()
+    {
+        $collector = new StandardDataCollector();
+        $collector->logQuery(['foo' => 'bar']);
+        $collector->collect(new Request(), new Response());
+
+        $collector->reset();
+        $collector->collect(new Request(), new Response());
+
+        $this->assertEquals([], $collector->getQueries());
+        $this->assertEquals(0, $collector->getQueryCount());
+    }
 }

--- a/Tests/DependencyInjection/DoctrineMongoDBExtensionTest.php
+++ b/Tests/DependencyInjection/DoctrineMongoDBExtensionTest.php
@@ -225,4 +225,14 @@ class DoctrineMongoDBExtensionTest extends TestCase
                 [new Reference('persistent_collection_factory_service')]
             ], $configDm1->getMethodCalls());
     }
+
+    public function testPublicServicesAndAliases()
+    {
+        $loader = new DoctrineMongoDBExtension();
+        $loader->load(self::buildConfiguration(), $container = $this->buildMinimalContainer());
+
+        $this->assertTrue($container->getDefinition('doctrine_mongodb')->isPublic());
+        $this->assertTrue($container->getDefinition('doctrine_mongodb.odm.dummy_document_manager')->isPublic());
+        $this->assertTrue($container->getAlias('doctrine_mongodb.odm.document_manager')->isPublic());
+    }
 }


### PR DESCRIPTION
Based on deprecation warnings got from Symfony 3.4:

- The "**Symfony\Bridge\Doctrine\ManagerRegistry::setContainer()**" method is deprecated since version 3.4 and will be removed in 4.0. Inject a PSR-11 container using the constructor instead.
- The "**doctrine_mongodb**" service is private, getting it from the container is deprecated since Symfony 3.2 and will fail in 4.0. You should either make the service public, or stop using the container directly and use dependency injection instead.
- The "**doctrine_mongodb.odm.default_document_manager**" service is private, getting it from the container is deprecated since Symfony 3.2 and will fail in 4.0. You should either make the service public, or stop using the container directly and use dependency injection instead.
- Implementing "**Symfony\Component\HttpKernel\DataCollector\DataCollectorInterface**" without the "**reset()**" method is deprecated since version 3.4 and will be unsupported in 4.0 for class "**Doctrine\Bundle\MongoDBBundle\DataCollector\PrettyDataCollector**".