### PR TITLE
Fix compatibility with Symfony 4.0

### DIFF
--- a/DataCollector/StandardDataCollector.php
+++ b/DataCollector/StandardDataCollector.php
@@ -54,6 +54,14 @@ class StandardDataCollector extends DataCollector implements LoggerInterface
         return $this->data['queries'];
     }
 
+    /**
+     * {@inheritdoc}
+     */
+    public function reset()
+    {
+        $this->queries = [];
+    }
+
     public function getName()
     {
         return 'mongodb';

--- a/DependencyInjection/DoctrineMongoDBExtension.php
+++ b/DependencyInjection/DoctrineMongoDBExtension.php
@@ -263,6 +263,7 @@ class DoctrineMongoDBExtension extends AbstractDoctrineExtension
         $container
             ->setDefinition(sprintf('doctrine_mongodb.odm.%s_document_manager', $documentManager['name']), $odmDmDef)
             ->setConfigurator([new Reference($managerConfiguratorName), 'configure'])
+            ->setPublic(true)
         ;
 
         if ($documentManager['name'] == $defaultDM) {
@@ -270,6 +271,8 @@ class DoctrineMongoDBExtension extends AbstractDoctrineExtension
                 'doctrine_mongodb.odm.document_manager',
                 new Alias(sprintf('doctrine_mongodb.odm.%s_document_manager', $documentManager['name']))
             );
+            $container->getAlias('doctrine_mongodb.odm.document_manager')->setPublic(true);
+
             $container->setAlias(
                 'doctrine_mongodb.odm.event_manager',
                 new Alias(sprintf('doctrine_mongodb.odm.%s_connection.event_manager', $connectionName))

--- a/ManagerRegistry.php
+++ b/ManagerRegistry.php
@@ -15,10 +15,34 @@
 namespace Doctrine\Bundle\MongoDBBundle;
 
 use Doctrine\ODM\MongoDB\MongoDBException;
+use Psr\Container\ContainerInterface;
 use Symfony\Bridge\Doctrine\ManagerRegistry as BaseManagerRegistry;
 
 class ManagerRegistry extends BaseManagerRegistry
 {
+    /**
+     * Construct.
+     *
+     * @param ContainerInterface $container
+     * @param array              $connections
+     * @param array              $entityManagers
+     * @param string             $defaultConnection
+     * @param string             $defaultEntityManager
+     */
+    public function __construct(ContainerInterface $container, $name, array $connections, array $entityManagers, $defaultConnection, $defaultEntityManager, $proxyInterfaceName)
+    {
+        $parentTraits = class_uses(parent::class);
+        if (isset($parentTraits[ContainerAwareTrait::class])) {
+            // this case should be removed when Symfony 3.4 becomes the lowest supported version
+            // and then also, the constructor should type-hint Psr\Container\ContainerInterface
+            $this->setContainer($container);
+        } else {
+            $this->container = $container;
+        }
+
+        parent::__construct($name, $connections, $entityManagers, $defaultConnection, $defaultEntityManager, $proxyInterfaceName);
+    }
+
     /**
      * Resolves a registered namespace alias to the full namespace.
      *

--- a/Resources/config/mongodb.xml
+++ b/Resources/config/mongodb.xml
@@ -143,16 +143,14 @@
         </service>
 
         <!-- Registry -->
-        <service id="doctrine_mongodb" class="%doctrine_mongodb.odm.class%">
+        <service id="doctrine_mongodb" class="%doctrine_mongodb.odm.class%" public="true">
+            <argument type="service" id="service_container" />
             <argument>MongoDB</argument>
             <argument>%doctrine_mongodb.odm.connections%</argument>
             <argument>%doctrine_mongodb.odm.document_managers%</argument>
             <argument>%doctrine_mongodb.odm.default_connection%</argument>
             <argument>%doctrine_mongodb.odm.default_document_manager%</argument>
             <argument>Doctrine\ODM\MongoDB\Proxy\Proxy</argument>
-            <call method="setContainer">
-                <argument type="service" id="service_container" />
-            </call>
         </service>
 
         <!-- listeners -->

--- a/Tests/DataCollector/StandardDataCollectorTest.php
+++ b/Tests/DataCollector/StandardDataCollectorTest.php
@@ -29,4 +29,16 @@ class StandardDataCollectorTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(1, $collector->getQueryCount());
         $this->assertEquals(['{"foo":"bar"}'], $collector->getQueries());
     }
+
+    public function testReset()
+    {
+        $collector = new StandardDataCollector();
+        $collector->logQuery(['foo' => 'bar']);
+        $collector->collect(new Request(), new Response());
+
+        $collector->reset();
+        $collector->collect(new Request(), new Response());
+
+        $this->assertEquals([], $collector->getQueries());
+    }
 }

--- a/Tests/DependencyInjection/DoctrineMongoDBExtensionTest.php
+++ b/Tests/DependencyInjection/DoctrineMongoDBExtensionTest.php
@@ -224,4 +224,14 @@ class DoctrineMongoDBExtensionTest extends \PHPUnit_Framework_TestCase
                 [new Reference('persistent_collection_factory_service')]
             ], $configDm1->getMethodCalls());
     }
+
+    public function testPublicServicesAndAliases()
+    {
+        $loader = new DoctrineMongoDBExtension();
+        $loader->load(self::buildConfiguration(), $container = $this->buildMinimalContainer());
+
+        $this->assertTrue($container->getDefinition('doctrine_mongodb')->isPublic());
+        $this->assertTrue($container->getDefinition('doctrine_mongodb.odm.dummy_document_manager')->isPublic());
+        $this->assertTrue($container->getAlias('doctrine_mongodb.odm.document_manager')->isPublic());
+    }
 }


### PR DESCRIPTION
This PR introduces compatibility with Symfony 4.0 and removes some deprecations with Symfony 3.4 and preserves BC.

Changes:

* Add `reset` method on the data collector for the profiler.
* Mark services as public (services are private by default since Symfony 3.4).

These PR are the counterparts of this PR on the ORM:

* https://github.com/doctrine/DoctrineBundle/pull/710
* https://github.com/doctrine/DoctrineBundle/pull/712