### PR TITLE
Replace legacy Doctrine common code

### DIFF
--- a/CacheWarmer/ProxyCacheWarmer.php
+++ b/CacheWarmer/ProxyCacheWarmer.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\Bundle\MongoDBBundle\CacheWarmer;
 
 use Doctrine\Common\Persistence\ManagerRegistry;
-use Doctrine\Common\Proxy\AbstractProxyFactory;
+use Doctrine\ODM\MongoDB\Configuration;
 use Doctrine\ODM\MongoDB\DocumentManager;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
 use RuntimeException;
@@ -56,7 +56,7 @@ class ProxyCacheWarmer implements CacheWarmerInterface
             throw new RuntimeException(sprintf('Doctrine Proxy directory (%s) is not writable for the current system user.', $proxyCacheDir));
         }
 
-        if ($this->container->getParameter('doctrine_mongodb.odm.auto_generate_proxy_classes') === AbstractProxyFactory::AUTOGENERATE_EVAL) {
+        if ($this->container->getParameter('doctrine_mongodb.odm.auto_generate_proxy_classes') === Configuration::AUTOGENERATE_EVAL) {
             return;
         }
 

--- a/DoctrineMongoDBBundle.php
+++ b/DoctrineMongoDBBundle.php
@@ -8,7 +8,6 @@ use Doctrine\Bundle\MongoDBBundle\DependencyInjection\Compiler\CreateHydratorDir
 use Doctrine\Bundle\MongoDBBundle\DependencyInjection\Compiler\CreateProxyDirectoryPass;
 use Doctrine\Bundle\MongoDBBundle\DependencyInjection\Compiler\ServiceRepositoryCompilerPass;
 use Doctrine\Bundle\MongoDBBundle\DependencyInjection\DoctrineMongoDBExtension;
-use Doctrine\Common\Util\ClassUtils;
 use Symfony\Bridge\Doctrine\DependencyInjection\CompilerPass\DoctrineValidationPass;
 use Symfony\Bridge\Doctrine\DependencyInjection\CompilerPass\RegisterEventListenersAndSubscribersPass;
 use Symfony\Bridge\Doctrine\DependencyInjection\Security\UserProvider\EntityFactory;
@@ -76,8 +75,7 @@ class DoctrineMongoDBBundle extends Bundle
             $file     = $dir . DIRECTORY_SEPARATOR . $fileName . '.php';
 
             if (! is_file($file) && $container->getParameter('doctrine_mongodb.odm.auto_generate_proxy_classes')) {
-                $originalClassName = ClassUtils::getRealClass($class);
-                $registry          = $container->get('doctrine_mongodb');
+                $registry = $container->get('doctrine_mongodb');
 
                 // Tries to auto-generate the proxy file
                 foreach ($registry->getManagers() as $dm) {
@@ -85,7 +83,8 @@ class DoctrineMongoDBBundle extends Bundle
                         continue;
                     }
 
-                    $classes = $dm->getMetadataFactory()->getAllMetadata();
+                    $originalClassName = $dm->getClassNameResolver()->getRealClass($class);
+                    $classes           = $dm->getMetadataFactory()->getAllMetadata();
 
                     foreach ($classes as $classMetadata) {
                         if ($classMetadata->name !== $originalClassName) {


### PR DESCRIPTION
Because the dependency to `doctrine/common` is not in the `composer.json`.