### PR TITLE
Prepare bundle for ODM Beta 1

### DIFF
--- a/CacheWarmer/ProxyCacheWarmer.php
+++ b/CacheWarmer/ProxyCacheWarmer.php
@@ -56,7 +56,7 @@ class ProxyCacheWarmer implements CacheWarmerInterface
             throw new RuntimeException(sprintf('Doctrine Proxy directory (%s) is not writable for the current system user.', $proxyCacheDir));
         }
 
-        if ($this->container->getParameter('doctrine_mongodb.odm.auto_generate_proxy_classes') !== AbstractProxyFactory::AUTOGENERATE_NEVER) {
+        if ($this->container->getParameter('doctrine_mongodb.odm.auto_generate_proxy_classes') === AbstractProxyFactory::AUTOGENERATE_EVAL) {
             return;
         }
 

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Doctrine\Bundle\MongoDBBundle\DependencyInjection;
 
-use Doctrine\Common\Proxy\AbstractProxyFactory;
 use Doctrine\ODM\MongoDB\Configuration as ODMConfiguration;
 use Doctrine\ODM\MongoDB\Repository\DefaultGridFSRepository;
 use Doctrine\ODM\MongoDB\Repository\DocumentRepository;
@@ -47,13 +46,13 @@ class Configuration implements ConfigurationInterface
                 ->scalarNode('proxy_namespace')->defaultValue('MongoDBODMProxies')->end()
                 ->scalarNode('proxy_dir')->defaultValue('%kernel.cache_dir%/doctrine/odm/mongodb/Proxies')->end()
                 ->scalarNode('auto_generate_proxy_classes')
-                    ->defaultValue(AbstractProxyFactory::AUTOGENERATE_NEVER)
+                    ->defaultValue(ODMConfiguration::AUTOGENERATE_EVAL)
                     ->beforeNormalization()
                     ->always(static function ($v) {
                         if ($v === false) {
-                            return AbstractProxyFactory::AUTOGENERATE_NEVER;
+                            return ODMConfiguration::AUTOGENERATE_EVAL;
                         } elseif ($v === true) {
-                            return AbstractProxyFactory::AUTOGENERATE_ALWAYS;
+                            return ODMConfiguration::AUTOGENERATE_FILE_NOT_EXISTS;
                         }
                         return $v;
                     })

--- a/DependencyInjection/DoctrineMongoDBExtension.php
+++ b/DependencyInjection/DoctrineMongoDBExtension.php
@@ -6,6 +6,7 @@ namespace Doctrine\Bundle\MongoDBBundle\DependencyInjection;
 
 use Doctrine\Bundle\MongoDBBundle\DependencyInjection\Compiler\ServiceRepositoryCompilerPass;
 use Doctrine\Bundle\MongoDBBundle\Repository\ServiceDocumentRepositoryInterface;
+use Doctrine\ODM\MongoDB\DocumentManager;
 use Symfony\Bridge\Doctrine\DependencyInjection\AbstractDoctrineExtension;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\Alias;
@@ -316,7 +317,7 @@ class DoctrineMongoDBExtension extends AbstractDoctrineExtension
     private function normalizeDriverOptions(array $connection)
     {
         $driverOptions            = $connection['driverOptions'] ?? [];
-        $driverOptions['typeMap'] = ['root' => 'array', 'document' => 'array'];
+        $driverOptions['typeMap'] = DocumentManager::CLIENT_TYPEMAP;
 
         if (isset($driverOptions['context'])) {
             $driverOptions['context'] = new Reference($driverOptions['context']);

--- a/Resources/config/mongodb.xml
+++ b/Resources/config/mongodb.xml
@@ -180,7 +180,7 @@
             <argument>%doctrine_mongodb.odm.document_managers%</argument>
             <argument>%doctrine_mongodb.odm.default_connection%</argument>
             <argument>%doctrine_mongodb.odm.default_document_manager%</argument>
-            <argument>Doctrine\ODM\MongoDB\Proxy\Proxy</argument>
+            <argument>ProxyManager\Proxy\GhostObjectInterface</argument>
             <argument type="service" id="service_container" />
         </service>
 

--- a/Tests/DependencyInjection/AbstractMongoDBExtensionTest.php
+++ b/Tests/DependencyInjection/AbstractMongoDBExtensionTest.php
@@ -48,7 +48,7 @@ abstract class AbstractMongoDBExtensionTest extends TestCase
         $this->assertEquals(Configuration::class, $container->getParameter('doctrine_mongodb.odm.configuration.class'));
         $this->assertEquals(DocumentManager::class, $container->getParameter('doctrine_mongodb.odm.document_manager.class'));
         $this->assertEquals('MongoDBODMProxies', $container->getParameter('doctrine_mongodb.odm.proxy_namespace'));
-        $this->assertEquals(false, $container->getParameter('doctrine_mongodb.odm.auto_generate_proxy_classes'));
+        $this->assertEquals(Configuration::AUTOGENERATE_EVAL, $container->getParameter('doctrine_mongodb.odm.auto_generate_proxy_classes'));
         $this->assertEquals(ArrayCache::class, $container->getParameter('doctrine_mongodb.odm.cache.array.class'));
         $this->assertEquals(ApcCache::class, $container->getParameter('doctrine_mongodb.odm.cache.apc.class'));
         $this->assertEquals(MemcacheCache::class, $container->getParameter('doctrine_mongodb.odm.cache.memcache.class'));

--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -33,7 +33,7 @@ class ConfigurationTest extends TestCase
         $defaults = [
             'fixture_loader'                 => ContainerAwareLoader::class,
             'auto_generate_hydrator_classes' => false,
-            'auto_generate_proxy_classes'    => false,
+            'auto_generate_proxy_classes'    => ODMConfiguration::AUTOGENERATE_EVAL,
             'auto_generate_persistent_collection_classes' => ODMConfiguration::AUTOGENERATE_NEVER,
             'default_database'               => 'default',
             'document_managers'              => [],
@@ -63,7 +63,7 @@ class ConfigurationTest extends TestCase
         $expected = [
             'fixture_loader'                 => ContainerAwareLoader::class,
             'auto_generate_hydrator_classes' => 1,
-            'auto_generate_proxy_classes'    => 1,
+            'auto_generate_proxy_classes'    => ODMConfiguration::AUTOGENERATE_FILE_NOT_EXISTS,
             'auto_generate_persistent_collection_classes' => ODMConfiguration::AUTOGENERATE_EVAL,
             'default_connection'             => 'conn1',
             'default_database'               => 'default_db_name',

--- a/Tests/TestCase.php
+++ b/Tests/TestCase.php
@@ -20,7 +20,7 @@ class TestCase extends BaseTestCase
     public static function createTestDocumentManager($paths = [])
     {
         $config = new Configuration();
-        $config->setAutoGenerateProxyClasses(1);
+        $config->setAutoGenerateProxyClasses(Configuration::AUTOGENERATE_FILE_NOT_EXISTS);
         $config->setProxyDir(sys_get_temp_dir());
         $config->setHydratorDir(sys_get_temp_dir());
         $config->setProxyNamespace('SymfonyTests\Doctrine');

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "require": {
         "php": "^7.2",
         "doctrine/annotations": "^1.2",
-        "doctrine/mongodb-odm": "^2.0@alpha",
+        "doctrine/mongodb-odm": "^2.0.0-beta1",
         "psr/log": "^1.0",
         "symfony/console": "^3.4 || ^4.0",
         "symfony/dependency-injection": "^3.4 || ^4.0",


### PR DESCRIPTION
Most changes are due to the proxy implementation change. We also use the new `CLIENT_TYPEMAP` constant from `DocumentManager` to stop replicating the `typeMap` option for the client.