### PR TITLE
Fix type guesser. Ignore field MappingException.

### DIFF
--- a/Form/DoctrineMongoDBTypeGuesser.php
+++ b/Form/DoctrineMongoDBTypeGuesser.php
@@ -17,7 +17,6 @@ use Symfony\Component\Form\FormTypeGuesserInterface;
 use Symfony\Component\Form\Guess\Guess;
 use Symfony\Component\Form\Guess\TypeGuess;
 use Symfony\Component\Form\Guess\ValueGuess;
-use Symfony\Component\HttpKernel\Kernel;
 
 /**
  * Tries to guess form types according to ODM mappings
@@ -44,10 +43,14 @@ class DoctrineMongoDBTypeGuesser implements FormTypeGuesserInterface
     public function guessType($class, $property)
     {
         if (!$ret = $this->getMetadata($class)) {
-            return new TypeGuess($this->typeFQCN ? TextType::class : 'text', [], Guess::LOW_CONFIDENCE);
+            return;
         }
 
         list($metadata, $name) = $ret;
+
+        if (! $metadata->hasField($property)) {
+            return;
+        }
 
         if ($metadata->hasAssociation($property)) {
             $multiple = $metadata->isCollectionValuedAssociation($property);

--- a/Tests/Fixtures/Form/Guesser.php
+++ b/Tests/Fixtures/Form/Guesser.php
@@ -47,4 +47,6 @@ class Guesser
 
     /** @ODM\Field(type="collection") */
     public $collectionField;
+
+    public $nonMappedField;
 }

--- a/Tests/Form/Type/GuesserTestType.php
+++ b/Tests/Form/Type/GuesserTestType.php
@@ -26,6 +26,7 @@ class GuesserTestType extends AbstractType
             ->add('intField')
             ->add('integerField')
             ->add('collectionField')
+            ->add('nonMappedField')
         ;
     }
 

--- a/Tests/Form/Type/TypeGuesserTest.php
+++ b/Tests/Form/Type/TypeGuesserTest.php
@@ -70,6 +70,7 @@ class TypeGuesserTest extends TypeTestCase
         $this->assertType('integer', $form->get('intField'));
         $this->assertType('integer', $form->get('integerField'));
         $this->assertType('collection', $form->get('collectionField'));
+        $this->assertType('text', $form->get('nonMappedField'));
     }
 
     protected function assertType($type, $form)


### PR DESCRIPTION
Fix errors like "No mapping found for field 'plainPassword' in class 'App\Document\Administrator'."