### PR TITLE
Fix registration of command subscribers

### DIFF
--- a/APM/CommandLoggerRegistry.php
+++ b/APM/CommandLoggerRegistry.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Bundle\MongoDBBundle\APM;
+
+use Doctrine\ODM\MongoDB\APM\CommandLoggerInterface;
+use function array_map;
+
+final class CommandLoggerRegistry
+{
+    /** @var CommandLoggerInterface[] */
+    private $commandLoggers = [];
+
+    public function __construct(iterable $commandLoggers)
+    {
+        foreach ($commandLoggers as $commandLogger) {
+            $this->addLogger($commandLogger);
+        }
+    }
+
+    public function register() : void
+    {
+        array_map(static function (CommandLoggerInterface $commandLogger) {
+            $commandLogger->register();
+        }, $this->commandLoggers);
+    }
+
+    public function unregister() : void
+    {
+        array_map(static function (CommandLoggerInterface $commandLogger) {
+            $commandLogger->unregister();
+        }, $this->commandLoggers);
+    }
+
+    private function addLogger(CommandLoggerInterface $logger) : void
+    {
+        $this->commandLoggers[] = $logger;
+    }
+}

--- a/DependencyInjection/DoctrineMongoDBExtension.php
+++ b/DependencyInjection/DoctrineMongoDBExtension.php
@@ -214,13 +214,13 @@ class DoctrineMongoDBExtension extends AbstractDoctrineExtension
         // logging
         if ($container->getParameterBag()->resolveValue($documentManager['logging'])) {
             $logger = $container->getDefinition('doctrine_mongodb.odm.command_logger');
-            $logger->addMethodCall('register');
+            $logger->addTag('doctrine_mongodb.odm.command_logger');
         }
 
         // profiler
         if ($container->getParameterBag()->resolveValue($documentManager['profiler']['enabled'])) {
             $logger = $container->getDefinition('doctrine_mongodb.odm.data_collector.command_logger');
-            $logger->addMethodCall('register');
+            $logger->addTag('doctrine_mongodb.odm.command_logger');
 
             $container
                 ->getDefinition('doctrine_mongodb.odm.data_collector')

--- a/DoctrineMongoDBBundle.php
+++ b/DoctrineMongoDBBundle.php
@@ -55,6 +55,7 @@ class DoctrineMongoDBBundle extends Bundle
         $registry = $this->container->get('doctrine_mongodb');
 
         $this->registerAutoloader($registry->getManager());
+        $this->registerCommandLoggers();
     }
 
     private function registerAutoloader(DocumentManager $documentManager) : void
@@ -69,7 +70,7 @@ class DoctrineMongoDBBundle extends Bundle
         spl_autoload_register($this->autoloader);
     }
 
-    public function shutdown()
+    private function unregisterAutoloader() : void
     {
         if ($this->autoloader === null) {
             return;
@@ -77,5 +78,23 @@ class DoctrineMongoDBBundle extends Bundle
 
         spl_autoload_unregister($this->autoloader);
         $this->autoloader = null;
+    }
+
+    private function registerCommandLoggers() : void
+    {
+        $commandLoggerRegistry = $this->container->get('doctrine_mongodb.odm.command_logger_registry');
+        $commandLoggerRegistry->register();
+    }
+
+    private function unregisterCommandLoggers() : void
+    {
+        $commandLoggerRegistry = $this->container->get('doctrine_mongodb.odm.command_logger_registry');
+        $commandLoggerRegistry->unregister();
+    }
+
+    public function shutdown()
+    {
+        $this->unregisterAutoloader();
+        $this->unregisterCommandLoggers();
     }
 }

--- a/Resources/config/mongodb.xml
+++ b/Resources/config/mongodb.xml
@@ -132,6 +132,10 @@
         <service id="doctrine_mongodb.odm.cache.array" class="%doctrine_mongodb.odm.cache.array.class%" />
 
         <!-- logger -->
+        <service id="doctrine_mongodb.odm.command_logger_registry" class="Doctrine\Bundle\MongoDBBundle\APM\CommandLoggerRegistry" public="true">
+            <argument type="tagged" tag="doctrine_mongodb.odm.command_logger" />
+        </service>
+
         <service id="doctrine_mongodb.odm.command_logger" class="Doctrine\Bundle\MongoDBBundle\APM\PSRCommandLogger" public="false">
             <argument type="service" id="logger" on-invalid="null" />
 

--- a/Tests/ContainerTest.php
+++ b/Tests/ContainerTest.php
@@ -46,7 +46,7 @@ class ContainerTest extends TestCase
         $this->extension->load([$config], $this->container);
 
         $definition = $this->container->getDefinition('doctrine_mongodb.odm.command_logger');
-        $this->assertSame($expected, $definition->hasMethodCall('register'));
+        $this->assertSame($expected, $definition->hasTag('doctrine_mongodb.odm.command_logger'));
     }
 
     public function provideLoggerConfigs()
@@ -90,7 +90,7 @@ class ContainerTest extends TestCase
         $this->extension->load([$config], $this->container);
 
         $loggerDefinition = $this->container->getDefinition('doctrine_mongodb.odm.data_collector.command_logger');
-        $this->assertSame($expected, $loggerDefinition->hasMethodCall('register'));
+        $this->assertSame($expected, $loggerDefinition->hasTag('doctrine_mongodb.odm.command_logger'));
 
         $dataCollectorDefinition = $this->container->getDefinition('doctrine_mongodb.odm.data_collector');
         $this->assertSame($expected, $dataCollectorDefinition->hasTag('data_collector'));

