### PR TITLE
Fix travis-ci build

### DIFF
--- a/Tests/Fixtures/Form/Document.php
+++ b/Tests/Fixtures/Form/Document.php
@@ -17,7 +17,8 @@ class Document
     /**
      * @ODM\ReferenceMany(
      *     targetDocument="Doctrine\Bundle\MongoDBBundle\Tests\Fixtures\Form\Category",
-     *     inversedBy="documents"
+     *     inversedBy="documents",
+     *     strategy="atomicSetArray"
      * )
      */
     public $categories;

--- a/Tests/Fixtures/Form/Guesser.php
+++ b/Tests/Fixtures/Form/Guesser.php
@@ -25,7 +25,8 @@ class Guesser
     /**
      * @ODM\ReferenceMany(
      *     targetDocument="Doctrine\Bundle\MongoDBBundle\Tests\Fixtures\Form\Category",
-     *     inversedBy="documents"
+     *     inversedBy="documents",
+     *     strategy="atomicSetArray"
      * )
      */
     public $categories;


### PR DESCRIPTION
With newer MongoDB versions, we no longer have access to the `$pushAll` operator. Since the lowest supported version still allows for this (which is perfectly fine on MongoDB < 4.0), we simply change the strategy on the collections from the default `pushAll` to `atomicSetArray` to work around this.