### PR TITLE
Prepare changelog for 3.5.0

### DIFF
--- a/CHANGELOG-3.5.md
+++ b/CHANGELOG-3.5.md
@@ -1,0 +1,25 @@
+CHANGELOG for 3.5.x
+===================
+
+This changelog references the relevant changes done in 3.5 minor versions.
+
+To get the diff for a specific change, go to
+https://github.com/doctrine/DoctrineMongoDBBundle/commit/XXX
+where XXX is the commit hash. To get the diff between two versions, go to
+https://github.com/doctrine/DoctrineMongoDBBundle/compare/XXX...YYY
+where XXX and YYY are the older and newer versions, respectively.
+
+To generate a changelog summary since the last version, run
+`git log --no-merges --oneline XXX...HEAD`
+
+3.5.0 (2018-09-24)
+------------------
+
+All issues and pull requests in this release may be found under the [3.5.0 milestone](https://github.com/doctrine/DoctrineMongoDBBundle/issues?q=milestone%3A3.5.0).
+
+ * [441](https://github.com/doctrine/DoctrineMongoDBBundle/pull/441) adds service aliases to autowire the document manager and manager registry services.
+ * [448](https://github.com/doctrine/DoctrineMongoDBBundle/pull/448) updates the documentation to document autowiring features.
+ * [469](https://github.com/doctrine/DoctrineMongoDBBundle/pull/469) deprecates the `default_repository_class` configuration option in favor of `default_document_repository_class`.
+ * [470](https://github.com/doctrine/DoctrineMongoDBBundle/pull/470) clarifies the documentation to better explain using multiple databases in one project.
+ * [471](https://github.com/doctrine/DoctrineMongoDBBundle/pull/471) fixes a wrong connection service name.
+ * [473](https://github.com/doctrine/DoctrineMongoDBBundle/pull/473) adds support for service repositories as added to DoctrineBundle.


### PR DESCRIPTION
Note: waiting for the merge of #473, but this wraps up the 3.5.0 release by adding its changelog. All further features will wait for 4.0 which will also bring support for ODM 2.0.