### PR TITLE
Fix configuration service names

### DIFF
--- a/Tests/DependencyInjection/AbstractMongoDBExtensionTest.php
+++ b/Tests/DependencyInjection/AbstractMongoDBExtensionTest.php
@@ -244,7 +244,7 @@ abstract class AbstractMongoDBExtensionTest extends TestCase
         $this->assertInstanceOf(Reference::class, $arguments[0]);
         $this->assertEquals('doctrine_mongodb.odm.conn1_connection', (string) $arguments[0]);
         $this->assertInstanceOf(Reference::class, $arguments[1]);
-        $this->assertEquals('doctrine_mongodb.odm.dm1_configuration', (string) $arguments[1]);
+        $this->assertEquals('doctrine_mongodb.odm.conn1_configuration', (string) $arguments[1]);
 
         $definition = $container->getDefinition('doctrine_mongodb.odm.conn2_connection');
         $this->assertEquals('%doctrine_mongodb.odm.connection.class%', $definition->getClass());
@@ -266,7 +266,7 @@ abstract class AbstractMongoDBExtensionTest extends TestCase
         $this->assertInstanceOf(Reference::class, $arguments[0]);
         $this->assertEquals('doctrine_mongodb.odm.conn2_connection', (string) $arguments[0]);
         $this->assertInstanceOf(Reference::class, $arguments[1]);
-        $this->assertEquals('doctrine_mongodb.odm.dm2_configuration', (string) $arguments[1]);
+        $this->assertEquals('doctrine_mongodb.odm.conn2_configuration', (string) $arguments[1]);
 
         $this->assertEquals('doctrine_mongodb.odm.dm2_document_manager', (string) $container->getAlias('doctrine_mongodb.odm.document_manager'));
         $this->assertEquals('doctrine_mongodb.odm.conn2_connection.event_manager', (string) $container->getAlias('doctrine_mongodb.odm.event_manager'));


### PR DESCRIPTION
Fixes #432, cc @MatTheCat.

A connection may be in use for multiple document managers, so we can't reliably pick a configuration object for a connection based on a document manager name. This comes in addition to the fact that document managers are created after their connections and a connection doesn't know which document managers it is used for.

The changes could be construed as a BC break since some configuration service names change. If necessary, this can be resolved by generating an alias for the old name, marking that service as deprecated and dropping this behavior in 4.0.

For configurations where document manager and connection have the same name, no changes are visible outside of the container.