### PR TITLE
Add registration of custom types in config

### DIFF
--- a/CacheWarmer/HydratorCacheWarmer.php
+++ b/CacheWarmer/HydratorCacheWarmer.php
@@ -7,6 +7,7 @@ namespace Doctrine\Bundle\MongoDBBundle\CacheWarmer;
 use Doctrine\Common\Persistence\ManagerRegistry;
 use Doctrine\ODM\MongoDB\Configuration;
 use Doctrine\ODM\MongoDB\DocumentManager;
+use Doctrine\ODM\MongoDB\Types\Type;
 use RuntimeException;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpKernel\CacheWarmer\CacheWarmerInterface;
@@ -44,6 +45,9 @@ class HydratorCacheWarmer implements CacheWarmerInterface
 
     public function warmUp($cacheDir)
     {
+        // register custom types during cache warm up to avoid errors while generating hydrator classes
+        $this->registerTypes();
+
         // we need the directory no matter the hydrator cache generation strategy.
         $hydratorCacheDir = $this->container->getParameter('doctrine_mongodb.odm.hydrator_dir');
         if (! file_exists($hydratorCacheDir)) {
@@ -64,6 +68,23 @@ class HydratorCacheWarmer implements CacheWarmerInterface
             /** @var DocumentManager $dm */
             $classes = $dm->getMetadataFactory()->getAllMetadata();
             $dm->getHydratorFactory()->generateHydratorClasses($classes);
+        }
+    }
+
+    private function registerTypes() : void
+    {
+        if (! $this->container->hasParameter('doctrine_mongodb.odm.types')) {
+            // no types defined
+            exit;
+        }
+
+        $types = $this->container->getParameter('doctrine_mongodb.odm.types');
+        foreach ($types as $key => $fqcn) {
+            if (Type::hasType($key)) {
+                Type::overrideType($key, $fqcn);
+            } else {
+                Type::addType($key, $fqcn);
+            }
         }
     }
 }

