### PR TITLE
Authentication details

### DIFF
--- a/Resources/doc/installation.rst
+++ b/Resources/doc/installation.rst
@@ -78,6 +78,21 @@ the MongoDB ODM across your application:
     Of course, you'll also need to make sure that the MongoDB server is running
     in the background. For more details, see the MongoDB `Quick Start`_ guide.
 
+
+Authentication
+--------------
+
+If you use authentication on your MongoDB database you can the provide username, 
+password, and authentication database in the following way:
+
+    # app/config/parameters.yaml
+    parameters:
+        mongodb_server: "mongodb://username:password@localhost:27017/?authSource=auth-db"
+
+.. note::
+
+    The authentication database is different to the default database used by MongoDB.
+
 .. _`installation chapter`: https://getcomposer.org/doc/00-intro.md
 .. _`MongoDB driver`: https://docs.mongodb.com/ecosystem/drivers/php/
 .. _`Quick Start`: http://www.mongodb.org/display/DOCS/Quickstart


### PR DESCRIPTION
As true for mysql you can set up users in mongo to increase the security. When this is done one needs to provide the ODM driver with the information of username, password and authentication database (the database within the connection where the actual user is stored, which is different from the default database. I found after some intense research how it's done and found out it is not mentioned in the docs so I wanted to add it here were it belongs.