### PR TITLE
Add server selection timeout and try once options

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -301,6 +301,8 @@ class Configuration implements ConfigurationInterface
                                             })->thenInvalid('The replicaSet option must be a string or null.')
                                         ->end()
                                     ->end()
+                                    ->integerNode('serverSelectionTimeoutMS')->end()
+                                    ->booleanNode('serverSelectionTryOnce')->end()
                                     ->integerNode('socketTimeoutMS')->end()
                                     ->booleanNode('ssl')->end()
                                     ->scalarNode('username')

--- a/Resources/config/schema/mongodb-1.0.xsd
+++ b/Resources/config/schema/mongodb-1.0.xsd
@@ -67,6 +67,8 @@
     <xsd:attribute name="password" type="xsd:string" />
     <xsd:attribute name="readPreference" type="read-preference" />
     <xsd:attribute name="replicaSet" type="xsd:string" />
+    <xsd:attribute name="serverSelectionTimeoutMS" type="xsd:integer" />
+    <xsd:attribute name="serverSelectionTryOnce" type="xsd:boolean" />
     <xsd:attribute name="ssl" type="xsd:boolean" />
     <xsd:attribute name="socketTimeoutMS" type="xsd:integer" />
     <xsd:attribute name="username" type="xsd:string" />

--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -99,6 +99,8 @@ class ConfigurationTest extends TestCase
                         'replicaSet'        => 'foo',
                         'slaveOkay'         => true,
                         'socketTimeoutMS'   => 1000,
+                        'serverSelectionTimeoutMS' => 5000,
+                        'serverSelectionTryOnce' => false,
                         'ssl'               => true,
                         'authMechanism'     => 'MONGODB-X509',
                         'authSource'        => 'some_db',

--- a/Tests/DependencyInjection/Fixtures/config/xml/full.xml
+++ b/Tests/DependencyInjection/Fixtures/config/xml/full.xml
@@ -40,6 +40,8 @@
                 password="password_val"
                 readPreference="secondaryPreferred"
                 replicaSet="foo"
+                serverSelectionTimeoutMS="5000"
+                serverSelectionTryOnce="false"
                 slaveOkay="true"
                 socketTimeoutMS="1000"
                 ssl="true"

--- a/Tests/DependencyInjection/Fixtures/config/yml/full.yml
+++ b/Tests/DependencyInjection/Fixtures/config/yml/full.yml
@@ -39,6 +39,8 @@ doctrine_mongodb:
                   - { dc: west }
                   - {  }
                 replicaSet:       foo
+                serverSelectionTimeoutMS: 5000
+                serverSelectionTryOnce: false
                 slaveOkay:        true
                 socketTimeoutMS:  1000
                 ssl:              true


### PR DESCRIPTION
The `serverSelectionTryOnce` and `serverSelectionTimeoutMS` options are not available in the configuration, even though they do work for the MongoDB client. 

This PR adds these two options, which are useful when dealing with replicaset failovers.