### PR TITLE
Fix link to PHP7 usage instructions

### DIFF
--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -893,6 +893,6 @@ Learn more from the Cookbook
 .. _`the cookbook`: http://symfony.com/doc/current/cookbook/security/entity_provider.html
 .. _`UniqueEntity`: http://symfony.com/doc/current/reference/constraints/UniqueEntity.html
 .. _`store sessions`: http://symfony.com/doc/current/cookbook/doctrine/mongodb_session_storage.html
-.. _`"Using PHP 7" section`: http://docs.doctrine-project.org/projects/doctrine-mongodb-odm/en/latest/reference/introduction.html#using-php-7
+.. _`"Using PHP 7" section`: https://www.doctrine-project.org/projects/doctrine-mongodb-odm/en/1.2/reference/introduction.html#using-php-7
 .. _`autowiring`: https://symfony.com/doc/current/service_container/autowiring.html
 .. _`recipes`: http://fabien.potencier.org/symfony4-contributing-recipes.html


### PR DESCRIPTION
The link to the instructions about using PHP7 points to the `latest` branch of the doc, which now references the 2.0 version. This version doesn't have the part about PHP7 so I forced the link to point to the doc of the 1.2 version.