### PR TITLE
Fix more deprecations with Symfony 4.2

### DIFF
--- a/Command/DoctrineODMCommand.php
+++ b/Command/DoctrineODMCommand.php
@@ -3,11 +3,15 @@
 
 namespace Doctrine\Bundle\MongoDBBundle\Command;
 
+use Doctrine\Bundle\MongoDBBundle\ManagerRegistry;
 use Doctrine\ODM\MongoDB\Tools\DisconnectedClassMetadataFactory;
 use Doctrine\ODM\MongoDB\Tools\DocumentGenerator;
 use Doctrine\ODM\MongoDB\Tools\Console\Helper\DocumentManagerHelper;
-use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
+use Symfony\Component\DependencyInjection\ContainerAwareTrait;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 /**
@@ -15,8 +19,30 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
  *
  * @author Justin Hileman <justin@justinhileman.info>
  */
-abstract class DoctrineODMCommand extends ContainerAwareCommand
+abstract class DoctrineODMCommand extends Command implements ContainerAwareInterface
 {
+    use ContainerAwareTrait;
+
+    /**
+     * @var ManagerRegistry|null
+     */
+    private $managerRegistry;
+
+    public function __construct(ManagerRegistry $registry = null)
+    {
+        parent::__construct(null);
+
+        $this->managerRegistry = $registry;
+    }
+
+    /**
+     * @return ContainerInterface
+     */
+    protected function getContainer()
+    {
+        return $this->container;
+    }
+
     public static function setApplicationDocumentManager(Application $application, $dmName)
     {
         $dm = $application->getKernel()->getContainer()->get('doctrine_mongodb')->getManager($dmName);
@@ -38,7 +64,19 @@ abstract class DoctrineODMCommand extends ContainerAwareCommand
 
     protected function getDoctrineDocumentManagers()
     {
-        return $this->getContainer()->get('doctrine_mongodb')->getManagers();
+        return $this->getManagerRegistry()->getManagers();
+    }
+
+    /**
+     * @internal
+     */
+    protected function getManagerRegistry()
+    {
+        if ($this->managerRegistry === null) {
+            $this->managerRegistry = $this->container->get('doctrine_mongodb');
+        }
+
+        return $this->managerRegistry;
     }
 
     protected function getBundleMetadatas(Bundle $bundle)

--- a/Command/InfoDoctrineODMCommand.php
+++ b/Command/InfoDoctrineODMCommand.php
@@ -38,10 +38,10 @@ EOT
     {
         $documentManagerName = $input->getOption('dm') ?
             $input->getOption('dm') :
-            $this->getContainer()->get('doctrine_mongodb')->getDefaultManagerName();
+            $this->getManagerRegistry()->getDefaultManagerName();
 
         /* @var $documentManager \Doctrine\ODM\MongoDB\DocumentManager */
-        $documentManager = $this->getContainer()->get('doctrine_mongodb')->getManager($documentManagerName);
+        $documentManager = $this->getManagerRegistry()->getManager($documentManagerName);
 
         $documentClassNames = $documentManager->getConfiguration()
                                           ->getMetadataDriverImpl()

--- a/Resources/config/mongodb.xml
+++ b/Resources/config/mongodb.xml
@@ -69,6 +69,8 @@
             <tag name="console.command"/>
         </service>
         <service id="Doctrine\Bundle\MongoDBBundle\Command\GenerateDocumentsDoctrineODMCommand" class="Doctrine\Bundle\MongoDBBundle\Command\GenerateDocumentsDoctrineODMCommand">
+            <argument type="service" id="doctrine_mongodb"/>
+
             <tag name="console.command"/>
         </service>
         <service id="Doctrine\Bundle\MongoDBBundle\Command\GenerateHydratorsDoctrineODMCommand" class="Doctrine\Bundle\MongoDBBundle\Command\GenerateHydratorsDoctrineODMCommand">
@@ -78,12 +80,19 @@
             <tag name="console.command"/>
         </service>
         <service id="Doctrine\Bundle\MongoDBBundle\Command\GenerateRepositoriesDoctrineODMCommand" class="Doctrine\Bundle\MongoDBBundle\Command\GenerateRepositoriesDoctrineODMCommand">
+            <argument type="service" id="doctrine_mongodb"/>
+
             <tag name="console.command"/>
         </service>
         <service id="Doctrine\Bundle\MongoDBBundle\Command\InfoDoctrineODMCommand" class="Doctrine\Bundle\MongoDBBundle\Command\InfoDoctrineODMCommand">
+            <argument type="service" id="doctrine_mongodb"/>
+
             <tag name="console.command"/>
         </service>
         <service id="Doctrine\Bundle\MongoDBBundle\Command\LoadDataFixturesDoctrineODMCommand" class="Doctrine\Bundle\MongoDBBundle\Command\LoadDataFixturesDoctrineODMCommand">
+            <argument type="service" id="doctrine_mongodb"/>
+            <argument type="service" id="kernel" on-invalid="null"/>
+
             <tag name="console.command"/>
         </service>
         <service id="Doctrine\Bundle\MongoDBBundle\Command\QueryDoctrineODMCommand" class="Doctrine\Bundle\MongoDBBundle\Command\QueryDoctrineODMCommand">

--- a/Tests/Command/LoadDataFixturesDoctrineODMCommandTest.php
+++ b/Tests/Command/LoadDataFixturesDoctrineODMCommandTest.php
@@ -3,8 +3,10 @@
 namespace Doctrine\Bundle\MongoDBBundle\Tests\Command;
 
 use Doctrine\Bundle\MongoDBBundle\Command\LoadDataFixturesDoctrineODMCommand;
+use Doctrine\Bundle\MongoDBBundle\ManagerRegistry;
 use Doctrine\Common\DataFixtures\Loader;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpKernel\KernelInterface;
 
 /**
  * @author Henrik Bjornskov <henrik@bjrnskov.dk>
@@ -13,7 +15,10 @@ class LoadDataFixturesDoctrineODMCommandTest extends TestCase
 {
     public function setUp()
     {
-        $this->command = new LoadDataFixturesDoctrineODMCommand();
+        $registry = $this->createMock(ManagerRegistry::class);
+        $kernel = $this->createMock(KernelInterface::class);
+
+        $this->command = new LoadDataFixturesDoctrineODMCommand($registry, $kernel);
     }
 
     public function testCommandIsNotEnabledWithMissingDependency()

--- a/Tests/ContainerTest.php
+++ b/Tests/ContainerTest.php
@@ -5,6 +5,7 @@ namespace Doctrine\Bundle\MongoDBBundle\Tests;
 
 use Doctrine\Bundle\MongoDBBundle\DependencyInjection\DoctrineMongoDBExtension;
 use Doctrine\Common\Annotations\AnnotationReader;
+use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
@@ -17,12 +18,14 @@ class ContainerTest extends TestCase
     protected function setUp()
     {
         $this->container = new ContainerBuilder(new ParameterBag([
-            'kernel.bundles'      => [],
-            'kernel.cache_dir'    => sys_get_temp_dir(),
-            'kernel.root_dir'     => sys_get_temp_dir(),
-            'kernel.environment'  => 'test',
-            'kernel.name'         => 'kernel',
-            'kernel.debug'        => true,
+            'kernel.bundles'         => [],
+            'kernel.cache_dir'       => sys_get_temp_dir(),
+            'kernel.root_dir'        => sys_get_temp_dir(),
+            'kernel.project_dir'     => sys_get_temp_dir(),
+            'kernel.environment'     => 'test',
+            'kernel.name'            => 'kernel',
+            'kernel.debug'           => true,
+            'kernel.container_class' => Container::class,
         ]));
 
         $this->container->setDefinition('annotation_reader', new Definition(AnnotationReader::class));

--- a/Tests/DependencyInjection/AbstractMongoDBExtensionTest.php
+++ b/Tests/DependencyInjection/AbstractMongoDBExtensionTest.php
@@ -21,6 +21,7 @@ use Doctrine\ODM\MongoDB\Mapping\Driver\AnnotationDriver;
 use PHPUnit_Framework_AssertionFailedError;
 use PHPUnit\Framework\ExpectationFailedException;
 use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntityValidator;
+use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
@@ -525,6 +526,8 @@ abstract class AbstractMongoDBExtensionTest extends TestCase
             'kernel.environment'      => 'test',
             'kernel.name'             => 'kernel',
             'kernel.root_dir'         => __DIR__,
+            'kernel.project_dir'      => __DIR__,
+            'kernel.container_class'  => Container::class,
         ]));
     }
 }

--- a/Tests/DependencyInjection/DoctrineMongoDBExtensionTest.php
+++ b/Tests/DependencyInjection/DoctrineMongoDBExtensionTest.php
@@ -4,6 +4,7 @@
 namespace Doctrine\Bundle\MongoDBBundle\Tests\DependencyInjection;
 
 use Doctrine\Bundle\MongoDBBundle\DependencyInjection\DoctrineMongoDBExtension;
+use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
 use Symfony\Component\DependencyInjection\Reference;
@@ -25,11 +26,13 @@ class DoctrineMongoDBExtensionTest extends TestCase
     public function buildMinimalContainer()
     {
         $container = new ContainerBuilder(new ParameterBag([
-            'kernel.root_dir'    => __DIR__,
-            'kernel.name'        => 'kernel',
-            'kernel.environment' => 'test',
-            'kernel.debug'       => 'true',
-            'kernel.bundles'     => [],
+            'kernel.root_dir'        => __DIR__,
+            'kernel.project_dir'     => __DIR__,
+            'kernel.name'            => 'kernel',
+            'kernel.environment'     => 'test',
+            'kernel.debug'           => 'true',
+            'kernel.bundles'         => [],
+            'kernel.container_class' => Container::class,
         ]));
         return $container;
     }
@@ -68,12 +71,14 @@ class DoctrineMongoDBExtensionTest extends TestCase
         }
 
         return new ContainerBuilder(new ParameterBag([
-            'kernel.debug'       => false,
-            'kernel.bundles'     => $map,
-            'kernel.cache_dir'   => sys_get_temp_dir(),
-            'kernel.environment' => 'test',
-            'kernel.name'        => 'kernel',
-            'kernel.root_dir'    => __DIR__.'/../../' // src dir
+            'kernel.debug'           => false,
+            'kernel.bundles'         => $map,
+            'kernel.cache_dir'       => sys_get_temp_dir(),
+            'kernel.environment'     => 'test',
+            'kernel.name'            => 'kernel',
+            'kernel.root_dir'        => __DIR__.'/../../',
+            'kernel.project_dir'     => __DIR__.'/../../',
+            'kernel.container_class' => Container::class,
         ]));
     }
 

--- a/Tests/ServiceRepositoryTest.php
+++ b/Tests/ServiceRepositoryTest.php
@@ -18,6 +18,7 @@ use Fixtures\Bundles\RepositoryServiceBundle\Repository\TestUnmappedDocumentRepo
 use Fixtures\Bundles\RepositoryServiceBundle\RepositoryServiceBundle;
 use LogicException;
 use Symfony\Component\DependencyInjection\Alias;
+use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
@@ -37,7 +38,9 @@ class ServiceRepositoryTest extends TestCase
             'kernel.bundles' => ['RepositoryServiceBundle' => RepositoryServiceBundle::class],
             'kernel.cache_dir' => sys_get_temp_dir(),
             'kernel.environment' => 'test',
-            'kernel.root_dir' => __DIR__ . '/../../../../', // src dir
+            'kernel.root_dir' => __DIR__ . '/../../../../',
+            'kernel.project_dir' => __DIR__ . '/../../../../',
+            'kernel.container_class' => Container::class,
         ]));
         $this->container->setDefinition('annotation_reader', new Definition(AnnotationReader::class));
         $extension = new DoctrineMongoDBExtension();


### PR DESCRIPTION
This drops usage of `ContainerAwareCommand` in our commands, replacing it with `ContainerAwareInterface` instead. It also fixes build issues due to missing kernel parameters when testing against Symfony 4.2.