--- a/Tests/FixtureIntegrationTest.php
+++ b/Tests/FixtureIntegrationTest.php
@@ -41,7 +41,7 @@ class FixtureIntegrationTest extends TestCase
 
     public function testFixturesLoader() : void
     {
-        $kernel = new IntegrationTestKernel('dev', true);
+        $kernel = new IntegrationTestKernel('dev', false);
         $kernel->addServices(static function (ContainerBuilder $c) : void {
             $c->autowire(OtherFixtures::class)
                 ->addTag(FixturesCompilerPass::FIXTURE_TAG);
@@ -74,7 +74,7 @@ class FixtureIntegrationTest extends TestCase
     {
         // See https://github.com/doctrine/DoctrineFixturesBundle/issues/215
 
-        $kernel = new IntegrationTestKernel('dev', true);
+        $kernel = new IntegrationTestKernel('dev', false);
         $kernel->addServices(static function (ContainerBuilder $c) : void {
             $c->autowire(WithDependenciesFixtures::class)
                 ->addTag(FixturesCompilerPass::FIXTURE_TAG);
@@ -116,7 +116,7 @@ class FixtureIntegrationTest extends TestCase
             $this->markTestSkipped();
         }
 
-        $kernel = new IntegrationTestKernel('dev', true);
+        $kernel = new IntegrationTestKernel('dev', false);
         $kernel->addServices(static function (ContainerBuilder $c) {
             $c->autowire(DependentOnRequiredConstructorArgsFixtures::class)
                 ->addTag(FixturesCompilerPass::FIXTURE_TAG);
@@ -147,7 +147,7 @@ class FixtureIntegrationTest extends TestCase
             $this->markTestSkipped();
         }
 
-        $kernel = new IntegrationTestKernel('dev', true);
+        $kernel = new IntegrationTestKernel('dev', false);
         $kernel->addServices(static function (ContainerBuilder $c) : void {
             $c->autowire(DependentOnRequiredConstructorArgsFixtures::class)
                 ->addTag(FixturesCompilerPass::FIXTURE_TAG);
@@ -165,7 +165,7 @@ class FixtureIntegrationTest extends TestCase
 
     public function testFixturesLoaderWithGroupsOptionViaInterface() : void
     {
-        $kernel = new IntegrationTestKernel('dev', true);
+        $kernel = new IntegrationTestKernel('dev', false);
         $kernel->addServices(static function (ContainerBuilder $c) : void {
             // has a "staging" group via the getGroups() method
             $c->autowire(OtherFixtures::class)
@@ -197,7 +197,7 @@ class FixtureIntegrationTest extends TestCase
 
     public function testFixturesLoaderWithGroupsOptionViaTag() : void
     {
-        $kernel = new IntegrationTestKernel('dev', true);
+        $kernel = new IntegrationTestKernel('dev', false);
         $kernel->addServices(static function (ContainerBuilder $c) : void {
             // has a "staging" group via the getGroups() method
             $c->autowire(OtherFixtures::class)
@@ -224,7 +224,7 @@ class FixtureIntegrationTest extends TestCase
 
     public function testLoadFixturesViaGroupWithMissingDependency() : void
     {
-        $kernel = new IntegrationTestKernel('dev', true);
+        $kernel = new IntegrationTestKernel('dev', false);
         $kernel->addServices(static function (ContainerBuilder $c) : void {
             // has a "staging" group via the getGroups() method
             $c->autowire(OtherFixtures::class)
@@ -250,7 +250,7 @@ class FixtureIntegrationTest extends TestCase
 
     public function testLoadFixturesViaGroupWithFulfilledDependency() : void
     {
-        $kernel = new IntegrationTestKernel('dev', true);
+        $kernel = new IntegrationTestKernel('dev', false);
         $kernel->addServices(static function (ContainerBuilder $c) : void {
             // has a "staging" group via the getGroups() method
             $c->autowire(OtherFixtures::class)
@@ -283,7 +283,7 @@ class FixtureIntegrationTest extends TestCase
 
     public function testLoadFixturesByShortName() : void
     {
-        $kernel = new IntegrationTestKernel('dev', true);
+        $kernel = new IntegrationTestKernel('dev', false);
         $kernel->addServices(static function (ContainerBuilder $c) : void {
             // has a "staging" group via the getGroups() method
             $c->autowire(OtherFixtures::class)

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "require": {
         "php": "^7.2",
         "doctrine/annotations": "^1.2",
-        "doctrine/mongodb-odm": "^2.0.0-beta1",
+        "doctrine/mongodb-odm": "^2.0.0-RC1",
         "psr/log": "^1.0",
         "symfony/console": "^3.4 || ^4.0",
         "symfony/dependency-injection": "^3.4 || ^4.0",


### PR DESCRIPTION
Fixes #563. Command subscribers were not properly registered - just adding a method call to the service definition is not enough.

To work around this, we add a command subscriber registry that is registered and unregistered when the bundle is booted and shut down. The registry proxies all calls to `register` and `unregister` to all registered subscribers. Since we don't have an interface for registrable command subscribers, I simply added `method_exists` checks to avoid fatal errors. We can still add an interface for such subscribers to the next release candidate for mongodb-odm and change the code to throw exceptions instead of silently skipping incompatible subscribers. Opinions @jmikola @malarzm?