### PR TITLE
Fix wrong data collector signature

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ env:
 
 before_install:
   - mv ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/xdebug.ini{,.disabled} || echo "xdebug not available"
-  - composer global require --no-update --no-progress --no-scripts --no-plugins symfony/flex dev-master
+  - composer global require --no-progress --no-scripts --no-plugins symfony/flex dev-master
 
 install:
   - composer self-update

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,10 +37,6 @@ jobs:
     - php: 7.2
       env: LOWEST DRIVER_VERSION="1.5.0" SYMFONY_DEPRECATIONS_HELPER=weak COMPOSER_FLAGS=" -n --prefer-lowest --prefer-stable --prefer-dist"
 
-    # Test against latest Symfony 3.4 stable
-    - php: 7.3
-      env: SYMFONY_REQUIRE="3.4.*"
-
     # Test against latest Symfony 4.3 stable
     - php: 7.3
       env: SYMFONY_REQUIRE="4.3.*"

--- a/DataCollector/CommandDataCollector.php
+++ b/DataCollector/CommandDataCollector.php
@@ -6,10 +6,10 @@ namespace Doctrine\Bundle\MongoDBBundle\DataCollector;
 
 use Doctrine\ODM\MongoDB\APM\Command;
 use Doctrine\ODM\MongoDB\APM\CommandLogger;
-use Exception;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\DataCollector\DataCollector;
+use Throwable;
 use function array_map;
 use function count;
 use function json_encode;
@@ -24,8 +24,7 @@ class CommandDataCollector extends DataCollector
         $this->commandLogger = $commandLogger;
     }
 
-    // phpcs:ignore SlevomatCodingStandard.Exceptions.ReferenceThrowableOnly
-    public function collect(Request $request, Response $response, ?Exception $exception = null) : void
+    public function collect(Request $request, Response $response, ?Throwable $exception = null) : void
     {
         $this->data = [
             'num_commands' => count($this->commandLogger),

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -18,7 +18,6 @@ use function in_array;
 use function is_array;
 use function is_string;
 use function json_decode;
-use function method_exists;
 use function preg_match;
 use function sprintf;
 
@@ -35,7 +34,7 @@ class Configuration implements ConfigurationInterface
     public function getConfigTreeBuilder()
     {
         $treeBuilder = new TreeBuilder('doctrine_mongodb');
-        $rootNode    = method_exists(TreeBuilder::class, 'getRootNode') ? $treeBuilder->getRootNode() : $treeBuilder->root('doctrine_mongodb');
+        $rootNode    = $treeBuilder->getRootNode();
 
         $this->addDocumentManagersSection($rootNode);
         $this->addConnectionsSection($rootNode);

--- a/README.markdown
+++ b/README.markdown
@@ -15,7 +15,7 @@ Compatibility
 The current version of this bundle has the following requirements:
  * PHP 7.2 or newer is required
  * `ext-mongodb` 1.5 or newer
- * Symfony 3.4 or newer is required
+ * Symfony 4.3 or newer is required
 
 Support for older Symfony, PHP and MongoDB versions is provided via the `3.0.x`
 releases (tracked in the `3.0` branch). This version sees bug and security fixes

--- a/Tests/DataCollector/CommandDataCollectorTest.php
+++ b/Tests/DataCollector/CommandDataCollectorTest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Bundle\MongoDBBundle\Tests\DataCollector;
+
+use Doctrine\Bundle\MongoDBBundle\DataCollector\CommandDataCollector;
+use Doctrine\Bundle\MongoDBBundle\Tests\TestCase;
+use Doctrine\ODM\MongoDB\APM\CommandLogger;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class CommandDataCollectorTest extends TestCase
+{
+    public function testCollector()
+    {
+        $collector = new CommandDataCollector(new CommandLogger());
+
+        $collector->collect($request = new Request(['group' => '0']), $response = new Response());
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -16,21 +16,21 @@
         "doctrine/annotations": "^1.2",
         "doctrine/mongodb-odm": "^2.0.0",
         "psr/log": "^1.0",
-        "symfony/console": "^3.4 || ^4.0 || ^5.0",
-        "symfony/dependency-injection": "^3.4 || ^4.0 || ^5.0",
-        "symfony/doctrine-bridge": "^3.4 || ^4.0 || ^5.0",
-        "symfony/config": "^3.4 || ^4.0 || ^5.0",
-        "symfony/framework-bundle": "^3.4 || ^4.0 || ^5.0",
-        "symfony/options-resolver": "^3.4 || ^4.0 || ^5.0"
+        "symfony/console": "^4.3.3|^5.0",
+        "symfony/dependency-injection": "^4.3.3|^5.0",
+        "symfony/doctrine-bridge": "^4.3.3|^5.0",
+        "symfony/config": "^4.3.3|^5.0",
+        "symfony/framework-bundle": "^4.3.3|^5.0",
+        "symfony/options-resolver": "^4.3.3|^5.0"
     },
     "require-dev": {
         "doctrine/coding-standard": "^6.0",
         "doctrine/data-fixtures": "^1.2.2",
         "phpunit/phpunit": "^7.3",
         "squizlabs/php_codesniffer": "^3.5",
-        "symfony/form": "^3.4 || ^4.0 || ^5.0",
-        "symfony/phpunit-bridge": "^3.4 || ^4.0 || ^5.0",
-        "symfony/yaml": "^3.4 || ^4.0 || ^5.0"
+        "symfony/form": "^4.3.3|^5.0",
+        "symfony/phpunit-bridge": "^4.3.3|^5.0",
+        "symfony/yaml": "^4.3.3|^5.0"
     },
     "suggest": {
         "doctrine/data-fixtures": "Load data fixtures"

--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
         "symfony/doctrine-bridge": "^4.3.3|^5.0",
         "symfony/config": "^4.3.3|^5.0",
         "symfony/framework-bundle": "^4.3.3|^5.0",
+        "symfony/http-kernel": "^4.3.7|^5.0",
         "symfony/options-resolver": "^4.3.3|^5.0"
     },
     "require-dev": {


### PR DESCRIPTION
When adding compatibility with Symfony 5 in #602, we missed that Symfony 3.4 was still supported. Supporting 3.4 and 5.0 at the same time is not possible due to a method signature change in the data collector.

This PR fixes this issue by removing support for Symfony 3.4, which will be released as 4.1.0. This has the following implications:
* 4.0.* will no longer be supported. Users currently using Symfony 3.4 alongside ODM 2.0 should upgrade to Symfony 4.3 or newer as soon as possible.
* 4.1.* will be the new supported release for ODM 2
* 3.6.* still supports Symfony 3.4 and ODM 1.3 and will continue to do so until the end of life of ODM 1 is reached.