### PR TITLE
Fix deprecations when running against ODM 1.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ env:
     - DRIVER_VERSION="stable"
     - ADAPTER_VERSION="^1.0.0"
     - COMPOSER_FLAGS="--prefer-dist"
+    - SYMFONY_DEPRECATIONS_HELPER="max[self]=0"
 
 matrix:
   include:

--- a/Repository/ContainerRepositoryFactory.php
+++ b/Repository/ContainerRepositoryFactory.php
@@ -71,7 +71,7 @@ final class ContainerRepositoryFactory implements RepositoryFactory
             return $this->managedRepositories[$repositoryHash];
         }
 
-        $repositoryClassName = $metadata->customRepositoryClassName ?: $documentManager->getConfiguration()->getDefaultRepositoryClassName();
+        $repositoryClassName = $metadata->customRepositoryClassName ?: (method_exists($documentManager->getConfiguration(), 'getDefaultDocumentRepositoryClassName') ? $documentManager->getConfiguration()->getDefaultDocumentRepositoryClassName() : $documentManager->getConfiguration()->getDefaultRepositoryClassName());
 
         return $this->managedRepositories[$repositoryHash] = new $repositoryClassName($documentManager, $documentManager->getUnitOfWork(), $metadata);
     }

--- a/Tests/DependencyInjection/Fixtures/config/yml/full.yml
+++ b/Tests/DependencyInjection/Fixtures/config/yml/full.yml
@@ -1,6 +1,6 @@
 doctrine_mongodb:
     fixture_loader: Symfony\Bridge\Doctrine\DataFixtures\ContainerAwareLoader
-    auto_generate_proxy_classes: true
+    auto_generate_proxy_classes: 2
     auto_generate_hydrator_classes: true
     auto_generate_persistent_collection_classes: 3
     default_connection: conn1

--- a/Tests/Mapping/Driver/YamlDriverTest.php
+++ b/Tests/Mapping/Driver/YamlDriverTest.php
@@ -5,6 +5,9 @@ namespace Doctrine\Bundle\MongoDBBundle\Tests\Mapping\Driver;
 
 use Doctrine\Bundle\MongoDBBundle\Mapping\Driver\YamlDriver;
 
+/**
+ * @group legacy
+ */
 class YamlDriverTest extends AbstractDriverTest
 {
     protected function getFileExtension()

--- a/Tests/TestCase.php
+++ b/Tests/TestCase.php
@@ -4,6 +4,7 @@
 namespace Doctrine\Bundle\MongoDBBundle\Tests;
 
 use Doctrine\Common\Annotations\AnnotationReader;
+use Doctrine\Common\Proxy\AbstractProxyFactory;
 use Doctrine\MongoDB\Connection;
 use Doctrine\ODM\MongoDB\DocumentManager;
 use Doctrine\ODM\MongoDB\Mapping\Driver\AnnotationDriver;
@@ -17,7 +18,7 @@ class TestCase extends BaseTestCase
     public static function createTestDocumentManager($paths = [])
     {
         $config = new \Doctrine\ODM\MongoDB\Configuration();
-        $config->setAutoGenerateProxyClasses(true);
+        $config->setAutoGenerateProxyClasses(AbstractProxyFactory::AUTOGENERATE_FILE_NOT_EXISTS);
         $config->setProxyDir(\sys_get_temp_dir());
         $config->setHydratorDir(\sys_get_temp_dir());
         $config->setProxyNamespace('SymfonyTests\Doctrine');


### PR DESCRIPTION
Apparently, some deprecations slipped through the cracks.

* Indirect notices are skipped - we generally can't fix these (think vendor code triggering deprecation notices)
* A single usage of a deprecated document repository class is ignored as fixing it requires bumping the minimum ODM version (which can't be done in a patch release)
* All other deprecations were fixed in the test suite.