### PR TITLE
Allow passing env variables for port config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,7 @@ services: mongodb
 
 install:
   - composer self-update
+  - pecl install memcached
   - pecl install -f mongodb-${DRIVER_VERSION}
   - composer update ${COMPOSER_FLAGS}
 

--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -489,6 +489,27 @@ class ConfigurationTest extends TestCase
         $this->assertFalse(array_key_exists('replicaSet', $processedConfig['connections']['conn1']['options']));
     }
 
+    public function testPortFromEnvVariable()
+    {
+        $config = [
+            'document_managers' => [
+                'dm1' => [
+                    'metadata_cache_driver' => [
+                        'type'           => 'memcached',
+                        'class'          => 'fooClass',
+                        'host'           => 'host_val',
+                        'port'           => '%env(int:MEMCACHE_PORT)%',
+                        'instance_class' => 'instance_val',
+                    ],
+                ],
+            ],
+        ];
+
+        $processor       = new Processor();
+        $configuration   = new Configuration(false);
+        $processedConfig = $processor->processConfiguration($configuration, [$config]);
+    }
+
     /**
      * @dataProvider provideExceptionConfiguration
      */

--- a/Tests/DependencyInjection/Fixtures/config/yml/mongodb_service_simple_single_connection.yml
+++ b/Tests/DependencyInjection/Fixtures/config/yml/mongodb_service_simple_single_connection.yml
@@ -9,5 +9,4 @@ doctrine_mongodb:
         type: memcached
         class: Doctrine\Common\Cache\MemcachedCache
         host: localhost
-        port: 11211
-        instance_class: Memcached
+        port: '%env(int:MEMCACHE_PORT)%'

--- a/Tests/DependencyInjection/Fixtures/config/yml/mongodb_service_simple_single_connection.yml
+++ b/Tests/DependencyInjection/Fixtures/config/yml/mongodb_service_simple_single_connection.yml
@@ -10,3 +10,4 @@ doctrine_mongodb:
         class: Doctrine\Common\Cache\MemcachedCache
         host: localhost
         port: '%env(int:MEMCACHE_PORT)%'
+        instance_class: Memcached

--- a/Tests/DependencyInjection/Fixtures/config/yml/mongodb_service_simple_single_connection.yml
+++ b/Tests/DependencyInjection/Fixtures/config/yml/mongodb_service_simple_single_connection.yml
@@ -10,4 +10,4 @@ doctrine_mongodb:
         class: Doctrine\Common\Cache\MemcachedCache
         host: localhost
         port: '%env(int:MEMCACHE_PORT)%'
-        instance_class: Memcached
+        instance_class: Doctrine\Bundle\MongoDBBundle\Tests\MemcachedStub

--- a/Tests/MemcachedStub.php
+++ b/Tests/MemcachedStub.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Doctrine\Bundle\MongoDBBundle\Tests;
+
+use function func_get_args;
+use Memcached;
+
+final class MemcachedStub extends Memcached
+{
+    public function addServer($host, $port, $weight = 0)
+    {
+        parent::addServer(...func_get_args());
+    }
+}


### PR DESCRIPTION
This PR currently adds a failing test showing that it indeed doesn't work to configure an environment variable for the `port` config key: the value `env_b716a6057d9db8cd_int_MEMCACHE_PORT_3ab2dd98024d8e49c24dd8b16ad41215` is directly passed to the `addServer` method - so something is off completely. @xabbuh do you have any pointers what's going on and what should be happening?