### PR TITLE
Updated doctrine/coding-standard to 6.0

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -51,9 +51,12 @@ class Configuration implements ConfigurationInterface
                     ->always(static function ($v) {
                         if ($v === false) {
                             return ODMConfiguration::AUTOGENERATE_EVAL;
-                        } elseif ($v === true) {
+                        }
+
+                        if ($v === true) {
                             return ODMConfiguration::AUTOGENERATE_FILE_NOT_EXISTS;
                         }
+
                         return $v;
                     })
                     ->end()
@@ -66,9 +69,12 @@ class Configuration implements ConfigurationInterface
                     ->always(static function ($v) {
                         if ($v === false) {
                             return ODMConfiguration::AUTOGENERATE_NEVER;
-                        } elseif ($v === true) {
+                        }
+
+                        if ($v === true) {
                             return ODMConfiguration::AUTOGENERATE_ALWAYS;
                         }
+
                         return $v;
                     })
                     ->end()

--- a/Tests/DependencyInjection/AbstractMongoDBExtensionTest.php
+++ b/Tests/DependencyInjection/AbstractMongoDBExtensionTest.php
@@ -444,6 +444,7 @@ abstract class AbstractMongoDBExtensionTest extends TestCase
 
             try {
                 $this->assertSame($params, $call[1], "Expected parameters to method '" . $methodName . "' did not match the actual parameters.");
+
                 return;
             } catch (PHPUnit_Framework_AssertionFailedError $e) {
                 $lastError = $e;

--- a/Tests/Form/Type/DocumentTypeTest.php
+++ b/Tests/Form/Type/DocumentTypeTest.php
@@ -56,7 +56,6 @@ class DocumentTypeTest extends TypeTestCase
         parent::tearDown();
     }
 
-
     public function testDocumentManagerOptionSetsEmOption()
     {
         $field = $this->factory->createNamed('name', $this->typeFQCN ? DocumentType::CLASS : 'document', null, [

--- a/Tests/Form/Type/TypeGuesserTest.php
+++ b/Tests/Form/Type/TypeGuesserTest.php
@@ -54,7 +54,6 @@ class TypeGuesserTest extends TypeTestCase
         parent::tearDown();
     }
 
-
     public function testTypesShouldBeGuessedCorrectly()
     {
         $form = $this->factory->create($this->typeFQCN ? GuesserTestType::class : new GuesserTestType(), null, ['dm' => $this->dm]);

--- a/Tests/Mapping/Driver/AbstractDriverTest.php
+++ b/Tests/Mapping/Driver/AbstractDriverTest.php
@@ -60,7 +60,9 @@ abstract class AbstractDriverTest extends TestCase
     }
 
     abstract protected function getFileExtension();
+
     abstract protected function getFixtureDir();
+
     abstract protected function getDriver(array $paths = []);
 
     private function getDriverLocator(FileDriver $driver)

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "symfony/options-resolver": "^3.4 || ^4.0"
     },
     "require-dev": {
-        "doctrine/coding-standard": "^5.0",
+        "doctrine/coding-standard": "^6.0",
         "doctrine/data-fixtures": "@dev",
         "phpunit/phpunit": "^7.3",
         "symfony/form": "^3.4 || ^4.0",

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -27,6 +27,7 @@
         <exclude name="SlevomatCodingStandard.Classes.SuperfluousAbstractClassNaming" />
         <exclude name="SlevomatCodingStandard.Classes.SuperfluousExceptionNaming" />
         <exclude name="SlevomatCodingStandard.Classes.SuperfluousInterfaceNaming" />
+        <exclude name="SlevomatCodingStandard.Classes.SuperfluousTraitNaming" />
     </rule>
 
     <rule ref="SlevomatCodingStandard.Classes.UnusedPrivateElements">


### PR DESCRIPTION
Updated `composer.json` and set `doctrine/coding-standard` to `^6.0` 
Tested and fixed required changes via `phpcbf`

Please Note, I've disabled the Sniff `SlevomatCodingStandard.Classes.SuperfluousTraitNaming`  as it would require remove/refactoring of https://github.com/doctrine/DoctrineMongoDBBundle/blob/master/Repository/ServiceRepositoryTrait.php otherwise. 