### PR TITLE
Migrate cs job to Github Actions

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -1,0 +1,46 @@
+name: "Coding Standards"
+
+on:
+  pull_request:
+    branches:
+      - "*.x"
+      - "master"
+  push:
+    branches:
+      - "*.x"
+      - "master"
+
+jobs:
+  coding-standards:
+    name: "Coding Standards"
+    runs-on: "ubuntu-20.04"
+
+    strategy:
+      matrix:
+        php-version:
+          - "7.4"
+
+    steps:
+      - name: "Checkout"
+        uses: "actions/checkout@v2"
+
+      - name: "Install PHP"
+        uses: "shivammathur/setup-php@v2"
+        with:
+          coverage: "none"
+          php-version: "${{ matrix.php-version }}"
+          tools: "cs2pr"
+
+      - name: "Cache dependencies installed with Composer"
+        uses: "actions/cache@v2"
+        with:
+          path: "~/.composer/cache"
+          key: "php-${{ matrix.php-version }}-composer-locked-${{ hashFiles('composer.lock') }}"
+          restore-keys: "php-${{ matrix.php-version }}-composer-locked-"
+
+      - name: "Install dependencies with Composer"
+        run: "composer install --no-interaction --no-progress --no-suggest"
+
+      # https://github.com/doctrine/.github/issues/3
+      - name: "Run PHP_CodeSniffer"
+        run: "vendor/bin/phpcs -q --no-colors --report=checkstyle | cs2pr"

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,12 +55,6 @@ jobs:
       if: type = cron
       env: DEV COMPOSER_FLAGS="-n --prefer-dist"
 
-    - stage: Code Quality
-      env: CODING_STANDARDS
-      php: 7.2
-      script:
-        - ./vendor/bin/phpcs
-
     - stage: Coverage
       php: 7.3
       env: COVERAGE PHPUNIT_FLAGS="--coverage-clover=coverage.clover" REQUIRE_SYMFONY_MESSENGER


### PR DESCRIPTION
Same as https://github.com/doctrine/DoctrineBundle/pull/1219, I copied the action from https://github.com/doctrine/.github/blob/main/workflow-templates/coding-standards.yml. 

~Here a working example of this action: franmomu/DoctrineMongoDBBundle#1~