### PR TITLE
Drop support for doctrine/data-fixtures <1.3

### DIFF
--- a/Tests/Command/LoadDataFixturesDoctrineODMCommandTest.php
+++ b/Tests/Command/LoadDataFixturesDoctrineODMCommandTest.php
@@ -7,10 +7,8 @@ namespace Doctrine\Bundle\MongoDBBundle\Tests\Command;
 use Doctrine\Bundle\MongoDBBundle\Command\LoadDataFixturesDoctrineODMCommand;
 use Doctrine\Bundle\MongoDBBundle\Loader\SymfonyFixturesLoaderInterface;
 use Doctrine\Bundle\MongoDBBundle\ManagerRegistry;
-use Doctrine\Common\DataFixtures\Loader;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpKernel\KernelInterface;
-use function class_exists;
 
 class LoadDataFixturesDoctrineODMCommandTest extends TestCase
 {
@@ -23,21 +21,8 @@ class LoadDataFixturesDoctrineODMCommandTest extends TestCase
         $this->command = new LoadDataFixturesDoctrineODMCommand($registry, $kernel, $loader);
     }
 
-    public function testCommandIsNotEnabledWithMissingDependency()
-    {
-        if (class_exists(Loader::class)) {
-            $this->markTestSkipped();
-        }
-
-        $this->assertFalse($this->command->isEnabled());
-    }
-
     public function testCommandIsEnabledWithDependency()
     {
-        if (! class_exists(Loader::class)) {
-            $this->markTestSkipped();
-        }
-
         $this->assertTrue($this->command->isEnabled());
     }
 }

--- a/Tests/FixtureIntegrationTest.php
+++ b/Tests/FixtureIntegrationTest.php
@@ -8,10 +8,8 @@ use Doctrine\Bundle\MongoDBBundle\DependencyInjection\Compiler\FixturesCompilerP
 use Doctrine\Bundle\MongoDBBundle\DoctrineMongoDBBundle;
 use Doctrine\Bundle\MongoDBBundle\Tests\Fixtures\FooBundle\DataFixtures\DependentOnRequiredConstructorArgsFixtures;
 use Doctrine\Bundle\MongoDBBundle\Tests\Fixtures\FooBundle\DataFixtures\OtherFixtures;
-use Doctrine\Bundle\MongoDBBundle\Tests\Fixtures\FooBundle\DataFixtures\RequiredConstructorArgsFixtures;
 use Doctrine\Bundle\MongoDBBundle\Tests\Fixtures\FooBundle\DataFixtures\WithDependenciesFixtures;
 use Doctrine\Bundle\MongoDBBundle\Tests\Fixtures\FooBundle\FooBundle;
-use Doctrine\Common\DataFixtures\Loader;
 use RuntimeException;
 use Symfony\Bridge\Doctrine\DataFixtures\ContainerAwareLoader;
 use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
@@ -22,23 +20,12 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Kernel;
 use Symfony\Component\Routing\RouteCollectionBuilder;
 use function array_map;
-use function class_exists;
 use function get_class;
-use function method_exists;
 use function rand;
 use function sys_get_temp_dir;
 
 class FixtureIntegrationTest extends TestCase
 {
-    protected function setUp()
-    {
-        if (class_exists(Loader::class)) {
-            return;
-        }
-
-        $this->markTestSkipped();
-    }
-
     public function testFixturesLoader() : void
     {
         $kernel = new IntegrationTestKernel('dev', false);
@@ -105,48 +92,10 @@ class FixtureIntegrationTest extends TestCase
 
     /**
      * @expectedException \LogicException
-     * @expectedExceptionMessage The getDependencies() method returned a class (Doctrine\Bundle\MongoDBBundle\Tests\Fixtures\FooBundle\DataFixtures\RequiredConstructorArgsFixtures) that has required constructor arguments. Upgrade to "doctrine/data-fixtures" version 1.3 or higher to support this.
-     */
-    public function testExceptionWithDependenciesWithRequiredArguments() : void
-    {
-        // see https://github.com/doctrine/data-fixtures/pull/274
-        // When that is merged, this test will only run when using
-        // an older version of that library.
-        if (method_exists(Loader::class, 'createFixture')) {
-            $this->markTestSkipped();
-        }
-
-        $kernel = new IntegrationTestKernel('dev', false);
-        $kernel->addServices(static function (ContainerBuilder $c) {
-            $c->autowire(DependentOnRequiredConstructorArgsFixtures::class)
-                ->addTag(FixturesCompilerPass::FIXTURE_TAG);
-
-            $c->autowire(RequiredConstructorArgsFixtures::class)
-                ->setArgument(0, 'foo')
-                ->addTag(FixturesCompilerPass::FIXTURE_TAG);
-
-            $c->setAlias('test.doctrine_mongodb.odm.symfony.fixtures.loader', new Alias('doctrine_mongodb.odm.symfony.fixtures.loader', true));
-        });
-        $kernel->boot();
-        $container = $kernel->getContainer();
-
-        /** @var ContainerAwareLoader $loader */
-        $loader = $container->get('test.doctrine_mongodb.odm.symfony.fixtures.loader');
-
-        $loader->getFixtures();
-    }
-
-    /**
-     * @expectedException \LogicException
      * @expectedExceptionMessage The "Doctrine\Bundle\MongoDBBundle\Tests\Fixtures\FooBundle\DataFixtures\RequiredConstructorArgsFixtures" fixture class is trying to be loaded, but is not available. Make sure this class is defined as a service and tagged with "doctrine.fixture.odm.mongodb".
      */
     public function testExceptionIfDependentFixtureNotWired() : void
     {
-        // only runs on newer versions of doctrine/data-fixtures
-        if (! method_exists(Loader::class, 'createFixture')) {
-            $this->markTestSkipped();
-        }
-
         $kernel = new IntegrationTestKernel('dev', false);
         $kernel->addServices(static function (ContainerBuilder $c) : void {
             $c->autowire(DependentOnRequiredConstructorArgsFixtures::class)

--- a/composer.json
+++ b/composer.json
@@ -25,9 +25,12 @@
         "symfony/http-kernel": "^4.3.7|^5.0",
         "symfony/options-resolver": "^4.3.3|^5.0"
     },
+    "conflict": {
+        "doctrine/data-fixtures": "<1.3"
+    },
     "require-dev": {
         "doctrine/coding-standard": "^6.0",
-        "doctrine/data-fixtures": "^1.2.2",
+        "doctrine/data-fixtures": "^1.3",
         "phpunit/phpunit": "^7.3",
         "squizlabs/php_codesniffer": "^3.5",
         "symfony/form": "^4.3.3|^5.0",


### PR DESCRIPTION
`doctrine/data-fixtures` 1.3 was released in 2017 and this allows to clean up some tests.

Is cherry-picked from https://github.com/doctrine/DoctrineMongoDBBundle/pull/653 so it's easy to review.