### PR TITLE
[Messenger] Clear DocumentManagers after a message is handled or failed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ before_install:
 install:
   - composer self-update
   - pecl install -f mongodb-${DRIVER_VERSION}
+  - if [[ -z ${REQUIRE_SYMFONY_MESSENGER} ]]; then composer require --dev symfony/messenger --no-update; fi
   - composer update ${COMPOSER_FLAGS}
 
 script:
@@ -39,15 +40,15 @@ jobs:
 
     # Test against latest Symfony 4.3 stable
     - php: 7.3
-      env: SYMFONY_REQUIRE="4.3.*"
+      env: SYMFONY_REQUIRE="4.3.*" REQUIRE_SYMFONY_MESSENGER
 
     # Test against latest Symfony 4.4 dev
     - php: 7.3
-      env: SYMFONY_REQUIRE="4.4.*"
+      env: SYMFONY_REQUIRE="4.4.*" REQUIRE_SYMFONY_MESSENGER
 
     # Test against latest Symfony 5.0 dev
     - php: 7.3
-      env: SYMFONY_REQUIRE="5.0.*"
+      env: SYMFONY_REQUIRE="5.0.*" REQUIRE_SYMFONY_MESSENGER
 
     # Test dev versions
     - php: 7.3
@@ -62,7 +63,7 @@ jobs:
 
     - stage: Coverage
       php: 7.3
-      env: COVERAGE PHPUNIT_FLAGS="--coverage-clover=coverage.clover"
+      env: COVERAGE PHPUNIT_FLAGS="--coverage-clover=coverage.clover" REQUIRE_SYMFONY_MESSENGER
       before_script:
         - mv ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/xdebug.ini{.disabled,}
         - if [[ ! $(php -m | grep -si xdebug) ]]; then echo "xdebug required for coverage"; exit 1; fi

--- a/Resources/config/messenger.xml
+++ b/Resources/config/messenger.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+    <services>
+        <service id="doctrine_mongodb.messenger.event_subscriber.doctrine_clear_document_manager"
+                 class="Symfony\Bridge\Doctrine\Messenger\DoctrineClearEntityManagerWorkerSubscriber" public="false">
+            <tag name="kernel.event_subscriber"/>
+            <argument type="service" id="doctrine_mongodb"/>
+        </service>
+    </services>
+</container>


### PR DESCRIPTION
This PR registers the [DoctrineClearEntityManagerWorkerSubscriber](https://github.com/symfony/doctrine-bridge/blob/master/Messenger/DoctrineClearEntityManagerWorkerSubscriber.php) which clears the document managers after each message is handled. The classname is misleading but it works with any ManagerRegistry which implements the `Doctrine\Persistence\ManagerRegistry`.

I'm using it in production and it works fine.
