### PR TITLE
Add database name to document manager docs

### DIFF
--- a/Resources/doc/config.rst
+++ b/Resources/doc/config.rst
@@ -300,11 +300,13 @@ following syntax:
             document_managers:
                 dm1:
                     connection: conn1
+                    database: db1
                     metadata_cache_driver: xcache
                     mappings:
                         AcmeDemoBundle: ~
                 dm2:
                     connection: conn2
+                    database: db2
                     mappings:
                         AcmeHelloBundle: ~
 
@@ -332,10 +334,10 @@ following syntax:
                     <doctrine_mongodb:options>
                     </doctrine_mongodb:options>
                 </doctrine_mongodb:connection>
-                <doctrine_mongodb:document-manager id="dm1" metadata-cache-driver="xcache" connection="conn1">
+                <doctrine_mongodb:document-manager id="dm1" metadata-cache-driver="xcache" connection="conn1" database="db1">
                     <doctrine_mongodb:mapping name="AcmeDemoBundle" />
                 </doctrine_mongodb:document-manager>
-                <doctrine_mongodb:document-manager id="dm2" connection="conn2">
+                <doctrine_mongodb:document-manager id="dm2" connection="conn2" database="db2">
                     <doctrine_mongodb:mapping name="AcmeHelloBundle" />
                 </doctrine_mongodb:document-manager>
             </doctrine_mongodb:config>


### PR DESCRIPTION
Fixes #241, #213.

Maybe we need to clean up our database options a bit - from `default_database`, the `database` option on the document manager config to the `db` option on the connection it can be confusing which option to set in which case. I'm open to suggestions on how to improve this.