### PR TITLE
Support custom types in configuration

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -39,6 +39,7 @@ class Configuration implements ConfigurationInterface
         $this->addDocumentManagersSection($rootNode);
         $this->addConnectionsSection($rootNode);
         $this->addResolveTargetDocumentsSection($rootNode);
+        $this->addTypesSection($rootNode);
 
         $rootNode
             ->children()
@@ -349,6 +350,31 @@ class Configuration implements ConfigurationInterface
                     ->useAttributeAsKey('interface')
                     ->prototype('scalar')
                         ->cannotBeEmpty()
+                    ->end()
+                ->end()
+            ->end();
+    }
+
+    /**
+     * Adds the "types" config section.
+     */
+    private function addTypesSection(ArrayNodeDefinition $rootNode)
+    {
+        $rootNode
+            ->fixXmlConfig('type')
+            ->children()
+                ->arrayNode('types')
+                    ->useAttributeAsKey('name')
+                    ->prototype('array')
+                        ->beforeNormalization()
+                            ->ifString()
+                            ->then(static function ($v) {
+                                return ['class' => $v];
+                            })
+                        ->end()
+                        ->children()
+                            ->scalarNode('class')->isRequired()->end()
+                        ->end()
                     ->end()
                 ->end()
             ->end();

--- a/DependencyInjection/DoctrineMongoDBExtension.php
+++ b/DependencyInjection/DoctrineMongoDBExtension.php
@@ -59,6 +59,11 @@ class DoctrineMongoDBExtension extends AbstractDoctrineExtension
         }
         $container->setParameter('doctrine_mongodb.odm.default_document_manager', $config['default_document_manager']);
 
+        if (! empty($config['types'])) {
+            $configuratorDefinition = $container->getDefinition('doctrine_mongodb.odm.manager_configurator.abstract');
+            $configuratorDefinition->addMethodCall('loadTypes', [$config['types']]);
+        }
+
         // set some options as parameters and unset them
         $config = $this->overrideParameters($config, $container);
 

--- a/DependencyInjection/DoctrineMongoDBExtension.php
+++ b/DependencyInjection/DoctrineMongoDBExtension.php
@@ -319,7 +319,8 @@ class DoctrineMongoDBExtension extends AbstractDoctrineExtension
 
             $odmConnArgs = [
                 $connection['server'] ?? null,
-                ($connection['options'] ?? []),
+                /* phpcs:ignore Squiz.Arrays.ArrayDeclaration.ValueNoNewline */
+                $connection['options'] ?? [],
                 $this->normalizeDriverOptions($connection),
             ];
 

--- a/DependencyInjection/DoctrineMongoDBExtension.php
+++ b/DependencyInjection/DoctrineMongoDBExtension.php
@@ -319,7 +319,7 @@ class DoctrineMongoDBExtension extends AbstractDoctrineExtension
 
             $odmConnArgs = [
                 $connection['server'] ?? null,
-                $connection['options'] ?? [],
+                ($connection['options'] ?? []),
                 $this->normalizeDriverOptions($connection),
             ];
 

--- a/ManagerConfigurator.php
+++ b/ManagerConfigurator.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Doctrine\Bundle\MongoDBBundle;
 
 use Doctrine\ODM\MongoDB\DocumentManager;
+use Doctrine\ODM\MongoDB\Mapping\MappingException;
+use Doctrine\ODM\MongoDB\Types\Type;
 
 /**
  * Configurator for an DocumentManager
@@ -46,6 +48,24 @@ class ManagerConfigurator
         $filterCollection = $documentManager->getFilterCollection();
         foreach ($this->enabledFilters as $filter) {
             $filterCollection->enable($filter);
+        }
+    }
+
+    /**
+     * Loads custom types.
+     *
+     * @param array $types
+     *
+     * @throws MappingException
+     */
+    public static function loadTypes(array $types) : void
+    {
+        foreach ($types as $typeName => $typeConfig) {
+            if (Type::hasType($typeName)) {
+                Type::overrideType($typeName, $typeConfig['class']);
+            } else {
+                Type::addType($typeName, $typeConfig['class']);
+            }
         }
     }
 }

--- a/Resources/config/schema/mongodb-1.0.xsd
+++ b/Resources/config/schema/mongodb-1.0.xsd
@@ -176,4 +176,13 @@
     <xsd:attribute name="enabled" type="xsd:boolean" />
     <xsd:attribute name="pretty" type="xsd:boolean" />
   </xsd:complexType>
+
+  <xsd:complexType name="type">
+    <xsd:simpleContent>
+      <xsd:extension base="xsd:string">
+        <xsd:attribute name="name" type="xsd:string" use="required" />
+        <xsd:attribute name="class" type="xsd:string" use="required" />
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
 </xsd:schema>

--- a/Tests/DependencyInjection/AbstractMongoDBExtensionTest.php
+++ b/Tests/DependencyInjection/AbstractMongoDBExtensionTest.php
@@ -433,6 +433,27 @@ abstract class AbstractMongoDBExtensionTest extends TestCase
         $this->assertEquals($enabledFilters, $definition->getArgument(0), 'Only enabled filters are passed to the ManagerConfigurator.');
     }
 
