### PR TITLE
Fix RST syntax in documentation

### DIFF
--- a/Resources/doc/config.rst
+++ b/Resources/doc/config.rst
@@ -343,7 +343,7 @@ following syntax:
             </doctrine_mongodb:config>
         </container>
 
-Now you can retrieve the configured services connection services::
+Now you can retrieve the configured services connection services:
 
 .. code-block:: php
 
@@ -351,7 +351,7 @@ Now you can retrieve the configured services connection services::
     $conn2 = $container->get('doctrine_mongodb.odm.conn2_connection');
 
 And you can also retrieve the configured document manager services which utilize the above
-connection services::
+connection services:
 
 .. code-block:: php
 

--- a/Resources/doc/form.rst
+++ b/Resources/doc/form.rst
@@ -9,7 +9,7 @@ actually stores the account information. We'll use MongoDB for storing the data.
 The simple User model
 ---------------------
 
-So, in this tutorial we begin with the model for a ``User`` document::
+So, in this tutorial we begin with the model for a ``User`` document:
 
 .. code-block:: php
 
@@ -83,7 +83,7 @@ on the database, so we've added this validation at the top of the class.
 Create a Form for the Model
 ---------------------------
 
-Next, create the form for the ``User`` model::
+Next, create the form for the ``User`` model:
 
 .. code-block:: php
 
@@ -136,7 +136,7 @@ won't be stored into database.
 
 In other words, create a second form for registration, which embeds the ``User``
 form and adds the extra field needed. Start by creating a simple class which
-represents the "registration"::
+represents the "registration":
 
 .. code-block:: php
 
@@ -181,7 +181,7 @@ represents the "registration"::
         }
     }
 
-Next, create the form for this ``Registration`` model::
+Next, create the form for this ``Registration`` model:
 
 .. code-block:: php
 
@@ -210,7 +210,7 @@ Handling the Form Submission
 ----------------------------
 
 Next, you need a controller to handle the form. Start by creating a simple
-controller for displaying the registration form::
+controller for displaying the registration form:
 
 .. code-block:: php
 
@@ -246,7 +246,7 @@ and its template:
     </form>
 
 Finally, create the controller which handles the form submission.  This performs
-the validation and saves the data into MongoDB::
+the validation and saves the data into MongoDB:
 
 .. code-block:: php
 

--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -37,7 +37,7 @@ Install the bundle with Composer
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 To install DoctrineMongoDBBundle with Composer just add the following to your
-`composer.json` file::
+`composer.json` file:
 
 .. code-block:: json
 
@@ -80,7 +80,7 @@ Register the annotations and the bundle
     This step is required only if you are using Symfony 3.2 or older.
 
 Next, register the annotations library by adding the following to the autoloader
-(below the existing ``AnnotationRegistry::registerLoader`` line)::
+(below the existing ``AnnotationRegistry::registerLoader`` line):
 
 .. code-block:: php
 
@@ -94,7 +94,7 @@ Next, register the annotations library by adding the following to the autoloader
     This step is not required if you installed the bundle using Symfony Flex.
 
 All that is left to do is to update your ``AppKernel.php`` file, and
-register the new bundle::
+register the new bundle:
 
 .. code-block:: php
 
@@ -139,7 +139,7 @@ the MongoDB ODM across your application:
 
 .. note::
 
-    If you are using Symfony Flex, you can allow `recipes` in the "contrib" repository to 
+    If you are using Symfony Flex, you can allow `recipes` in the "contrib" repository to
     work with this bundle by executing the following command:
 
     .. code-block:: bash
@@ -173,7 +173,7 @@ Creating a Document Class
 Suppose you're building an application where products need to be displayed.
 Without even thinking about Doctrine or MongoDB, you already know that you
 need a ``Product`` object to represent those products. Create this class
-inside the ``Document`` directory of your ``AcmeStoreBundle``::
+inside the ``Document`` directory of your ``AcmeStoreBundle``:
 
 .. code-block:: php
 
@@ -353,7 +353,7 @@ Let's walk through this example:
   to MongoDB. In this example, the ``$product`` object has not been persisted yet,
   so the document manager makes a query to MongoDB, which adds a new entry.
 
-If you are using `autowiring`, you can use type hinting to fetch the ``doctrine_mongodb.odm.document_manager`` service::
+If you are using `autowiring`, you can use type hinting to fetch the ``doctrine_mongodb.odm.document_manager`` service:
 
 .. code-block:: php
 
@@ -401,7 +401,7 @@ Fetching Objects from MongoDB
 
 Fetching an object back out of MongoDB is even easier. For example, suppose
 you've configured a route to display a specific ``Product`` based on its
-``id`` value::
+``id`` value:
 
 .. code-block:: php
 
@@ -421,7 +421,7 @@ you've configured a route to display a specific ``Product`` based on its
 When you query for a particular type of object, you always use what's known
 as its "repository". You can think of a repository as a PHP class whose only
 job is to help you fetch objects of a certain class. You can access the
-repository object for a document class via::
+repository object for a document class via:
 
 .. code-block:: php
 
@@ -436,7 +436,7 @@ repository object for a document class via::
     As long as your document lives under the ``Document`` namespace of your bundle,
     this will work.
 
-Once you have your repository, you have access to all sorts of helpful methods::
+Once you have your repository, you have access to all sorts of helpful methods:
 
 .. code-block:: php
 
@@ -459,7 +459,7 @@ Once you have your repository, you have access to all sorts of helpful methods::
     about in the `Querying for Objects`_ section.
 
 You can also take advantage of the useful ``findBy()`` and ``findOneBy()`` methods
-to easily fetch objects based on multiple conditions::
+to easily fetch objects based on multiple conditions:
 
 .. code-block:: php
 
@@ -476,7 +476,7 @@ Updating an Object
 ~~~~~~~~~~~~~~~~~~
 
 Once you've fetched an object from Doctrine, updating it is easy. Suppose
-you have a route that maps a product id to an update action in a controller::
+you have a route that maps a product id to an update action in a controller:
 
 .. code-block:: php
 
@@ -510,7 +510,7 @@ Deleting an Object
 ~~~~~~~~~~~~~~~~~~
 
 Deleting an object is very similar, but requires a call to the ``remove()``
-method of the document manager::
+method of the document manager:
 
 .. code-block:: php
 
@@ -535,7 +535,7 @@ Using the Query Builder
 Doctrine's ODM ships with a query "Builder" object, which allows you to construct
 a query for exactly which documents you want to return. If you use an IDE,
 you can also take advantage of auto-completion as you type the method names.
-From inside a controller::
+From inside a controller:
 
 .. code-block:: php
 
@@ -634,7 +634,7 @@ ordered alphabetically.
         }
     }
 
-You can use this new method just like the default finder methods of the repository::
+You can use this new method just like the default finder methods of the repository:
 
 .. code-block:: php
 


### PR DESCRIPTION
The DoctrineMongoDBBundle documentation is partly broken on symfony.com website: https://symfony.com/doc/current/bundles/DoctrineMongoDBBundle/index.html (see the "code-block php" appearing on the page).

This PR fixes these issues.