### PR TITLE
First implementation of symfony fixture loader + group support #461

### DIFF
--- a/Command/LoadDataFixturesDoctrineODMCommand.php
+++ b/Command/LoadDataFixturesDoctrineODMCommand.php
@@ -3,6 +3,7 @@
 
 namespace Doctrine\Bundle\MongoDBBundle\Command;
 
+use Doctrine\Bundle\MongoDBBundle\Loader\SymfonyFixturesLoaderInterface;
 use Doctrine\Bundle\MongoDBBundle\ManagerRegistry;
 use Doctrine\Common\DataFixtures\Executor\MongoDBExecutor;
 use Doctrine\Common\DataFixtures\Loader;
@@ -11,6 +12,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\ConfirmationQuestion;
+use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\HttpKernel\KernelInterface;
 
 /**
@@ -21,13 +23,22 @@ use Symfony\Component\HttpKernel\KernelInterface;
  */
 class LoadDataFixturesDoctrineODMCommand extends DoctrineODMCommand
 {
+    /**
+     * @var KernelInterface
+     */
     private $kernel;
 
-    public function __construct(ManagerRegistry $registry = null, KernelInterface $kernel = null)
+    /**
+     * @var SymfonyFixturesLoaderInterface
+     */
+    private $fixturesLoader;
+
+    public function __construct(ManagerRegistry $registry = null, KernelInterface $kernel = null, SymfonyFixturesLoaderInterface $fixturesLoader = null)
     {
         parent::__construct($registry);
 
         $this->kernel = $kernel;
+        $this->fixturesLoader = $fixturesLoader;
     }
 
     /**
@@ -45,20 +56,31 @@ class LoadDataFixturesDoctrineODMCommand extends DoctrineODMCommand
             ->setDescription('Load data fixtures to your database.')
             ->addOption('fixtures', null, InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY, 'The directory or file to load data fixtures from.')
             ->addOption('bundles', 'b', InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY, 'The bundles to load data fixtures from.')
+            ->addOption('services', null, InputOption::VALUE_NONE, 'Use services as fixtures')
+            ->addOption('group', null, InputOption::VALUE_IS_ARRAY|InputOption::VALUE_REQUIRED, 'Only load fixtures that belong to this group (use with --services)')
             ->addOption('append', null, InputOption::VALUE_NONE, 'Append the data fixtures instead of flushing the database first.')
             ->addOption('dm', null, InputOption::VALUE_REQUIRED, 'The document manager to use for this command.')
             ->setHelp(<<<EOT
-The <info>doctrine:mongodb:fixtures:load</info> command loads data fixtures from your bundles:
+The <info>doctrine:mongodb:fixtures:load</info> command loads data fixtures from your application:
 
-  <info>./app/console doctrine:mongodb:fixtures:load</info>
+  <info>php %command.full_name%</info>
 
 You can also optionally specify the path to fixtures with the <info>--fixtures</info> option:
-
-  <info>./app/console doctrine:mongodb:fixtures:load --fixtures=/path/to/fixtures1 --fixtures=/path/to/fixtures2</info>
+  <info>php %command.full_name%</info> --fixtures=/path/to/fixtures1 --fixtures=/path/to/fixtures2</info>
 
 If you want to append the fixtures instead of flushing the database first you can use the <info>--append</info> option:
 
-  <info>./app/console doctrine:mongodb:fixtures:load --append</info>
+  <info>php %command.full_name%</info> --append</info>
+
+
+Alternatively, you can also load fixture services instead of files. Fixture services are tagged with `<comment>doctrine.fixture.odm</comment>`.
+When using `<comment>--services</comment>`, both `<comment>--fixtures</comment>` and `<comment>--bundles</comment>` will no longer work.
+Using `<comment>--services</comment>` will be the default behaviour in 4.0.
+When loading fixture services, you can also choose to load only fixtures that live in a certain group:
+`<info>php %command.full_name%</info> <comment>--group=group1</comment> <comment>--services</comment>`
+
+
+
 EOT
         );
     }
@@ -66,11 +88,13 @@ EOT
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $dm = $this->getManagerRegistry()->getManager($input->getOption('dm'));
+        $ui = new SymfonyStyle($input, $output);
 
         $dirOrFile = $input->getOption('fixtures');
         $bundles = $input->getOption('bundles');
-        if ($bundles && $dirOrFile) {
-            throw new \InvalidArgumentException('Use only one option: --bundles or --fixtures.');
+        $services = (bool) $input->getOption('services');
+        if (($services && $bundles) || ($services && $dirOrFile) || ($bundles && $dirOrFile)) {
+            throw new \InvalidArgumentException('Can only use one of "--bundles", "--fixtures", "--services".');
         }
 
         if ($input->isInteractive() && !$input->getOption('append')) {
@@ -82,37 +106,57 @@ EOT
             }
         }
 
-        if ($dirOrFile) {
-            $paths = is_array($dirOrFile) ? $dirOrFile : [$dirOrFile];
-        } elseif ($bundles) {
-            $paths = [$this->getKernel()->getRootDir().'/DataFixtures/MongoDB'];
-            foreach ($bundles as $bundle) {
-                $paths[] = $this->getKernel()->getBundle($bundle)->getPath();
+        if (!$services) {
+            @trigger_error('--bundles and --fixtures are deprecated since doctrine/mongodb-odm-bundle 3.6 and will be removed in 4.0. Use --services instead.', E_USER_DEPRECATED);
+
+            if ($dirOrFile) {
+                $paths = is_array($dirOrFile) ? $dirOrFile : [$dirOrFile];
+            } elseif ($bundles) {
+                $paths = [$this->getKernel()->getRootDir().'/DataFixtures/MongoDB'];
+                foreach ($bundles as $bundle) {
+                    $paths[] = $this->getKernel()->getBundle($bundle)->getPath();
+                }
+            } else {
+                $paths = $this->container->getParameter('doctrine_mongodb.odm.fixtures_dirs');
+                $paths = is_array($paths) ? $paths : [$paths];
+                $paths[] = $this->getKernel()->getRootDir().'/DataFixtures/MongoDB';
+                foreach ($this->getKernel()->getBundles() as $bundle) {
+                    $paths[] = $bundle->getPath().'/DataFixtures/MongoDB';
+                }
+            }
+            $loaderClass = $this->container->getParameter('doctrine_mongodb.odm.fixture_loader');
+            $loader = new $loaderClass($this->container);
+            foreach ($paths as $path) {
+                if (is_dir($path)) {
+                    $loader->loadFromDirectory($path);
+                } else if (is_file($path)) {
+                    $loader->loadFromFile($path);
+                }
+            }
+            $fixtures = $loader->getFixtures();
+            if (!$fixtures) {
+                throw new \InvalidArgumentException(
+                    sprintf('Could not find any fixtures to load in: %s', "\n\n- ".implode("\n- ", $paths))
+                );
             }
         } else {
-            $paths = $this->container->getParameter('doctrine_mongodb.odm.fixtures_dirs');
-            $paths = is_array($paths) ? $paths : [$paths];
-            $paths[] = $this->getKernel()->getRootDir().'/DataFixtures/MongoDB';
-            foreach ($this->getKernel()->getBundles() as $bundle) {
-                $paths[] = $bundle->getPath().'/DataFixtures/MongoDB';
+            if (! $this->fixturesLoader) {
+                throw new \RuntimeException('Cannot use fixture services without injecting a fixtures loader.');
             }
-        }
 
-        $loaderClass = $this->container->getParameter('doctrine_mongodb.odm.fixture_loader');
-        $loader = new $loaderClass($this->container);
-        foreach ($paths as $path) {
-            if (is_dir($path)) {
-                $loader->loadFromDirectory($path);
-            } else if (is_file($path)) {
-                $loader->loadFromFile($path);
+            $groups   = $input->getOption('group');
+            $fixtures = $this->fixturesLoader->getFixtures($groups);
+            if (! $fixtures) {
+                $message = 'Could not find any fixture services to load';
+
+                if (! empty($groups)) {
+                    $message .= sprintf(' in the groups (%s)', implode(', ', $groups));
+                }
+
+                $ui->error($message . '.');
+
+                return 1;
             }
-        }
-
-        $fixtures = $loader->getFixtures();
-        if (!$fixtures) {
-            throw new \InvalidArgumentException(
-                sprintf('Could not find any fixtures to load in: %s', "\n\n- ".implode("\n- ", $paths))
-            );
         }
 
         $purger = new MongoDBPurger($dm);

--- a/DependencyInjection/Compiler/FixturesCompilerPass.php
+++ b/DependencyInjection/Compiler/FixturesCompilerPass.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * This file is part of the Doctrine Fixtures Bundle
+ *
+ * The code was originally distributed inside the Symfony framework.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ * (c) Doctrine Project
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Doctrine\Bundle\MongoDBBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+final class FixturesCompilerPass implements CompilerPassInterface
+{
+    const FIXTURE_TAG = 'doctrine.fixture.odm.mongodb';
+
+    public function process(ContainerBuilder $container)
+    {
+        $definition = $container->getDefinition('doctrine_mongodb.odm.symfony.fixtures.loader');
+        $taggedServices = $container->findTaggedServiceIds(self::FIXTURE_TAG);
+
+        $fixtures = [];
+        foreach ($taggedServices as $serviceId => $tags) {
+            $groups = [];
+            foreach ($tags as $tagData) {
+                if (! isset($tagData['group'])) {
+                    continue;
+                }
+
+                $groups[] = $tagData['group'];
+            }
+
+            $fixtures[] = [
+                'fixture' => new Reference($serviceId),
+                'groups' => $groups,
+            ];
+        }
+
+        $definition->addMethodCall('addFixtures', [$fixtures]);
+    }
+}

--- a/DependencyInjection/DoctrineMongoDBExtension.php
+++ b/DependencyInjection/DoctrineMongoDBExtension.php
@@ -3,7 +3,9 @@
 
 namespace Doctrine\Bundle\MongoDBBundle\DependencyInjection;
 
+use Doctrine\Bundle\MongoDBBundle\DependencyInjection\Compiler\FixturesCompilerPass;
 use Doctrine\Bundle\MongoDBBundle\DependencyInjection\Compiler\ServiceRepositoryCompilerPass;
+use Doctrine\Bundle\MongoDBBundle\Fixture\ODMFixtureInterface;
 use Doctrine\Bundle\MongoDBBundle\Repository\ServiceDocumentRepositoryInterface;
 use Doctrine\Common\EventSubscriber;
 use Symfony\Bridge\Doctrine\DependencyInjection\AbstractDoctrineExtension;
@@ -56,6 +58,10 @@ class DoctrineMongoDBExtension extends AbstractDoctrineExtension
 
         // set the fixtures loader
         $container->setParameter('doctrine_mongodb.odm.fixture_loader', $config['fixture_loader']);
+
+        // Autowiring fixture loader
+        $container->registerForAutoconfiguration(ODMFixtureInterface::class)
+            ->addTag(FixturesCompilerPass::FIXTURE_TAG);
 
         // load the connections
         $this->loadConnections($config['connections'], $container);

--- a/DoctrineMongoDBBundle.php
+++ b/DoctrineMongoDBBundle.php
@@ -3,6 +3,7 @@
 
 namespace Doctrine\Bundle\MongoDBBundle;
 
+use Doctrine\Bundle\MongoDBBundle\DependencyInjection\Compiler\FixturesCompilerPass;
 use Doctrine\Bundle\MongoDBBundle\DependencyInjection\Compiler\ServiceRepositoryCompilerPass;
 use Doctrine\Common\Util\ClassUtils;
 use Doctrine\Bundle\MongoDBBundle\DependencyInjection\Compiler\CreateHydratorDirectoryPass;
@@ -33,6 +34,7 @@ class DoctrineMongoDBBundle extends Bundle
         $container->addCompilerPass(new CreateHydratorDirectoryPass(), PassConfig::TYPE_BEFORE_REMOVING);
         $container->addCompilerPass(new DoctrineValidationPass('mongodb'));
         $container->addCompilerPass(new ServiceRepositoryCompilerPass());
+        $container->addCompilerPass(new FixturesCompilerPass());
 
         if ($container->hasExtension('security')) {
             $container->getExtension('security')->addUserProviderFactory(new EntityFactory('mongodb', 'doctrine_mongodb.odm.security.user.provider'));

--- a/Fixture/Fixture.php
+++ b/Fixture/Fixture.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Doctrine\Bundle\MongoDBBundle\Fixture;
+
+use Doctrine\Common\DataFixtures\AbstractFixture;
+
+/**
+ * Base class designed for data fixtures so they don't have to extend and
+ * implement different classes/interfaces according to their needs.
+ */
+abstract class Fixture extends AbstractFixture implements ODMFixtureInterface
+{
+}

--- a/Fixture/FixtureGroupInterface.php
+++ b/Fixture/FixtureGroupInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Doctrine\Bundle\MongoDBBundle\Fixture;
+
+/**
+ * FixtureGroupInterface can be implemented by fixtures that belong in groups
+ */
+interface FixtureGroupInterface
+{
+    /**
+     * This method must return an array of groups
+     * on which the implementing class belongs to
+     *
+     * @return string[]
+     */
+    public static function getGroups();
+}

--- a/Fixture/ODMFixtureInterface.php
+++ b/Fixture/ODMFixtureInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Doctrine\Bundle\MongoDBBundle\Fixture;
+
+use Doctrine\Common\DataFixtures\FixtureInterface;
+
+/**
+ * Marks your fixtures that are specifically for the ODM.
+ */
+interface ODMFixtureInterface extends FixtureInterface
+{
+}

--- a/Loader/SymfonyFixturesLoader.php
+++ b/Loader/SymfonyFixturesLoader.php
@@ -1,0 +1,150 @@
+<?php
+
+namespace Doctrine\Bundle\MongoDBBundle\Loader;
+
+use Doctrine\Bundle\MongoDBBundle\DependencyInjection\Compiler\FixturesCompilerPass;
+use Doctrine\Bundle\MongoDBBundle\Fixture\FixtureGroupInterface;
+use Doctrine\Common\DataFixtures\DependentFixtureInterface;
+use Doctrine\Common\DataFixtures\FixtureInterface;
+use LogicException;
+use ReflectionClass;
+use RuntimeException;
+use Symfony\Bridge\Doctrine\DataFixtures\ContainerAwareLoader;
+use function array_key_exists;
+use function array_values;
+use function get_class;
+use function sprintf;
+
+final class SymfonyFixturesLoader extends ContainerAwareLoader implements SymfonyFixturesLoaderInterface
+{
+    /** @var FixtureInterface[] */
+    private $loadedFixtures = [];
+
+    /** @var array<string, array<string, bool>> */
+    private $groupsFixtureMapping = [];
+
+    /**
+     * @internal
+     * @param array $fixtures
+     */
+    public function addFixtures(array $fixtures)
+    {
+        // Because parent::addFixture may call $this->createFixture
+        // we cannot call $this->addFixture in this loop
+        foreach ($fixtures as $fixture) {
+            $class                        = get_class($fixture['fixture']);
+            $this->loadedFixtures[$class] = $fixture['fixture'];
+            $this->addGroupsFixtureMapping($class, $fixture['groups']);
+        }
+
+        // Now that all fixtures are in the $this->loadedFixtures array,
+        // it is safe to call $this->addFixture in this loop
+        foreach ($this->loadedFixtures as $fixture) {
+            $this->addFixture($fixture);
+        }
+    }
+
+    public function addFixture(FixtureInterface $fixture)
+    {
+        $class                        = get_class($fixture);
+        $this->loadedFixtures[$class] = $fixture;
+
+        $reflection = new ReflectionClass($fixture);
+        $this->addGroupsFixtureMapping($class, [$reflection->getShortName()]);
+
+        if ($fixture instanceof FixtureGroupInterface) {
+            $this->addGroupsFixtureMapping($class, $fixture::getGroups());
+        }
+
+        parent::addFixture($fixture);
+    }
+
+    /**
+     * Overridden to not allow new fixture classes to be instantiated.
+     *
+     * @param string $class
+     * @return FixtureInterface
+     */
+    protected function createFixture($class)
+    {
+        /*
+         * We don't actually need to create the fixture. We just
+         * return the one that already exists.
+         */
+
+        if (! isset($this->loadedFixtures[$class])) {
+            throw new LogicException(sprintf(
+                'The "%s" fixture class is trying to be loaded, but is not available. Make sure this class is defined as a service and tagged with "%s".',
+                $class,
+                FixturesCompilerPass::FIXTURE_TAG
+            ));
+        }
+
+        return $this->loadedFixtures[$class];
+    }
+
+    /**
+     * Returns the array of data fixtures to execute.
+     *
+     * @param string[] $groups
+     *
+     * @return FixtureInterface[]
+     */
+    public function getFixtures(array $groups = [])
+    {
+        $fixtures = parent::getFixtures();
+
+        if (empty($groups)) {
+            return $fixtures;
+        }
+
+        $filteredFixtures = [];
+        foreach ($fixtures as $fixture) {
+            foreach ($groups as $group) {
+                $fixtureClass = get_class($fixture);
+                if (isset($this->groupsFixtureMapping[$group][$fixtureClass])) {
+                    $filteredFixtures[$fixtureClass] = $fixture;
+                    continue 2;
+                }
+            }
+        }
+
+        foreach ($filteredFixtures as $fixture) {
+            $this->validateDependencies($filteredFixtures, $fixture);
+        }
+
+        return array_values($filteredFixtures);
+    }
+
+    /**
+     * Generates an array of the groups and their fixtures
+     *
+     * @param $className
+     * @param string[] $groups
+     */
+    private function addGroupsFixtureMapping($className, array $groups)
+    {
+        foreach ($groups as $group) {
+            $this->groupsFixtureMapping[$group][$className] = true;
+        }
+    }
+
+    /**
+     * @param string[] $fixtures An array of fixtures with class names as keys
+     * @param FixtureInterface $fixture
+     */
+    private function validateDependencies(array $fixtures, FixtureInterface $fixture)
+    {
+        if (! $fixture instanceof DependentFixtureInterface) {
+            return;
+        }
+
+        $dependenciesClasses = $fixture->getDependencies();
+
+        foreach ($dependenciesClasses as $class) {
+            if (! array_key_exists($class, $fixtures)) {
+                throw new RuntimeException(sprintf('Fixture "%s" was declared as a dependency for fixture "%s", but it was not included in any of the loaded fixture groups.', $class, get_class($fixture)));
+            }
+        }
+    }
+}

--- a/Loader/SymfonyFixturesLoader.php
+++ b/Loader/SymfonyFixturesLoader.php
@@ -6,6 +6,7 @@ use Doctrine\Bundle\MongoDBBundle\DependencyInjection\Compiler\FixturesCompilerP
 use Doctrine\Bundle\MongoDBBundle\Fixture\FixtureGroupInterface;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Common\DataFixtures\FixtureInterface;
+use Doctrine\Common\DataFixtures\Loader;
 use LogicException;
 use ReflectionClass;
 use RuntimeException;
@@ -48,6 +49,12 @@ final class SymfonyFixturesLoader extends ContainerAwareLoader implements Symfon
     {
         $class                        = get_class($fixture);
         $this->loadedFixtures[$class] = $fixture;
+
+        // see https://github.com/doctrine/data-fixtures/pull/274
+        // this is to give a clear error if you do not have this version
+        if (!method_exists(Loader::class, 'createFixture')) {
+            $this->checkForNonInstantiableFixtures($fixture);
+        }
 
         $reflection = new ReflectionClass($fixture);
         $this->addGroupsFixtureMapping($class, [$reflection->getShortName()]);
@@ -144,6 +151,38 @@ final class SymfonyFixturesLoader extends ContainerAwareLoader implements Symfon
         foreach ($dependenciesClasses as $class) {
             if (! array_key_exists($class, $fixtures)) {
                 throw new RuntimeException(sprintf('Fixture "%s" was declared as a dependency for fixture "%s", but it was not included in any of the loaded fixture groups.', $class, get_class($fixture)));
+            }
+        }
+    }
+
+    /**
+     * For doctrine/data-fixtures 1.2 or lower, this detects an unsupported
+     * feature with DependentFixtureInterface so that we can throw a
+     * clear exception.
+     *
+     * @param FixtureInterface $fixture
+     * @throws \Exception
+     */
+    private function checkForNonInstantiableFixtures(FixtureInterface $fixture)
+    {
+        if (!$fixture instanceof DependentFixtureInterface) {
+            return;
+        }
+
+        foreach ($fixture->getDependencies() as $dependency) {
+            if (!class_exists($dependency)) {
+                continue;
+            }
+
+            if (!method_exists($dependency, '__construct')) {
+                continue;
+            }
+
+            $reflMethod = new \ReflectionMethod($dependency, '__construct');
+            foreach ($reflMethod->getParameters() as $param) {
+                if (!$param->isOptional()) {
+                    throw new \LogicException(sprintf('The getDependencies() method returned a class (%s) that has required constructor arguments. Upgrade to "doctrine/data-fixtures" version 1.3 or higher to support this.', $dependency));
+                }
             }
         }
     }

--- a/Loader/SymfonyFixturesLoader.php
+++ b/Loader/SymfonyFixturesLoader.php
@@ -27,7 +27,7 @@ final class SymfonyFixturesLoader extends ContainerAwareLoader implements Symfon
      * @internal
      * @param array $fixtures
      */
-    public function addFixtures(array $fixtures)
+    public function addFixtures($fixtures)
     {
         // Because parent::addFixture may call $this->createFixture
         // we cannot call $this->addFixture in this loop
@@ -90,7 +90,7 @@ final class SymfonyFixturesLoader extends ContainerAwareLoader implements Symfon
      *
      * @return FixtureInterface[]
      */
-    public function getFixtures(array $groups = [])
+    public function getFixtures($groups = [])
     {
         $fixtures = parent::getFixtures();
 

--- a/Loader/SymfonyFixturesLoaderInterface.php
+++ b/Loader/SymfonyFixturesLoaderInterface.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Doctrine\Bundle\MongoDBBundle\Loader;
+
+use Doctrine\Common\DataFixtures\FixtureInterface;
+
+interface SymfonyFixturesLoaderInterface
+{
+    /**
+     * Add multple fixtures
+     *
+     * @internal
+     * @param array $fixtures
+     */
+    public function addFixtures(array $fixtures);
+
+    /**
+     * Add a single fixture
+     *
+     * @param FixtureInterface $fixture
+     * @return mixed
+     */
+    public function addFixture(FixtureInterface $fixture);
+
+    /**
+     * Returns the array of data fixtures to execute.
+     *
+     * @param string[] $groups
+     *
+     * @return FixtureInterface[]
+     */
+    public function getFixtures(array $groups = []);
+}

--- a/Loader/SymfonyFixturesLoaderInterface.php
+++ b/Loader/SymfonyFixturesLoaderInterface.php
@@ -12,7 +12,7 @@ interface SymfonyFixturesLoaderInterface
      * @internal
      * @param array $fixtures
      */
-    public function addFixtures(array $fixtures);
+    public function addFixtures($fixtures);
 
     /**
      * Add a single fixture
@@ -29,5 +29,5 @@ interface SymfonyFixturesLoaderInterface
      *
      * @return FixtureInterface[]
      */
-    public function getFixtures(array $groups = []);
+    public function getFixtures($groups = []);
 }

--- a/Resources/config/mongodb.xml
+++ b/Resources/config/mongodb.xml
@@ -92,6 +92,7 @@
         <service id="Doctrine\Bundle\MongoDBBundle\Command\LoadDataFixturesDoctrineODMCommand" class="Doctrine\Bundle\MongoDBBundle\Command\LoadDataFixturesDoctrineODMCommand">
             <argument type="service" id="doctrine_mongodb"/>
             <argument type="service" id="kernel" on-invalid="null"/>
+            <argument type="service" id="doctrine_mongodb.odm.symfony.fixtures.loader" />
 
             <tag name="console.command"/>
         </service>
@@ -210,5 +211,9 @@
 
         <!-- listeners -->
         <service id="doctrine_mongodb.odm.listeners.resolve_target_document" class="%doctrine_mongodb.odm.listeners.resolve_target_document.class%" public="false" />
+
+        <service id="doctrine_mongodb.odm.symfony.fixtures.loader" class="Doctrine\Bundle\MongoDBBundle\Loader\SymfonyFixturesLoader" public="false">
+            <argument type="service" id="service_container" />
+        </service>
     </services>
 </container>

--- a/Tests/Command/LoadDataFixturesDoctrineODMCommandTest.php
+++ b/Tests/Command/LoadDataFixturesDoctrineODMCommandTest.php
@@ -3,6 +3,7 @@
 namespace Doctrine\Bundle\MongoDBBundle\Tests\Command;
 
 use Doctrine\Bundle\MongoDBBundle\Command\LoadDataFixturesDoctrineODMCommand;
+use Doctrine\Bundle\MongoDBBundle\Loader\SymfonyFixturesLoaderInterface;
 use Doctrine\Bundle\MongoDBBundle\ManagerRegistry;
 use Doctrine\Common\DataFixtures\Loader;
 use PHPUnit\Framework\TestCase;
@@ -17,8 +18,9 @@ class LoadDataFixturesDoctrineODMCommandTest extends TestCase
     {
         $registry = $this->createMock(ManagerRegistry::class);
         $kernel = $this->createMock(KernelInterface::class);
+        $loader = $this->createMock(SymfonyFixturesLoaderInterface::class);
 
-        $this->command = new LoadDataFixturesDoctrineODMCommand($registry, $kernel);
+        $this->command = new LoadDataFixturesDoctrineODMCommand($registry, $kernel, $loader);
     }
 
     public function testCommandIsNotEnabledWithMissingDependency()

--- a/Tests/FixtureIntegrationTest.php
+++ b/Tests/FixtureIntegrationTest.php
@@ -1,0 +1,375 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Bundle\MongoDBBundle\Tests;
+
+use Doctrine\Bundle\MongoDBBundle\DependencyInjection\Compiler\FixturesCompilerPass;
+use Doctrine\Bundle\MongoDBBundle\DoctrineMongoDBBundle;
+use Doctrine\Bundle\MongoDBBundle\Tests\Fixtures\FooBundle\DataFixtures\DependentOnRequiredConstructorArgsFixtures;
+use Doctrine\Bundle\MongoDBBundle\Tests\Fixtures\FooBundle\DataFixtures\OtherFixtures;
+use Doctrine\Bundle\MongoDBBundle\Tests\Fixtures\FooBundle\DataFixtures\RequiredConstructorArgsFixtures;
+use Doctrine\Bundle\MongoDBBundle\Tests\Fixtures\FooBundle\DataFixtures\WithDependenciesFixtures;
+use Doctrine\Bundle\MongoDBBundle\Tests\Fixtures\FooBundle\FooBundle;
+use Doctrine\Common\DataFixtures\Loader;
+use RuntimeException;
+use Stubs\DocumentManager;
+use Symfony\Bridge\Doctrine\DataFixtures\ContainerAwareLoader;
+use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
+use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
+use Symfony\Component\Config\Loader\LoaderInterface;
+use Symfony\Component\DependencyInjection\Alias;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\HttpKernel\Kernel;
+use Symfony\Component\Routing\RouteCollectionBuilder;
+use function array_map;
+use function get_class;
+use function method_exists;
+use function rand;
+use function sys_get_temp_dir;
+
+class FixtureIntegrationTest extends TestCase
+{
+    protected function setUp()
+    {
+        if (! class_exists(Loader::class)) {
+            $this->markTestSkipped();
+        }
+    }
+
+    public function testFixturesLoader(): void
+    {
+        $kernel = new IntegrationTestKernel('dev', true);
+        $kernel->addServices(static function (ContainerBuilder $c): void {
+            $c->autowire(OtherFixtures::class)
+                ->addTag(FixturesCompilerPass::FIXTURE_TAG);
+
+            $c->autowire(WithDependenciesFixtures::class)
+                ->addTag(FixturesCompilerPass::FIXTURE_TAG);
+
+            $c->setAlias('test.doctrine_mongodb.odm.symfony.fixtures.loader', new Alias('doctrine_mongodb.odm.symfony.fixtures.loader', true));
+        });
+        $kernel->boot();
+        $container = $kernel->getContainer();
+
+        /** @var ContainerAwareLoader $loader */
+        $loader = $container->get('test.doctrine_mongodb.odm.symfony.fixtures.loader');
+
+        $actualFixtures = $loader->getFixtures();
+        $this->assertCount(2, $actualFixtures);
+        $actualFixtureClasses = array_map(static function ($fixture) {
+            return get_class($fixture);
+        }, $actualFixtures);
+
+        $this->assertSame([
+            OtherFixtures::class,
+            WithDependenciesFixtures::class,
+        ], $actualFixtureClasses);
+        $this->assertInstanceOf(WithDependenciesFixtures::class, $actualFixtures[1]);
+    }
+
+    public function testFixturesLoaderWhenFixtureHasDependencyThatIsNotYetLoaded(): void
+    {
+        // See https://github.com/doctrine/DoctrineFixturesBundle/issues/215
+
+        $kernel = new IntegrationTestKernel('dev', true);
+        $kernel->addServices(static function (ContainerBuilder $c): void {
+            $c->autowire(WithDependenciesFixtures::class)
+                ->addTag(FixturesCompilerPass::FIXTURE_TAG);
+
+            $c->autowire(OtherFixtures::class)
+                ->addTag(FixturesCompilerPass::FIXTURE_TAG);
+
+            $c->setAlias('test.doctrine_mongodb.odm.symfony.fixtures.loader', new Alias('doctrine_mongodb.odm.symfony.fixtures.loader', true));
+        });
+        $kernel->boot();
+        $container = $kernel->getContainer();
+
+        /** @var ContainerAwareLoader $loader */
+        $loader = $container->get('test.doctrine_mongodb.odm.symfony.fixtures.loader');
+
+        $actualFixtures = $loader->getFixtures();
+        $this->assertCount(2, $actualFixtures);
+        $actualFixtureClasses = array_map(static function ($fixture) {
+            return get_class($fixture);
+        }, $actualFixtures);
+
+        $this->assertSame([
+            OtherFixtures::class,
+            WithDependenciesFixtures::class,
+        ], $actualFixtureClasses);
+        $this->assertInstanceOf(WithDependenciesFixtures::class, $actualFixtures[1]);
+    }
+
+    /**
+     * @expectedException \LogicException
+     * @expectedExceptionMessage The getDependencies() method returned a class (Doctrine\Bundle\MongoDBBundle\Tests\Fixtures\FooBundle\DataFixtures\RequiredConstructorArgsFixtures) that has required constructor arguments. Upgrade to "doctrine/data-fixtures" version 1.3 or higher to support this.
+     */
+    public function testExceptionWithDependenciesWithRequiredArguments(): void
+    {
+        // see https://github.com/doctrine/data-fixtures/pull/274
+        // When that is merged, this test will only run when using
+        // an older version of that library.
+        if (method_exists(Loader::class, 'createFixture')) {
+            $this->markTestSkipped();
+        }
+
+        $kernel = new IntegrationTestKernel('dev', true);
+        $kernel->addServices(static function (ContainerBuilder $c) {
+            $c->autowire(DependentOnRequiredConstructorArgsFixtures::class)
+                ->addTag(FixturesCompilerPass::FIXTURE_TAG);
+
+            $c->autowire(RequiredConstructorArgsFixtures::class)
+                ->setArgument(0, 'foo')
+                ->addTag(FixturesCompilerPass::FIXTURE_TAG);
+
+            $c->setAlias('test.doctrine_mongodb.odm.symfony.fixtures.loader', new Alias('doctrine_mongodb.odm.symfony.fixtures.loader', true));
+        });
+        $kernel->boot();
+        $container = $kernel->getContainer();
+
+        /** @var ContainerAwareLoader $loader */
+        $loader = $container->get('test.doctrine_mongodb.odm.symfony.fixtures.loader');
+
+        $loader->getFixtures();
+    }
+
+    /**
+     * @expectedException \LogicException
+     * @expectedExceptionMessage The "Doctrine\Bundle\MongoDBBundle\Tests\Fixtures\FooBundle\DataFixtures\RequiredConstructorArgsFixtures" fixture class is trying to be loaded, but is not available. Make sure this class is defined as a service and tagged with "doctrine.fixture.odm.mongodb".
+     */
+    public function testExceptionIfDependentFixtureNotWired(): void
+    {
+        // only runs on newer versions of doctrine/data-fixtures
+        if (! method_exists(Loader::class, 'createFixture')) {
+            $this->markTestSkipped();
+        }
+
+        $kernel = new IntegrationTestKernel('dev', true);
+        $kernel->addServices(static function (ContainerBuilder $c): void {
+            $c->autowire(DependentOnRequiredConstructorArgsFixtures::class)
+                ->addTag(FixturesCompilerPass::FIXTURE_TAG);
+
+            $c->setAlias('test.doctrine_mongodb.odm.symfony.fixtures.loader', new Alias('doctrine_mongodb.odm.symfony.fixtures.loader', true));
+        });
+        $kernel->boot();
+        $container = $kernel->getContainer();
+
+        /** @var ContainerAwareLoader $loader */
+        $loader = $container->get('test.doctrine_mongodb.odm.symfony.fixtures.loader');
+
+        $loader->getFixtures();
+    }
+
+    public function testFixturesLoaderWithGroupsOptionViaInterface(): void
+    {
+        $kernel = new IntegrationTestKernel('dev', true);
+        $kernel->addServices(static function (ContainerBuilder $c): void {
+            // has a "staging" group via the getGroups() method
+            $c->autowire(OtherFixtures::class)
+                ->addTag(FixturesCompilerPass::FIXTURE_TAG);
+
+            // no getGroups() method
+            $c->autowire(WithDependenciesFixtures::class)
+                ->addTag(FixturesCompilerPass::FIXTURE_TAG);
+
+            $c->setAlias('test.doctrine_mongodb.odm.symfony.fixtures.loader', new Alias('doctrine_mongodb.odm.symfony.fixtures.loader', true));
+        });
+        $kernel->boot();
+        $container = $kernel->getContainer();
+
+        /** @var ContainerAwareLoader $loader */
+        $loader = $container->get('test.doctrine_mongodb.odm.symfony.fixtures.loader');
+
+        $actualFixtures = $loader->getFixtures(['staging']);
+        $this->assertCount(1, $actualFixtures);
+        $actualFixtureClasses = array_map(static function ($fixture) {
+            return get_class($fixture);
+        }, $actualFixtures);
+
+        $this->assertSame([
+            OtherFixtures::class,
+        ], $actualFixtureClasses);
+        $this->assertInstanceOf(OtherFixtures::class, $actualFixtures[0]);
+    }
+
+    public function testFixturesLoaderWithGroupsOptionViaTag(): void
+    {
+        $kernel = new IntegrationTestKernel('dev', true);
+        $kernel->addServices(static function (ContainerBuilder $c): void {
+            // has a "staging" group via the getGroups() method
+            $c->autowire(OtherFixtures::class)
+                ->addTag(FixturesCompilerPass::FIXTURE_TAG, ['group' => 'group1'])
+                ->addTag(FixturesCompilerPass::FIXTURE_TAG, ['group' => 'group2']);
+
+            // no getGroups() method
+            $c->autowire(WithDependenciesFixtures::class)
+                ->addTag(FixturesCompilerPass::FIXTURE_TAG, ['group' => 'group2']);
+
+            $c->setAlias('test.doctrine_mongodb.odm.symfony.fixtures.loader', new Alias('doctrine_mongodb.odm.symfony.fixtures.loader', true));
+        });
+        $kernel->boot();
+        $container = $kernel->getContainer();
+
+        /** @var ContainerAwareLoader $loader */
+        $loader = $container->get('test.doctrine_mongodb.odm.symfony.fixtures.loader');
+
+        $this->assertCount(1, $loader->getFixtures(['staging']));
+        $this->assertCount(1, $loader->getFixtures(['group1']));
+        $this->assertCount(2, $loader->getFixtures(['group2']));
+        $this->assertCount(0, $loader->getFixtures(['group3']));
+    }
+
+    public function testLoadFixturesViaGroupWithMissingDependency(): void
+    {
+        $kernel = new IntegrationTestKernel('dev', true);
+        $kernel->addServices(static function (ContainerBuilder $c): void {
+            // has a "staging" group via the getGroups() method
+            $c->autowire(OtherFixtures::class)
+                ->addTag(FixturesCompilerPass::FIXTURE_TAG);
+
+            // no getGroups() method
+            $c->autowire(WithDependenciesFixtures::class)
+                ->addTag(FixturesCompilerPass::FIXTURE_TAG);
+
+            $c->setAlias('test.doctrine_mongodb.odm.symfony.fixtures.loader', new Alias('doctrine_mongodb.odm.symfony.fixtures.loader', true));
+        });
+        $kernel->boot();
+        $container = $kernel->getContainer();
+
+        /** @var ContainerAwareLoader $loader */
+        $loader = $container->get('test.doctrine_mongodb.odm.symfony.fixtures.loader');
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Fixture "Doctrine\Bundle\MongoDBBundle\Tests\Fixtures\FooBundle\DataFixtures\OtherFixtures" was declared as a dependency for fixture "Doctrine\Bundle\MongoDBBundle\Tests\Fixtures\FooBundle\DataFixtures\WithDependenciesFixtures", but it was not included in any of the loaded fixture groups.');
+
+        $loader->getFixtures(['missingDependencyGroup']);
+    }
+
+    public function testLoadFixturesViaGroupWithFulfilledDependency(): void
+    {
+        $kernel = new IntegrationTestKernel('dev', true);
+        $kernel->addServices(static function (ContainerBuilder $c): void {
+            // has a "staging" group via the getGroups() method
+            $c->autowire(OtherFixtures::class)
+                ->addTag(FixturesCompilerPass::FIXTURE_TAG);
+
+            // no getGroups() method
+            $c->autowire(WithDependenciesFixtures::class)
+                ->addTag(FixturesCompilerPass::FIXTURE_TAG);
+
+            $c->setAlias('test.doctrine_mongodb.odm.symfony.fixtures.loader', new Alias('doctrine_mongodb.odm.symfony.fixtures.loader', true));
+        });
+        $kernel->boot();
+        $container = $kernel->getContainer();
+
+        /** @var ContainerAwareLoader $loader */
+        $loader = $container->get('test.doctrine_mongodb.odm.symfony.fixtures.loader');
+
+        $actualFixtures = $loader->getFixtures(['fulfilledDependencyGroup']);
+
+        $this->assertCount(2, $actualFixtures);
+        $actualFixtureClasses = array_map(static function ($fixture) {
+            return get_class($fixture);
+        }, $actualFixtures);
+
+        $this->assertSame([
+            OtherFixtures::class,
+            WithDependenciesFixtures::class,
+        ], $actualFixtureClasses);
+    }
+
+    public function testLoadFixturesByShortName(): void
+    {
+        $kernel = new IntegrationTestKernel('dev', true);
+        $kernel->addServices(static function (ContainerBuilder $c): void {
+            // has a "staging" group via the getGroups() method
+            $c->autowire(OtherFixtures::class)
+                ->addTag(FixturesCompilerPass::FIXTURE_TAG);
+
+            // no getGroups() method
+            $c->autowire(WithDependenciesFixtures::class)
+                ->addTag(FixturesCompilerPass::FIXTURE_TAG);
+
+            $c->setAlias('test.doctrine_mongodb.odm.symfony.fixtures.loader', new Alias('doctrine_mongodb.odm.symfony.fixtures.loader', true));
+        });
+        $kernel->boot();
+        $container = $kernel->getContainer();
+
+        /** @var ContainerAwareLoader $loader */
+        $loader = $container->get('test.doctrine_mongodb.odm.symfony.fixtures.loader');
+
+        $actualFixtures = $loader->getFixtures(['OtherFixtures']);
+
+        $this->assertCount(1, $actualFixtures);
+        $actualFixtureClasses = array_map(static function ($fixture) {
+            return get_class($fixture);
+        }, $actualFixtures);
+
+        $this->assertSame([
+            OtherFixtures::class,
+        ], $actualFixtureClasses);
+    }
+}
+
+class IntegrationTestKernel extends Kernel
+{
+    use MicroKernelTrait;
+
+    /** @var callable */
+    private $servicesCallback;
+
+    /** @var int */
+    private $randomKey;
+
+    public function __construct(string $environment, bool $debug)
+    {
+        $this->randomKey = rand(100, 999);
+
+        parent::__construct($environment, $debug);
+    }
+
+    protected function getContainerClass(): string
+    {
+        return 'test' . $this->randomKey . parent::getContainerClass();
+    }
+
+    public function registerBundles(): array
+    {
+        return [
+            new FrameworkBundle(),
+            new DoctrineMongoDBBundle(),
+            new FooBundle(),
+        ];
+    }
+
+    public function addServices(callable $callback): void
+    {
+        $this->servicesCallback = $callback;
+    }
+
+    protected function configureRoutes(RouteCollectionBuilder $routes): void
+    {
+    }
+
+    protected function configureContainer(ContainerBuilder $c, LoaderInterface $loader): void
+    {
+        $c->setParameter('kernel.secret', 'foo');
+
+        // Inject a mock document manager to avoid errors with a BC alias
+        $c->autowire('doctrine_mongodb.odm.document_manager', DocumentManager::class);
+
+        $callback = $this->servicesCallback;
+        $callback($c);
+    }
+
+    public function getCacheDir(): string
+    {
+        return sys_get_temp_dir() . '/doctrine_mongodb_odm_bundle' . $this->randomKey;
+    }
+
+    public function getLogDir(): string
+    {
+        return sys_get_temp_dir();
+    }
+}

--- a/Tests/FixtureIntegrationTest.php
+++ b/Tests/FixtureIntegrationTest.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 namespace Doctrine\Bundle\MongoDBBundle\Tests;
 
 use Doctrine\Bundle\MongoDBBundle\DependencyInjection\Compiler\FixturesCompilerPass;
@@ -37,10 +35,10 @@ class FixtureIntegrationTest extends TestCase
         }
     }
 
