### PR TITLE
Don't register fixtures loader as command if the library is not installed

### DIFF
--- a/DependencyInjection/DoctrineMongoDBExtension.php
+++ b/DependencyInjection/DoctrineMongoDBExtension.php
@@ -3,6 +3,7 @@
 
 namespace Doctrine\Bundle\MongoDBBundle\DependencyInjection;
 
+use Doctrine\Bundle\MongoDBBundle\Command\LoadDataFixturesDoctrineODMCommand;
 use Doctrine\Bundle\MongoDBBundle\DependencyInjection\Compiler\FixturesCompilerPass;
 use Doctrine\Bundle\MongoDBBundle\DependencyInjection\Compiler\ServiceRepositoryCompilerPass;
 use Doctrine\Bundle\MongoDBBundle\Fixture\ODMFixtureInterface;
@@ -98,6 +99,10 @@ class DoctrineMongoDBExtension extends AbstractDoctrineExtension
         // BC Aliases for Document Manager
         $container->setAlias('doctrine.odm.mongodb.document_manager', new Alias('doctrine_mongodb.odm.document_manager'));
 
+        if (class_exists(DataFixturesLoader::class)) {
+            $container->findDefinition(LoadDataFixturesDoctrineODMCommand::class)
+                ->addTag('console.command');
+        }
 
         $container->registerForAutoconfiguration(ServiceDocumentRepositoryInterface::class)
             ->addTag(ServiceRepositoryCompilerPass::REPOSITORY_SERVICE_TAG);

--- a/Resources/config/mongodb.xml
+++ b/Resources/config/mongodb.xml
@@ -92,9 +92,7 @@
         <service id="Doctrine\Bundle\MongoDBBundle\Command\LoadDataFixturesDoctrineODMCommand" class="Doctrine\Bundle\MongoDBBundle\Command\LoadDataFixturesDoctrineODMCommand">
             <argument type="service" id="doctrine_mongodb"/>
             <argument type="service" id="kernel" on-invalid="null"/>
-            <argument type="service" id="doctrine_mongodb.odm.symfony.fixtures.loader" on-invalid="null" />
-
-            <tag name="console.command"/>
+            <argument type="service" id="doctrine_mongodb.odm.symfony.fixtures.loader" />
         </service>
         <service id="Doctrine\Bundle\MongoDBBundle\Command\QueryDoctrineODMCommand" class="Doctrine\Bundle\MongoDBBundle\Command\QueryDoctrineODMCommand">
             <tag name="console.command"/>


### PR DESCRIPTION
Fixes #567.

Since the command now uses a class from the optional data-fixtures library as a dependency, this causes errors when the library is not installed. Thus, we no longer automatically register the fixture command unless the library is installed.