### PR TITLE
Use PHPUnit\Framework\TestCase instead of PHPUnit_Framework_TestCase

### DIFF
--- a/Tests/Command/LoadDataFixturesDoctrineODMCommandTest.php
+++ b/Tests/Command/LoadDataFixturesDoctrineODMCommandTest.php
@@ -4,11 +4,12 @@ namespace Doctrine\Bundle\MongoDBBundle\Tests\Command;
 
 use Doctrine\Bundle\MongoDBBundle\Command\LoadDataFixturesDoctrineODMCommand;
 use Doctrine\Common\DataFixtures\Loader;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @author Henrik Bjornskov <henrik@bjrnskov.dk>
  */
-class LoadDataFixturesDoctrineODMCommandTest extends \PHPUnit_Framework_TestCase
+class LoadDataFixturesDoctrineODMCommandTest extends TestCase
 {
     public function setUp()
     {

--- a/Tests/DataCollector/PrettyDataCollectorTest.php
+++ b/Tests/DataCollector/PrettyDataCollectorTest.php
@@ -17,8 +17,9 @@ namespace Doctrine\Bundle\MongoDBBundle\Tests\DataCollector;
 use Doctrine\Bundle\MongoDBBundle\DataCollector\PrettyDataCollector;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use PHPUnit\Framework\TestCase;
 
-class PrettyDataCollectorTest extends \PHPUnit_Framework_TestCase
+class PrettyDataCollectorTest extends TestCase
 {
     /**
      * @dataProvider getQueries

--- a/Tests/DataCollector/StandardDataCollectorTest.php
+++ b/Tests/DataCollector/StandardDataCollectorTest.php
@@ -17,8 +17,9 @@ namespace Doctrine\Bundle\MongoDBBundle\Tests\DataCollector;
 use Doctrine\Bundle\MongoDBBundle\DataCollector\StandardDataCollector;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use PHPUnit\Framework\TestCase;
 
-class StandardDataCollectorTest extends \PHPUnit_Framework_TestCase
+class StandardDataCollectorTest extends TestCase
 {
     public function testCollect()
     {

--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -21,8 +21,9 @@ use Symfony\Bridge\Doctrine\DataFixtures\ContainerAwareLoader;
 use Symfony\Component\Config\Definition\Processor;
 use Symfony\Component\Config\Util\XmlUtils;
 use Symfony\Component\Yaml\Yaml;
+use PHPUnit\Framework\TestCase;
 
-class ConfigurationTest extends \PHPUnit_Framework_TestCase
+class ConfigurationTest extends TestCase
 {
     public function testDefaults()
     {

--- a/Tests/DependencyInjection/DoctrineMongoDBExtensionTest.php
+++ b/Tests/DependencyInjection/DoctrineMongoDBExtensionTest.php
@@ -18,8 +18,9 @@ use Doctrine\Bundle\MongoDBBundle\DependencyInjection\DoctrineMongoDBExtension;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
 use Symfony\Component\DependencyInjection\Reference;
+use PHPUnit\Framework\TestCase;
 
-class DoctrineMongoDBExtensionTest extends \PHPUnit_Framework_TestCase
+class DoctrineMongoDBExtensionTest extends TestCase
 {
     public static function buildConfiguration(array $settings = [])
     {

--- a/Tests/Logger/LoggerTest.php
+++ b/Tests/Logger/LoggerTest.php
@@ -16,8 +16,9 @@ namespace Doctrine\Bundle\MongoDBBundle\Tests\Logger;
 
 use Doctrine\Bundle\MongoDBBundle\Logger\Logger;
 use Psr\Log\LoggerInterface;
+use PHPUnit\Framework\TestCase;
 
-class LoggerTest extends \PHPUnit_Framework_TestCase
+class LoggerTest extends TestCase
 {
     private $logger;
 

--- a/Tests/Mapping/Driver/AbstractDriverTest.php
+++ b/Tests/Mapping/Driver/AbstractDriverTest.php
@@ -15,8 +15,9 @@
 namespace Doctrine\Bundle\MongoDBBundle\Tests\Mapping\Driver;
 
 use Doctrine\Common\Persistence\Mapping\Driver\FileDriver;
+use PHPUnit\Framework\TestCase;
 
-abstract class AbstractDriverTest extends \PHPUnit_Framework_TestCase
+abstract class AbstractDriverTest extends TestCase
 {
     public function testFindMappingFile()
     {

--- a/Tests/TestCase.php
+++ b/Tests/TestCase.php
@@ -18,8 +18,9 @@ use Doctrine\Common\Annotations\AnnotationReader;
 use Doctrine\MongoDB\Connection;
 use Doctrine\ODM\MongoDB\DocumentManager;
 use Doctrine\ODM\MongoDB\Mapping\Driver\AnnotationDriver;
+use PHPUnit\Framework\TestCase as BaseTestCase;
 
-class TestCase extends \PHPUnit_Framework_TestCase
+class TestCase extends BaseTestCase
 {
     /**
      * @return DocumentManager

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "symfony/form": "^2.7 || ^3.0 || ^4.0",
         "symfony/yaml": "^2.7 || ^3.0 || ^4.0",
         "symfony/phpunit-bridge": "^2.7 || ^3.0 || ^4.0",
-        "phpunit/phpunit": "^5.6"
+        "phpunit/phpunit": "^5.7"
     },
     "suggest": {
         "doctrine/data-fixtures": "Load data fixtures"


### PR DESCRIPTION
I use the `PHPUnit\Framework\TestCase` notation instead of `PHPUnit_Framework_TestCase` while extending our TestCases. This will help us migrate to PHPUnit 6, that [no longer support snake case class names](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-6.0.md#changed-1).

I just need to bump PHPUnit version to [`^5.7`](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-5.7.md#570---2016-12-02), that support this namespace.