-    public function testFixturesLoader(): void
+    public function testFixturesLoader()
     {
         $kernel = new IntegrationTestKernel('dev', true);
-        $kernel->addServices(static function (ContainerBuilder $c): void {
+        $kernel->addServices(static function (ContainerBuilder $c) {
             $c->autowire(OtherFixtures::class)
                 ->addTag(FixturesCompilerPass::FIXTURE_TAG);
 
@@ -68,12 +66,12 @@ class FixtureIntegrationTest extends TestCase
         $this->assertInstanceOf(WithDependenciesFixtures::class, $actualFixtures[1]);
     }
 
-    public function testFixturesLoaderWhenFixtureHasDependencyThatIsNotYetLoaded(): void
+    public function testFixturesLoaderWhenFixtureHasDependencyThatIsNotYetLoaded()
     {
         // See https://github.com/doctrine/DoctrineFixturesBundle/issues/215
 
         $kernel = new IntegrationTestKernel('dev', true);
-        $kernel->addServices(static function (ContainerBuilder $c): void {
+        $kernel->addServices(static function (ContainerBuilder $c) {
             $c->autowire(WithDependenciesFixtures::class)
                 ->addTag(FixturesCompilerPass::FIXTURE_TAG);
 
@@ -105,7 +103,7 @@ class FixtureIntegrationTest extends TestCase
      * @expectedException \LogicException
      * @expectedExceptionMessage The getDependencies() method returned a class (Doctrine\Bundle\MongoDBBundle\Tests\Fixtures\FooBundle\DataFixtures\RequiredConstructorArgsFixtures) that has required constructor arguments. Upgrade to "doctrine/data-fixtures" version 1.3 or higher to support this.
      */
-    public function testExceptionWithDependenciesWithRequiredArguments(): void
+    public function testExceptionWithDependenciesWithRequiredArguments()
     {
         // see https://github.com/doctrine/data-fixtures/pull/274
         // When that is merged, this test will only run when using
@@ -138,7 +136,7 @@ class FixtureIntegrationTest extends TestCase
      * @expectedException \LogicException
      * @expectedExceptionMessage The "Doctrine\Bundle\MongoDBBundle\Tests\Fixtures\FooBundle\DataFixtures\RequiredConstructorArgsFixtures" fixture class is trying to be loaded, but is not available. Make sure this class is defined as a service and tagged with "doctrine.fixture.odm.mongodb".
      */
-    public function testExceptionIfDependentFixtureNotWired(): void
+    public function testExceptionIfDependentFixtureNotWired()
     {
         // only runs on newer versions of doctrine/data-fixtures
         if (! method_exists(Loader::class, 'createFixture')) {
@@ -146,7 +144,7 @@ class FixtureIntegrationTest extends TestCase
         }
 
         $kernel = new IntegrationTestKernel('dev', true);
-        $kernel->addServices(static function (ContainerBuilder $c): void {
+        $kernel->addServices(static function (ContainerBuilder $c) {
             $c->autowire(DependentOnRequiredConstructorArgsFixtures::class)
                 ->addTag(FixturesCompilerPass::FIXTURE_TAG);
 
@@ -161,10 +159,10 @@ class FixtureIntegrationTest extends TestCase
         $loader->getFixtures();
     }
 
-    public function testFixturesLoaderWithGroupsOptionViaInterface(): void
+    public function testFixturesLoaderWithGroupsOptionViaInterface()
     {
         $kernel = new IntegrationTestKernel('dev', true);
-        $kernel->addServices(static function (ContainerBuilder $c): void {
+        $kernel->addServices(static function (ContainerBuilder $c) {
             // has a "staging" group via the getGroups() method
             $c->autowire(OtherFixtures::class)
                 ->addTag(FixturesCompilerPass::FIXTURE_TAG);
@@ -193,10 +191,10 @@ class FixtureIntegrationTest extends TestCase
         $this->assertInstanceOf(OtherFixtures::class, $actualFixtures[0]);
     }
 
-    public function testFixturesLoaderWithGroupsOptionViaTag(): void
+    public function testFixturesLoaderWithGroupsOptionViaTag()
     {
         $kernel = new IntegrationTestKernel('dev', true);
-        $kernel->addServices(static function (ContainerBuilder $c): void {
+        $kernel->addServices(static function (ContainerBuilder $c) {
             // has a "staging" group via the getGroups() method
             $c->autowire(OtherFixtures::class)
                 ->addTag(FixturesCompilerPass::FIXTURE_TAG, ['group' => 'group1'])
@@ -220,10 +218,10 @@ class FixtureIntegrationTest extends TestCase
         $this->assertCount(0, $loader->getFixtures(['group3']));
     }
 
-    public function testLoadFixturesViaGroupWithMissingDependency(): void
+    public function testLoadFixturesViaGroupWithMissingDependency()
     {
         $kernel = new IntegrationTestKernel('dev', true);
-        $kernel->addServices(static function (ContainerBuilder $c): void {
+        $kernel->addServices(static function (ContainerBuilder $c) {
             // has a "staging" group via the getGroups() method
             $c->autowire(OtherFixtures::class)
                 ->addTag(FixturesCompilerPass::FIXTURE_TAG);
@@ -246,10 +244,10 @@ class FixtureIntegrationTest extends TestCase
         $loader->getFixtures(['missingDependencyGroup']);
     }
 
-    public function testLoadFixturesViaGroupWithFulfilledDependency(): void
+    public function testLoadFixturesViaGroupWithFulfilledDependency()
     {
         $kernel = new IntegrationTestKernel('dev', true);
-        $kernel->addServices(static function (ContainerBuilder $c): void {
+        $kernel->addServices(static function (ContainerBuilder $c) {
             // has a "staging" group via the getGroups() method
             $c->autowire(OtherFixtures::class)
                 ->addTag(FixturesCompilerPass::FIXTURE_TAG);
@@ -279,10 +277,10 @@ class FixtureIntegrationTest extends TestCase
         ], $actualFixtureClasses);
     }
 
-    public function testLoadFixturesByShortName(): void
+    public function testLoadFixturesByShortName()
     {
         $kernel = new IntegrationTestKernel('dev', true);
-        $kernel->addServices(static function (ContainerBuilder $c): void {
+        $kernel->addServices(static function (ContainerBuilder $c) {
             // has a "staging" group via the getGroups() method
             $c->autowire(OtherFixtures::class)
                 ->addTag(FixturesCompilerPass::FIXTURE_TAG);
@@ -322,19 +320,19 @@ class IntegrationTestKernel extends Kernel
     /** @var int */
     private $randomKey;
 
-    public function __construct(string $environment, bool $debug)
+    public function __construct($environment, $debug)
     {
         $this->randomKey = rand(100, 999);
 
         parent::__construct($environment, $debug);
     }
 
-    protected function getContainerClass(): string
+    protected function getContainerClass()
     {
         return 'test' . $this->randomKey . parent::getContainerClass();
     }
 
-    public function registerBundles(): array
+    public function registerBundles()
     {
         return [
             new FrameworkBundle(),
@@ -343,16 +341,16 @@ class IntegrationTestKernel extends Kernel
         ];
     }
 
-    public function addServices(callable $callback): void
+    public function addServices(callable $callback)
     {
         $this->servicesCallback = $callback;
     }
 
-    protected function configureRoutes(RouteCollectionBuilder $routes): void
+    protected function configureRoutes(RouteCollectionBuilder $routes)
     {
     }
 
-    protected function configureContainer(ContainerBuilder $c, LoaderInterface $loader): void
+    protected function configureContainer(ContainerBuilder $c, LoaderInterface $loader)
     {
         $c->setParameter('kernel.secret', 'foo');
 
@@ -363,12 +361,12 @@ class IntegrationTestKernel extends Kernel
         $callback($c);
     }
 
-    public function getCacheDir(): string
+    public function getCacheDir()
     {
         return sys_get_temp_dir() . '/doctrine_mongodb_odm_bundle' . $this->randomKey;
     }
 
-    public function getLogDir(): string
+    public function getLogDir()
     {
         return sys_get_temp_dir();
     }

--- a/Tests/Fixtures/FooBundle/DataFixtures/DependentOnRequiredConstructorArgsFixtures.php
+++ b/Tests/Fixtures/FooBundle/DataFixtures/DependentOnRequiredConstructorArgsFixtures.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Bundle\MongoDBBundle\Tests\Fixtures\FooBundle\DataFixtures;
+
+use Doctrine\Bundle\MongoDBBundle\Fixture\ODMFixtureInterface;
+use Doctrine\Common\DataFixtures\DependentFixtureInterface;
+use Doctrine\Common\Persistence\ObjectManager;
+
+class DependentOnRequiredConstructorArgsFixtures implements ODMFixtureInterface, DependentFixtureInterface
+{
+    public function load(ObjectManager $manager) : void
+    {
+        // ...
+    }
+
+    public function getDependencies() : array
+    {
+        return [RequiredConstructorArgsFixtures::class];
+    }
+}

--- a/Tests/Fixtures/FooBundle/DataFixtures/DependentOnRequiredConstructorArgsFixtures.php
+++ b/Tests/Fixtures/FooBundle/DataFixtures/DependentOnRequiredConstructorArgsFixtures.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 namespace Doctrine\Bundle\MongoDBBundle\Tests\Fixtures\FooBundle\DataFixtures;
 
 use Doctrine\Bundle\MongoDBBundle\Fixture\ODMFixtureInterface;
@@ -10,12 +8,12 @@ use Doctrine\Common\Persistence\ObjectManager;
 
 class DependentOnRequiredConstructorArgsFixtures implements ODMFixtureInterface, DependentFixtureInterface
 {
-    public function load(ObjectManager $manager) : void
+    public function load(ObjectManager $manager)
     {
         // ...
     }
 
-    public function getDependencies() : array
+    public function getDependencies()
     {
         return [RequiredConstructorArgsFixtures::class];
     }

--- a/Tests/Fixtures/FooBundle/DataFixtures/OtherFixtures.php
+++ b/Tests/Fixtures/FooBundle/DataFixtures/OtherFixtures.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Bundle\MongoDBBundle\Tests\Fixtures\FooBundle\DataFixtures;
+
+use Doctrine\Bundle\MongoDBBundle\Fixture\FixtureGroupInterface;
+use Doctrine\Bundle\MongoDBBundle\Fixture\ODMFixtureInterface;
+use Doctrine\Common\Persistence\ObjectManager;
+
+class OtherFixtures implements ODMFixtureInterface, FixtureGroupInterface
+{
+    public function load(ObjectManager $manager) : void
+    {
+        // ...
+    }
+
+    public static function getGroups() : array
+    {
+        return ['staging', 'fulfilledDependencyGroup'];
+    }
+}

--- a/Tests/Fixtures/FooBundle/DataFixtures/OtherFixtures.php
+++ b/Tests/Fixtures/FooBundle/DataFixtures/OtherFixtures.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 namespace Doctrine\Bundle\MongoDBBundle\Tests\Fixtures\FooBundle\DataFixtures;
 
 use Doctrine\Bundle\MongoDBBundle\Fixture\FixtureGroupInterface;
@@ -10,12 +8,12 @@ use Doctrine\Common\Persistence\ObjectManager;
 
 class OtherFixtures implements ODMFixtureInterface, FixtureGroupInterface
 {
-    public function load(ObjectManager $manager) : void
+    public function load(ObjectManager $manager)
     {
         // ...
     }
 
-    public static function getGroups() : array
+    public static function getGroups()
     {
         return ['staging', 'fulfilledDependencyGroup'];
     }

--- a/Tests/Fixtures/FooBundle/DataFixtures/RequiredConstructorArgsFixtures.php
+++ b/Tests/Fixtures/FooBundle/DataFixtures/RequiredConstructorArgsFixtures.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Bundle\MongoDBBundle\Tests\Fixtures\FooBundle\DataFixtures;
+
+use Doctrine\Bundle\MongoDBBundle\Fixture\ODMFixtureInterface;
+use Doctrine\Common\Persistence\ObjectManager;
+
+class RequiredConstructorArgsFixtures implements ODMFixtureInterface
+{
+    public function __construct($fooRequiredArg)
+    {
+    }
+
+    public function load(ObjectManager $manager) : void
+    {
+        // ...
+    }
+}

--- a/Tests/Fixtures/FooBundle/DataFixtures/RequiredConstructorArgsFixtures.php
+++ b/Tests/Fixtures/FooBundle/DataFixtures/RequiredConstructorArgsFixtures.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 namespace Doctrine\Bundle\MongoDBBundle\Tests\Fixtures\FooBundle\DataFixtures;
 
 use Doctrine\Bundle\MongoDBBundle\Fixture\ODMFixtureInterface;
@@ -13,7 +11,7 @@ class RequiredConstructorArgsFixtures implements ODMFixtureInterface
     {
     }
 
-    public function load(ObjectManager $manager) : void
+    public function load(ObjectManager $manager)
     {
         // ...
     }

--- a/Tests/Fixtures/FooBundle/DataFixtures/WithDependenciesFixtures.php
+++ b/Tests/Fixtures/FooBundle/DataFixtures/WithDependenciesFixtures.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Bundle\MongoDBBundle\Tests\Fixtures\FooBundle\DataFixtures;
+
+use Doctrine\Bundle\MongoDBBundle\Fixture\FixtureGroupInterface;
+use Doctrine\Bundle\MongoDBBundle\Fixture\ODMFixtureInterface;
+use Doctrine\Common\DataFixtures\DependentFixtureInterface;
+use Doctrine\Common\Persistence\ObjectManager;
+
+class WithDependenciesFixtures implements ODMFixtureInterface, DependentFixtureInterface, FixtureGroupInterface
+{
+    public function load(ObjectManager $manager) : void
+    {
+        // ...
+    }
+
+    public function getDependencies() : array
+    {
+        return [OtherFixtures::class];
+    }
+
+    public static function getGroups() : array
+    {
+        return ['missingDependencyGroup', 'fulfilledDependencyGroup'];
+    }
+}

--- a/Tests/Fixtures/FooBundle/DataFixtures/WithDependenciesFixtures.php
+++ b/Tests/Fixtures/FooBundle/DataFixtures/WithDependenciesFixtures.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 namespace Doctrine\Bundle\MongoDBBundle\Tests\Fixtures\FooBundle\DataFixtures;
 
 use Doctrine\Bundle\MongoDBBundle\Fixture\FixtureGroupInterface;
@@ -11,17 +9,17 @@ use Doctrine\Common\Persistence\ObjectManager;
 
 class WithDependenciesFixtures implements ODMFixtureInterface, DependentFixtureInterface, FixtureGroupInterface
 {
-    public function load(ObjectManager $manager) : void
+    public function load(ObjectManager $manager)
     {
         // ...
     }
 
-    public function getDependencies() : array
+    public function getDependencies()
     {
         return [OtherFixtures::class];
     }
 
-    public static function getGroups() : array
+    public static function getGroups()
     {
         return ['missingDependencyGroup', 'fulfilledDependencyGroup'];
     }

--- a/Tests/Fixtures/FooBundle/FooBundle.php
+++ b/Tests/Fixtures/FooBundle/FooBundle.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Bundle\MongoDBBundle\Tests\Fixtures\FooBundle;
+
+use Symfony\Component\HttpKernel\Bundle\Bundle;
+
+class FooBundle extends Bundle
+{
+}

--- a/Tests/Fixtures/FooBundle/FooBundle.php
+++ b/Tests/Fixtures/FooBundle/FooBundle.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 namespace Doctrine\Bundle\MongoDBBundle\Tests\Fixtures\FooBundle;
 
 use Symfony\Component\HttpKernel\Bundle\Bundle;

--- a/Tests/ServiceRepositoryTest.php
+++ b/Tests/ServiceRepositoryTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Doctrine\Bundle\DoctrineBundle\Tests;
+namespace Doctrine\Bundle\MongoDBBundle\Tests;
 
 use Doctrine\Bundle\MongoDBBundle\DependencyInjection\Compiler\ServiceRepositoryCompilerPass;
 use Doctrine\Bundle\MongoDBBundle\DependencyInjection\DoctrineMongoDBExtension;

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "symfony/config": "^3.4 || ^4.0"
     },
     "require-dev": {
-        "doctrine/data-fixtures": "@dev",
+        "doctrine/data-fixtures": "^1.2.2",
         "symfony/form": "^3.4 || ^4.0",
         "symfony/yaml": "^3.4 || ^4.0",
         "symfony/phpunit-bridge": "^3.4 || ^4.0",


### PR DESCRIPTION
A first implementation, basically copy/paste from the fixturesbundle. 

Couple questions:
- Do we want to keep depending on the fixturesBundle or should we copy any files over so we can avoid the fixturesBundle which also installs the orm stuff which if you only use odm you don't need? (for example the FixtureGroupInterface)
- i based it on 3.5.3 as that is what i have locally, it would be nice if this could be included in 3.6, but not sure we can keep it backward compatible? Maybe if we keep fixtures/bundle options and keep their old implementation and if you provide an --autowire option it uses the new one? 

Thoughts?

Fixes #461 