### PR TITLE
Fix #507 Symfony 4.2 deprecation

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -34,8 +34,8 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode    = $treeBuilder->root('doctrine_mongodb');
+        $treeBuilder = new TreeBuilder('doctrine_mongodb');
+        $rootNode = $treeBuilder->getRootNode();
 
         $this->addDocumentManagersSection($rootNode);
         $this->addConnectionsSection($rootNode);


### PR DESCRIPTION
https://github.com/doctrine/DoctrineMongoDBBundle/issues/507

Not sure how far the BC goes, so if this will be for 4.0 or 3.5?

It seems 4.1 and previous don't have a __construct on the TreeBuilder, so i think you need to have some version check instead? 