### PR TITLE
Deprecation fix for SF4.2

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -25,8 +25,8 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('doctrine_mongodb');
+        $treeBuilder = new TreeBuilder('doctrine_mongodb');
+        $rootNode    = method_exists(TreeBuilder::class, 'getRootNode') ? $treeBuilder->getRootNode() : $treeBuilder->root('doctrine_mongodb');
 
         $this->addDocumentManagersSection($rootNode);
         $this->addConnectionsSection($rootNode);


### PR DESCRIPTION
A tree builder without a root node is deprecated since Symfony 4.2 and will not be supported anymore in 5.0.

more details:
symfony.com/blog/new-in-symfony-4-2-important-deprecations#deprecated-tree-builders-without-root-nodes