### PR TITLE
Changed 'exit()' calls to throw RuntimeException instead

### DIFF
--- a/DependencyInjection/Compiler/CreateHydratorDirectoryPass.php
+++ b/DependencyInjection/Compiler/CreateHydratorDirectoryPass.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\Bundle\MongoDBBundle\DependencyInjection\Compiler;
 
+use RuntimeException;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use function dirname;
@@ -27,10 +28,14 @@ class CreateHydratorDirectoryPass implements CompilerPassInterface
         $hydratorCacheDir = $container->getParameter('doctrine_mongodb.odm.hydrator_dir');
         if (! is_dir($hydratorCacheDir)) {
             if (@mkdir($hydratorCacheDir, 0775, true) === false) {
-                exit(sprintf('Unable to create the Doctrine Hydrator directory (%s)', dirname($hydratorCacheDir)));
+                throw new RuntimeException(
+                    sprintf('Unable to create the Doctrine Hydrator directory (%s)', dirname($hydratorCacheDir))
+                );
             }
         } elseif (! is_writable($hydratorCacheDir)) {
-            exit(sprintf('Unable to write in the Doctrine Hydrator directory (%s)', $hydratorCacheDir));
+            throw new RuntimeException(
+                sprintf('Unable to write in the Doctrine Hydrator directory (%s)', $hydratorCacheDir)
+            );
         }
     }
 }

--- a/DependencyInjection/Compiler/CreateProxyDirectoryPass.php
+++ b/DependencyInjection/Compiler/CreateProxyDirectoryPass.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\Bundle\MongoDBBundle\DependencyInjection\Compiler;
 
+use RuntimeException;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use function dirname;
@@ -27,10 +28,14 @@ class CreateProxyDirectoryPass implements CompilerPassInterface
         $proxyCacheDir = $container->getParameter('doctrine_mongodb.odm.proxy_dir');
         if (! is_dir($proxyCacheDir)) {
             if (@mkdir($proxyCacheDir, 0775, true) === false) {
-                exit(sprintf('Unable to create the Doctrine Proxy directory (%s)', dirname($proxyCacheDir)));
+                throw new RuntimeException(
+                    sprintf('Unable to create the Doctrine Proxy directory (%s)', dirname($proxyCacheDir))
+                );
             }
         } elseif (! is_writable($proxyCacheDir)) {
-            exit(sprintf('Unable to write in the Doctrine Proxy directory (%s)', $proxyCacheDir));
+            throw new RuntimeException(
+                sprintf('Unable to write in the Doctrine Proxy directory (%s)', $proxyCacheDir)
+            );
         }
     }
 }


### PR DESCRIPTION
I think this is rather important to give programmers/dev-ops some more feedback than just a message returned in `exit()` function. With exceptions we give the app a chance to put the error message into some log file.