### PR TITLE
Fix clearstatcache call arguments

### DIFF
--- a/DoctrineMongoDBBundle.php
+++ b/DoctrineMongoDBBundle.php
@@ -78,7 +78,7 @@ class DoctrineMongoDBBundle extends Bundle
                             }
                         }
 
-                        clearstatcache($file);
+                        clearstatcache(true, $file);
                     }
 
                     if (is_file($file)) {


### PR DESCRIPTION
Supersedes #511, fixes #510. This moves the fix to the 3.5 branch, which will then be merged down to master.