--- a/CacheWarmer/HydratorCacheWarmer.php
+++ b/CacheWarmer/HydratorCacheWarmer.php
@@ -75,7 +75,7 @@ class HydratorCacheWarmer implements CacheWarmerInterface
     {
         if (! $this->container->hasParameter('doctrine_mongodb.odm.types')) {
             // no types defined
-            exit;
+            return;
         }
 
         $types = $this->container->getParameter('doctrine_mongodb.odm.types');

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -40,6 +40,7 @@ class Configuration implements ConfigurationInterface
         $this->addDocumentManagersSection($rootNode);
         $this->addConnectionsSection($rootNode);
         $this->addResolveTargetDocumentsSection($rootNode);
+        $this->addCustomTypesSection($rootNode);
 
         $rootNode
             ->children()
@@ -343,6 +344,23 @@ class Configuration implements ConfigurationInterface
                 ->arrayNode('resolve_target_documents')
                     ->useAttributeAsKey('interface')
                     ->prototype('scalar')
+                        ->cannotBeEmpty()
+                    ->end()
+                ->end()
+            ->end();
+    }
+
+    /**
+     * Adds the "types" config section.
+     */
+    private function addCustomTypesSection(ArrayNodeDefinition $rootNode)
+    {
+        $rootNode
+            ->fixXmlConfig('type')
+            ->children()
+                ->arrayNode('types')
+                    ->useAttributeAsKey('name')
+                    ->scalarPrototype()
                         ->cannotBeEmpty()
                     ->end()
                 ->end()

--- a/DependencyInjection/DoctrineMongoDBExtension.php
+++ b/DependencyInjection/DoctrineMongoDBExtension.php
@@ -105,6 +105,7 @@ class DoctrineMongoDBExtension extends AbstractDoctrineExtension
             'persistent_collection_dir',
             'persistent_collection_namespace',
             'auto_generate_persistent_collection_classes',
+            'types',
         ];
 
         foreach ($overrides as $key) {

--- a/DoctrineMongoDBBundle.php
+++ b/DoctrineMongoDBBundle.php
@@ -10,6 +10,7 @@ use Doctrine\Bundle\MongoDBBundle\DependencyInjection\Compiler\ServiceRepository
 use Doctrine\Bundle\MongoDBBundle\DependencyInjection\DoctrineMongoDBExtension;
 use Doctrine\ODM\MongoDB\Configuration;
 use Doctrine\ODM\MongoDB\DocumentManager;
+use Doctrine\ODM\MongoDB\Types\Type;
 use Symfony\Bridge\Doctrine\DependencyInjection\CompilerPass\DoctrineValidationPass;
 use Symfony\Bridge\Doctrine\DependencyInjection\CompilerPass\RegisterEventListenersAndSubscribersPass;
 use Symfony\Bridge\Doctrine\DependencyInjection\Security\UserProvider\EntityFactory;
@@ -49,6 +50,8 @@ class DoctrineMongoDBBundle extends Bundle
 
     public function boot()
     {
+        $this->registerTypes();
+
         /** @var ManagerRegistry $registry */
         $registry = $this->container->get('doctrine_mongodb');
 
@@ -65,6 +68,23 @@ class DoctrineMongoDBBundle extends Bundle
         $this->autoloader = $configuration->getProxyManagerConfiguration()->getProxyAutoloader();
 
         spl_autoload_register($this->autoloader);
+    }
+
+    private function registerTypes() : void
+    {
+        if (! $this->container->hasParameter('doctrine_mongodb.odm.types')) {
+            // no types defined
+            exit;
+        }
+
+        $types = $this->container->getParameter('doctrine_mongodb.odm.types');
+        foreach ($types as $key => $fqcn) {
+            if (Type::hasType($key)) {
+                Type::overrideType($key, $fqcn);
+            } else {
+                Type::addType($key, $fqcn);
+            }
+        }
     }
 
     public function shutdown()

--- a/Resources/config/schema/mongodb-1.0.xsd
+++ b/Resources/config/schema/mongodb-1.0.xsd
@@ -13,6 +13,7 @@
       <xsd:element name="connection" type="connection" minOccurs="0" maxOccurs="unbounded" />
       <xsd:element name="document-manager" type="document-manager" minOccurs="0" maxOccurs="unbounded" />
       <xsd:element name="resolve-target-document" type="resolve_target_document" minOccurs="0" maxOccurs="unbounded" />
+      <xsd:element name="type" type="type" minOccurs="0" maxOccurs="unbounded" />
     </xsd:sequence>
     <xsd:attribute name="auto-generate-hydrator-classes" type="xsd:integer" />
     <xsd:attribute name="auto-generate-proxy-classes" type="xsd:integer" />
@@ -175,5 +176,13 @@
   <xsd:complexType name="profiler">
     <xsd:attribute name="enabled" type="xsd:boolean" />
     <xsd:attribute name="pretty" type="xsd:boolean" />
+  </xsd:complexType>
+
+  <xsd:complexType name="type">
+    <xsd:simpleContent>
+      <xsd:extension base="xsd:string">
+        <xsd:attribute name="name" type="xsd:string" use="required" />
+      </xsd:extension>
+    </xsd:simpleContent>
   </xsd:complexType>
 </xsd:schema>

--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -46,6 +46,7 @@ class ConfigurationTest extends TestCase
             'default_commit_options'         => [],
             'persistent_collection_dir'      => '%kernel.cache_dir%/doctrine/odm/mongodb/PersistentCollections',
             'persistent_collection_namespace'=> 'PersistentCollections',
+            'types'                          => [],
         ];
 
         $this->assertEquals($defaults, $options);
@@ -186,6 +187,7 @@ class ConfigurationTest extends TestCase
                 ],
             ],
             'resolve_target_documents' => ['Foo\BarInterface' => 'Bar\FooClass'],
+            'types' => [],
         ];
 
         $this->assertEquals($expected, $options);

--- a/Tests/DependencyInjection/Fixtures/config/yml/full.yml
+++ b/Tests/DependencyInjection/Fixtures/config/yml/full.yml
@@ -97,3 +97,4 @@ doctrine_mongodb:
                     is_bundle: false
             metadata_cache_driver: apc
             logging: true
+    types: []


### PR DESCRIPTION
Adds registration of custom types via configuration, similar to Doctrine ORM.

See Issue: #75

Still need to update config checks and test the code, therefore not yet ready for review.