### PR TITLE
Event subscriber

### DIFF
--- a/DependencyInjection/DoctrineMongoDBExtension.php
+++ b/DependencyInjection/DoctrineMongoDBExtension.php
@@ -5,6 +5,7 @@ namespace Doctrine\Bundle\MongoDBBundle\DependencyInjection;
 
 use Doctrine\Bundle\MongoDBBundle\DependencyInjection\Compiler\ServiceRepositoryCompilerPass;
 use Doctrine\Bundle\MongoDBBundle\Repository\ServiceDocumentRepositoryInterface;
+use Doctrine\Common\EventSubscriber;
 use Symfony\Bridge\Doctrine\DependencyInjection\AbstractDoctrineExtension;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\Alias;
@@ -74,7 +75,13 @@ class DoctrineMongoDBExtension extends AbstractDoctrineExtension
             foreach ($config['resolve_target_documents'] as $name => $implementation) {
                 $def->addMethodCall('addResolveTargetDocument', [$name, $implementation, []]);
             }
-            $def->addTag('doctrine_mongodb.odm.event_listener', ['event' => 'loadClassMetadata']);
+
+            // Register service has an event subscriber if implement interface
+            if (in_array(EventSubscriber::class, class_implements($container->getParameterBag()->resolveValue($def->getClass())))) {
+                $def->addTag('doctrine_mongodb.odm.event_subscriber');
+            } else {
+                $def->addTag('doctrine_mongodb.odm.event_listener', ['event' => 'loadClassMetadata']);
+            }
         }
 
         // BC Aliases for Document Manager

--- a/Tests/DependencyInjection/AbstractMongoDBExtensionTest.php
+++ b/Tests/DependencyInjection/AbstractMongoDBExtensionTest.php
@@ -13,6 +13,7 @@ use Doctrine\Common\Cache\ArrayCache;
 use Doctrine\Common\Cache\MemcacheCache;
 use Doctrine\Common\Cache\MemcachedCache;
 use Doctrine\Common\Cache\XcacheCache;
+use Doctrine\Common\EventSubscriber;
 use Doctrine\Common\Persistence\Mapping\Driver\MappingDriverChain;
 use Doctrine\MongoDB\Connection;
 use Doctrine\ODM\MongoDB\Configuration;
@@ -409,7 +410,12 @@ abstract class AbstractMongoDBExtensionTest extends TestCase
 
         $definition = $container->getDefinition('doctrine_mongodb.odm.listeners.resolve_target_document');
         $this->assertDefinitionMethodCallOnce($definition, 'addResolveTargetDocument', [UserInterface::class, 'MyUserClass', []]);
-        $this->assertEquals(['doctrine_mongodb.odm.event_listener' => [['event' => 'loadClassMetadata']]], $definition->getTags());
+
+        if (in_array(EventSubscriber::class, class_implements($container->getParameterBag()->resolveValue($definition->getClass())))) {
+            $this->assertEquals(['doctrine_mongodb.odm.event_subscriber' => [[]]], $definition->getTags());
+        } else {
+            $this->assertEquals(['doctrine_mongodb.odm.event_listener' => [['event' => 'loadClassMetadata']]], $definition->getTags());
+        }
     }
 
     public function testFilters()


### PR DESCRIPTION
Replacing tag `doctrine_mongodb.odm.event_listener` by `doctrine_mongodb.odm.event_subscriber`.

Following new Pull Requests from the next related issue: https://github.com/doctrine/mongodb-odm/issues/1993