+    public function testCustomTypes()
+    {
+        $container = $this->getContainer();
+        $loader    = new DoctrineMongoDBExtension();
+        $container->registerExtension($loader);
+
+        $this->loadFromFile($container, 'odm_types');
+
+        $container->getCompilerPassConfig()->setOptimizationPasses([]);
+        $container->getCompilerPassConfig()->setRemovingPasses([]);
+        $container->compile();
+
+        $expected = [
+            'custom_type_shortcut' => ['class' => 'Vendor\Type\CustomTypeShortcut'],
+            'custom_type' => ['class' => 'Vendor\Type\CustomType'],
+        ];
+
+        $definition = $container->getDefinition('doctrine_mongodb.odm.manager_configurator.abstract');
+        $this->assertDefinitionMethodCallAny($definition, 'loadTypes', [$expected]);
+    }
+
     /**
      * Asserts that the given definition contains a call to the method that uses
      * the specified parameters.

--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -46,6 +46,7 @@ class ConfigurationTest extends TestCase
             'default_commit_options'         => [],
             'persistent_collection_dir'      => '%kernel.cache_dir%/doctrine/odm/mongodb/PersistentCollections',
             'persistent_collection_namespace'=> 'PersistentCollections',
+            'types'                          => [],
         ];
 
         $this->assertEquals($defaults, $options);
@@ -186,6 +187,7 @@ class ConfigurationTest extends TestCase
                 ],
             ],
             'resolve_target_documents' => ['Foo\BarInterface' => 'Bar\FooClass'],
+            'types' => [],
         ];
 
         $this->assertEquals($expected, $options);

--- a/Tests/DependencyInjection/DoctrineMongoDBExtensionTest.php
+++ b/Tests/DependencyInjection/DoctrineMongoDBExtensionTest.php
@@ -17,13 +17,14 @@ class DoctrineMongoDBExtensionTest extends TestCase
 {
     public static function buildConfiguration(array $settings = [])
     {
-        return [array_merge(
-            [
-                'connections' => ['default' => []],
-                'document_managers' => ['default' => []],
-            ],
-            $settings
-        ),
+        return [
+            array_merge(
+                [
+                    'connections' => ['default' => []],
+                    'document_managers' => ['default' => []],
+                ],
+                $settings
+            ),
         ];
     }
 

--- a/Tests/DependencyInjection/Fixtures/config/xml/odm_types.xml
+++ b/Tests/DependencyInjection/Fixtures/config/xml/odm_types.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:doctrine="http://symfony.com/schema/dic/doctrine/odm/mongodb"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd
+                        http://symfony.com/schema/dic/doctrine/odm/mongodb http://symfony.com/schema/dic/doctrine/odm/mongodb/mongodb-1.0.xsd">
+
+    <doctrine:mongodb>
+        <doctrine:connection id="default" server="mongodb://localhost:27017" />
+        <doctrine:type name="custom_type_shortcut" class="Vendor\Type\CustomTypeShortcut" />
+        <doctrine:type name="custom_type" class="Vendor\Type\CustomType" />
+    </doctrine:mongodb>
+</container>

--- a/Tests/DependencyInjection/Fixtures/config/yml/odm_types.yml
+++ b/Tests/DependencyInjection/Fixtures/config/yml/odm_types.yml
@@ -1,0 +1,8 @@
+doctrine_mongodb:
+    connections:
+        default:
+            server: mongodb://localhost:27017
+    types:
+        custom_type_shortcut: Vendor\Type\CustomTypeShortcut
+        custom_type:
+            class: Vendor\Type\CustomType

--- a/Tests/TestCase.php
+++ b/Tests/TestCase.php
@@ -9,7 +9,6 @@ use Doctrine\Common\Cache\ArrayCache;
 use Doctrine\ODM\MongoDB\Configuration;
 use Doctrine\ODM\MongoDB\DocumentManager;
 use Doctrine\ODM\MongoDB\Mapping\Driver\AnnotationDriver;
-use MongoDB\Client;
 use PHPUnit\Framework\TestCase as BaseTestCase;
 use function sys_get_temp_dir;
 
@@ -29,6 +28,6 @@ class TestCase extends BaseTestCase
         $config->setMetadataDriverImpl(new AnnotationDriver(new AnnotationReader(), $paths));
         $config->setMetadataCacheImpl(new ArrayCache());
 
-        return DocumentManager::create(new Client('mongodb://mongo_test:27017', [], ['typeMap' => DocumentManager::CLIENT_TYPEMAP]), $config);
+        return DocumentManager::create(null, $config);
     }
 }

--- a/Tests/TestCase.php
+++ b/Tests/TestCase.php
@@ -9,6 +9,7 @@ use Doctrine\Common\Cache\ArrayCache;
 use Doctrine\ODM\MongoDB\Configuration;
 use Doctrine\ODM\MongoDB\DocumentManager;
 use Doctrine\ODM\MongoDB\Mapping\Driver\AnnotationDriver;
+use MongoDB\Client;
 use PHPUnit\Framework\TestCase as BaseTestCase;
 use function sys_get_temp_dir;
 
@@ -28,6 +29,6 @@ class TestCase extends BaseTestCase
         $config->setMetadataDriverImpl(new AnnotationDriver(new AnnotationReader(), $paths));
         $config->setMetadataCacheImpl(new ArrayCache());
 
-        return DocumentManager::create(null, $config);
+        return DocumentManager::create(new Client('mongodb://mongo_test:27017', [], ['typeMap' => DocumentManager::CLIENT_TYPEMAP]), $config);
     }
 }


### PR DESCRIPTION
Currently no problems with DM usage and doctrine:mongodb:generate:hydrators command.
It is possible to move method `\Doctrine\Bundle\MongoDBBundle\ManagerConfigurator::loadTypes` in separate service, but it is kinda looking OK in abstract Configurator.