### PR TITLE
Update coding standards to 8.2

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -39,7 +39,7 @@ jobs:
           restore-keys: "php-${{ matrix.php-version }}-composer-locked-"
 
       - name: "Install dependencies with Composer"
-        run: "composer install --no-interaction --no-progress --no-suggest"
+        run: "composer update --no-interaction --no-progress --prefer-dist --prefer-stable"
 
       # https://github.com/doctrine/.github/issues/3
       - name: "Run PHP_CodeSniffer"

--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -31,15 +31,11 @@ jobs:
           php-version: "${{ matrix.php-version }}"
           tools: "cs2pr"
 
-      - name: "Cache dependencies installed with Composer"
-        uses: "actions/cache@v2"
-        with:
-          path: "~/.composer/cache"
-          key: "php-${{ matrix.php-version }}-composer-locked-${{ hashFiles('composer.lock') }}"
-          restore-keys: "php-${{ matrix.php-version }}-composer-locked-"
+      - name: "Set minimum-stability to stable in Composer"
+        run: "composer config minimum-stability stable"
 
       - name: "Install dependencies with Composer"
-        run: "composer update --no-interaction --no-progress --prefer-dist --prefer-stable"
+        uses: "ramsey/composer-install@v1"
 
       # https://github.com/doctrine/.github/issues/3
       - name: "Run PHP_CodeSniffer"

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ composer.phar
 composer.lock
 phpunit.xml
 .phpcs-cache
+.phpunit.result.cache

--- a/APM/CommandLoggerRegistry.php
+++ b/APM/CommandLoggerRegistry.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\Bundle\MongoDBBundle\APM;
 
 use Doctrine\ODM\MongoDB\APM\CommandLoggerInterface;
+
 use function array_map;
 
 final class CommandLoggerRegistry
@@ -19,21 +20,21 @@ final class CommandLoggerRegistry
         }
     }
 
-    public function register() : void
+    public function register(): void
     {
         array_map(static function (CommandLoggerInterface $commandLogger) {
             $commandLogger->register();
         }, $this->commandLoggers);
     }
 
-    public function unregister() : void
+    public function unregister(): void
     {
         array_map(static function (CommandLoggerInterface $commandLogger) {
             $commandLogger->unregister();
         }, $this->commandLoggers);
     }
 
-    private function addLogger(CommandLoggerInterface $logger) : void
+    private function addLogger(CommandLoggerInterface $logger): void
     {
         $this->commandLoggers[] = $logger;
     }

--- a/APM/PSRCommandLogger.php
+++ b/APM/PSRCommandLogger.php
@@ -9,6 +9,7 @@ use MongoDB\Driver\Monitoring\CommandFailedEvent;
 use MongoDB\Driver\Monitoring\CommandStartedEvent;
 use MongoDB\Driver\Monitoring\CommandSucceededEvent;
 use Psr\Log\LoggerInterface;
+
 use function json_encode;
 use function MongoDB\Driver\Monitoring\addSubscriber;
 use function MongoDB\Driver\Monitoring\removeSubscriber;
@@ -30,7 +31,7 @@ final class PSRCommandLogger implements CommandLoggerInterface
         $this->prefix = $prefix;
     }
 
-    public function register() : void
+    public function register(): void
     {
         if ($this->logger === null || $this->registered) {
             return;
@@ -40,7 +41,7 @@ final class PSRCommandLogger implements CommandLoggerInterface
         addSubscriber($this);
     }
 
-    public function unregister() : void
+    public function unregister(): void
     {
         if (! $this->registered) {
             return;

--- a/CacheWarmer/HydratorCacheWarmer.php
+++ b/CacheWarmer/HydratorCacheWarmer.php
@@ -10,6 +10,8 @@ use Doctrine\Persistence\ManagerRegistry;
 use RuntimeException;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpKernel\CacheWarmer\CacheWarmerInterface;
+
+use function assert;
 use function dirname;
 use function file_exists;
 use function is_writable;
@@ -42,6 +44,9 @@ class HydratorCacheWarmer implements CacheWarmerInterface
         return false;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     public function warmUp($cacheDir)
     {
         // we need the directory no matter the hydrator cache generation strategy.
@@ -58,8 +63,8 @@ class HydratorCacheWarmer implements CacheWarmerInterface
             return;
         }
 
-        /** @var ManagerRegistry $registry */
         $registry = $this->container->get('doctrine_mongodb');
+        assert($registry instanceof ManagerRegistry);
         foreach ($registry->getManagers() as $dm) {
             /** @var DocumentManager $dm */
             $classes = $dm->getMetadataFactory()->getAllMetadata();

--- a/CacheWarmer/PersistentCollectionCacheWarmer.php
+++ b/CacheWarmer/PersistentCollectionCacheWarmer.php
@@ -10,6 +10,8 @@ use Doctrine\Persistence\ManagerRegistry;
 use RuntimeException;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpKernel\CacheWarmer\CacheWarmerInterface;
+
+use function assert;
 use function dirname;
 use function file_exists;
 use function in_array;
@@ -43,6 +45,9 @@ class PersistentCollectionCacheWarmer implements CacheWarmerInterface
         return false;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     public function warmUp($cacheDir)
     {
         // we need the directory no matter the hydrator cache generation strategy.
@@ -61,8 +66,8 @@ class PersistentCollectionCacheWarmer implements CacheWarmerInterface
         }
 
         $generated = [];
-        /** @var ManagerRegistry $registry */
-        $registry = $this->container->get('doctrine_mongodb');
+        $registry  = $this->container->get('doctrine_mongodb');
+        assert($registry instanceof ManagerRegistry);
         foreach ($registry->getManagers() as $dm) {
             /** @var DocumentManager $dm */
             $collectionGenerator = $dm->getConfiguration()->getPersistentCollectionGenerator();
@@ -73,6 +78,7 @@ class PersistentCollectionCacheWarmer implements CacheWarmerInterface
                     if (empty($mapping['collectionClass']) || in_array($mapping['collectionClass'], $generated)) {
                         continue;
                     }
+
                     $generated[] = $mapping['collectionClass'];
                     $collectionGenerator->generateClass($mapping['collectionClass'], $collCacheDir);
                 }

--- a/CacheWarmer/ProxyCacheWarmer.php
+++ b/CacheWarmer/ProxyCacheWarmer.php
@@ -11,7 +11,9 @@ use Doctrine\Persistence\ManagerRegistry;
 use RuntimeException;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpKernel\CacheWarmer\CacheWarmerInterface;
+
 use function array_filter;
+use function assert;
 use function dirname;
 use function file_exists;
 use function is_writable;
@@ -44,6 +46,9 @@ class ProxyCacheWarmer implements CacheWarmerInterface
         return false;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     public function warmUp($cacheDir)
     {
         // we need the directory no matter the proxy cache generation strategy.
@@ -60,8 +65,8 @@ class ProxyCacheWarmer implements CacheWarmerInterface
             return;
         }
 
-        /** @var ManagerRegistry $registry */
         $registry = $this->container->get('doctrine_mongodb');
+        assert($registry instanceof ManagerRegistry);
         foreach ($registry->getManagers() as $dm) {
             /** @var DocumentManager $dm */
             $classes = $this->getClassesForProxyGeneration($dm);

--- a/Command/ClearMetadataCacheDoctrineODMCommand.php
+++ b/Command/ClearMetadataCacheDoctrineODMCommand.php
@@ -36,6 +36,9 @@ EOT
         );
     }
 
+    /**
+     * @return int
+     */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         DoctrineODMCommand::setApplicationDocumentManager($this->getApplication(), $input->getOption('dm'));

--- a/Command/CreateSchemaDoctrineODMCommand.php
+++ b/Command/CreateSchemaDoctrineODMCommand.php
@@ -36,6 +36,9 @@ EOT
         );
     }
 
+    /**
+     * @return int
+     */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         DoctrineODMCommand::setApplicationDocumentManager($this->getApplication(), $input->getOption('dm'));

--- a/Command/DoctrineODMCommand.php
+++ b/Command/DoctrineODMCommand.php
@@ -6,6 +6,7 @@ namespace Doctrine\Bundle\MongoDBBundle\Command;
 
 use Doctrine\Bundle\MongoDBBundle\ManagerRegistry;
 use Doctrine\ODM\MongoDB\Tools\Console\Helper\DocumentManagerHelper;
+use Doctrine\Persistence\ObjectManager;
 use InvalidArgumentException;
 use RuntimeException;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
@@ -14,10 +15,13 @@ use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
-use const DIRECTORY_SEPARATOR;
+
+use function assert;
 use function sprintf;
 use function str_replace;
 use function strtolower;
+
+use const DIRECTORY_SEPARATOR;
 
 /**
  * Base class for Doctrine ODM console commands to extend.
@@ -44,6 +48,9 @@ abstract class DoctrineODMCommand extends Command implements ContainerAwareInter
         return $this->container;
     }
 
+    /**
+     * @param string $dmName
+     */
     public static function setApplicationDocumentManager(Application $application, $dmName)
     {
         $dm        = $application->getKernel()->getContainer()->get('doctrine_mongodb')->getManager($dmName);
@@ -51,6 +58,9 @@ abstract class DoctrineODMCommand extends Command implements ContainerAwareInter
         $helperSet->set(new DocumentManagerHelper($dm), 'dm');
     }
 
+    /**
+     * @return ObjectManager[]
+     */
     protected function getDoctrineDocumentManagers()
     {
         return $this->getManagerRegistry()->getManagers();
@@ -58,6 +68,8 @@ abstract class DoctrineODMCommand extends Command implements ContainerAwareInter
 
     /**
      * @internal
+     *
+     * @return ManagerRegistry
      */
     protected function getManagerRegistry()
     {
@@ -68,11 +80,16 @@ abstract class DoctrineODMCommand extends Command implements ContainerAwareInter
         return $this->managerRegistry;
     }
 
+    /**
+     * @param string $bundleName
+     *
+     * @return Bundle
+     */
     protected function findBundle($bundleName)
     {
         $foundBundle = false;
         foreach ($this->getApplication()->getKernel()->getBundles() as $bundle) {
-            /** @var $bundle Bundle */
+            assert($bundle instanceof Bundle);
             if (strtolower($bundleName) === strtolower($bundle->getName())) {
                 $foundBundle = $bundle;
                 break;

--- a/Command/DropSchemaDoctrineODMCommand.php
+++ b/Command/DropSchemaDoctrineODMCommand.php
@@ -36,6 +36,9 @@ EOT
         );
     }
 
+    /**
+     * @return int
+     */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         DoctrineODMCommand::setApplicationDocumentManager($this->getApplication(), $input->getOption('dm'));

--- a/Command/GenerateHydratorsDoctrineODMCommand.php
+++ b/Command/GenerateHydratorsDoctrineODMCommand.php
@@ -35,6 +35,9 @@ EOT
         );
     }
 
+    /**
+     * @return int
+     */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         DoctrineODMCommand::setApplicationDocumentManager($this->getApplication(), $input->getOption('dm'));

--- a/Command/GenerateProxiesDoctrineODMCommand.php
+++ b/Command/GenerateProxiesDoctrineODMCommand.php
@@ -35,6 +35,9 @@ EOT
         );
     }
 
+    /**
+     * @return int
+     */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         DoctrineODMCommand::setApplicationDocumentManager($this->getApplication(), $input->getOption('dm'));

--- a/Command/InfoDoctrineODMCommand.php
+++ b/Command/InfoDoctrineODMCommand.php
@@ -10,6 +10,8 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Throwable;
+
+use function assert;
 use function count;
 use function sprintf;
 
@@ -39,14 +41,17 @@ EOT
         );
     }
 
+    /**
+     * @return int
+     */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $documentManagerName = $input->getOption('dm') ?
             $input->getOption('dm') :
             $this->getManagerRegistry()->getDefaultManagerName();
 
-        /** @var DocumentManager $documentManager */
         $documentManager = $this->getManagerRegistry()->getManager($documentManagerName);
+        assert($documentManager instanceof DocumentManager);
 
         $documentClassNames = $documentManager->getConfiguration()
                                           ->getMetadataDriverImpl()

--- a/Command/LoadDataFixturesDoctrineODMCommand.php
+++ b/Command/LoadDataFixturesDoctrineODMCommand.php
@@ -16,11 +16,13 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\ConfirmationQuestion;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\HttpKernel\KernelInterface;
-use const E_USER_DEPRECATED;
+
 use function class_exists;
 use function implode;
 use function sprintf;
 use function trigger_error;
+
+use const E_USER_DEPRECATED;
 
 /**
  * Load data fixtures from bundles.
@@ -53,7 +55,7 @@ class LoadDataFixturesDoctrineODMCommand extends DoctrineODMCommand
         $this
             ->setDescription('Load data fixtures to your database.')
             ->addOption('services', null, InputOption::VALUE_NONE, 'Use services as fixtures')
-            ->addOption('group', null, InputOption::VALUE_IS_ARRAY|InputOption::VALUE_REQUIRED, 'Only load fixtures that belong to this group (use with --services)')
+            ->addOption('group', null, InputOption::VALUE_IS_ARRAY | InputOption::VALUE_REQUIRED, 'Only load fixtures that belong to this group (use with --services)')
             ->addOption('append', null, InputOption::VALUE_NONE, 'Append the data fixtures instead of flushing the database first.')
             ->addOption('dm', null, InputOption::VALUE_REQUIRED, 'The document manager to use for this command.')
             ->setHelp(<<<EOT
@@ -77,6 +79,9 @@ EOT
         );
     }
 
+    /**
+     * @return int
+     */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $dm = $this->getManagerRegistry()->getManager($input->getOption('dm'));

--- a/Command/QueryDoctrineODMCommand.php
+++ b/Command/QueryDoctrineODMCommand.php
@@ -25,6 +25,9 @@ class QueryDoctrineODMCommand extends QueryCommand
             ->addOption('dm', null, InputOption::VALUE_OPTIONAL, 'The document manager to use for this command.');
     }
 
+    /**
+     * @return int
+     */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         DoctrineODMCommand::setApplicationDocumentManager($this->getApplication(), $input->getOption('dm'));

--- a/Command/ShardDoctrineODMCommand.php
+++ b/Command/ShardDoctrineODMCommand.php
@@ -36,6 +36,9 @@ EOT
         );
     }
 
+    /**
+     * @return int
+     */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         DoctrineODMCommand::setApplicationDocumentManager($this->getApplication(), $input->getOption('dm'));

--- a/Command/TailCursorDoctrineODMCommand.php
+++ b/Command/TailCursorDoctrineODMCommand.php
@@ -16,6 +16,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 use Throwable;
+
 use function sleep;
 use function sprintf;
 
@@ -40,6 +41,9 @@ class TailCursorDoctrineODMCommand extends Command implements ContainerAwareInte
             ->addOption('sleep-time', null, InputOption::VALUE_REQUIRED, 'The number of seconds to wait between two checks.', 10);
     }
 
+    /**
+     * @return int
+     */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $dm                   = $this->getContainer()->get('doctrine_mongodb.odm.document_manager');
@@ -66,6 +70,7 @@ class TailCursorDoctrineODMCommand extends Command implements ContainerAwareInte
                     $output->writeln('<error>Invalid cursor, requerying</error>');
                     $cursor = $repository->$method();
                 }
+
                 $output->writeln('<comment>Nothing found, waiting to try again</comment>');
                 // read all results so far, wait for more
                 sleep($sleepTime);

--- a/Command/UpdateSchemaDoctrineODMCommand.php
+++ b/Command/UpdateSchemaDoctrineODMCommand.php
@@ -36,6 +36,9 @@ EOT
         );
     }
 
+    /**
+     * @return int
+     */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         DoctrineODMCommand::setApplicationDocumentManager($this->getApplication(), $input->getOption('dm'));

--- a/Cursor/TailableCursorProcessorInterface.php
+++ b/Cursor/TailableCursorProcessorInterface.php
@@ -9,5 +9,8 @@ namespace Doctrine\Bundle\MongoDBBundle\Cursor;
  */
 interface TailableCursorProcessorInterface
 {
+    /**
+     * @param mixed $document
+     */
     public function process($document);
 }

--- a/DataCollector/CommandDataCollector.php
+++ b/DataCollector/CommandDataCollector.php
@@ -10,6 +10,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\DataCollector\DataCollector;
 use Throwable;
+
 use function array_map;
 use function count;
 use function json_encode;
@@ -24,12 +25,12 @@ class CommandDataCollector extends DataCollector
         $this->commandLogger = $commandLogger;
     }
 
-    public function collect(Request $request, Response $response, ?Throwable $exception = null) : void
+    public function collect(Request $request, Response $response, ?Throwable $exception = null): void
     {
         $this->data = [
             'num_commands' => count($this->commandLogger),
             'commands' => array_map(
-                static function (Command $command) : string {
+                static function (Command $command): string {
                     return json_encode($command->getCommand());
                 },
                 $this->commandLogger->getAll()
@@ -37,7 +38,7 @@ class CommandDataCollector extends DataCollector
         ];
     }
 
-    public function reset() : void
+    public function reset(): void
     {
         $this->commandLogger->clear();
         $this->data = [
@@ -46,7 +47,7 @@ class CommandDataCollector extends DataCollector
         ];
     }
 
-    public function getCommandCount() : int
+    public function getCommandCount(): int
     {
         return $this->data['num_commands'];
     }
@@ -54,12 +55,12 @@ class CommandDataCollector extends DataCollector
     /**
      * @return string[]
      */
-    public function getCommands() : array
+    public function getCommands(): array
     {
         return $this->data['commands'];
     }
 
-    public function getName() : string
+    public function getName(): string
     {
         return 'mongodb';
     }

--- a/DependencyInjection/Compiler/CreateHydratorDirectoryPass.php
+++ b/DependencyInjection/Compiler/CreateHydratorDirectoryPass.php
@@ -7,6 +7,7 @@ namespace Doctrine\Bundle\MongoDBBundle\DependencyInjection\Compiler;
 use RuntimeException;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+
 use function dirname;
 use function is_dir;
 use function is_writable;
@@ -20,10 +21,12 @@ class CreateHydratorDirectoryPass implements CompilerPassInterface
         if (! $container->hasParameter('doctrine_mongodb.odm.hydrator_dir')) {
             return;
         }
+
         // Don't do anything if auto_generate_hydrator_classes is false
         if (! $container->getParameter('doctrine_mongodb.odm.auto_generate_hydrator_classes')) {
             return;
         }
+
         // Create document proxy directory
         $hydratorCacheDir = $container->getParameter('doctrine_mongodb.odm.hydrator_dir');
         if (! is_dir($hydratorCacheDir)) {

--- a/DependencyInjection/Compiler/CreateProxyDirectoryPass.php
+++ b/DependencyInjection/Compiler/CreateProxyDirectoryPass.php
@@ -7,6 +7,7 @@ namespace Doctrine\Bundle\MongoDBBundle\DependencyInjection\Compiler;
 use RuntimeException;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+
 use function dirname;
 use function is_dir;
 use function is_writable;
@@ -20,10 +21,12 @@ class CreateProxyDirectoryPass implements CompilerPassInterface
         if (! $container->hasParameter('doctrine_mongodb.odm.proxy_dir')) {
             return;
         }
+
         // Don't do anything if auto_generate_proxy_classes is false
         if (! $container->getParameter('doctrine_mongodb.odm.auto_generate_proxy_classes')) {
             return;
         }
+
         // Create document proxy directory
         $proxyCacheDir = $container->getParameter('doctrine_mongodb.odm.proxy_dir');
         if (! is_dir($proxyCacheDir)) {

--- a/DependencyInjection/Compiler/DoctrineMongoDBMappingsPass.php
+++ b/DependencyInjection/Compiler/DoctrineMongoDBMappingsPass.php
@@ -57,6 +57,8 @@ class DoctrineMongoDBMappingsPass extends RegisterMappingsPass
      *                                    enable the mapping. Set to false to not do any check,
      *                                    optional.
      * @param string[] $aliasMap          Map of alias to namespace.
+     *
+     * @return DoctrineMongoDBMappingsPass
      */
     public static function createXmlMappingDriver(array $mappings, array $managerParameters, $enabledParameter = false, array $aliasMap = [])
     {
@@ -77,6 +79,8 @@ class DoctrineMongoDBMappingsPass extends RegisterMappingsPass
      *                                    enable the mapping. Set to false to not do any check,
      *                                    optional.
      * @param string[] $aliasMap          Map of alias to namespace.
+     *
+     * @return DoctrineMongoDBMappingsPass
      */
     public static function createPhpMappingDriver(array $mappings, array $managerParameters = [], $enabledParameter = false, array $aliasMap = [])
     {
@@ -98,6 +102,8 @@ class DoctrineMongoDBMappingsPass extends RegisterMappingsPass
      *                                    enable the mapping. Set to false to not do any check,
      *                                    optional.
      * @param string[] $aliasMap          Map of alias to namespace.
+     *
+     * @return DoctrineMongoDBMappingsPass
      */
     public static function createAnnotationMappingDriver(array $namespaces, array $directories, array $managerParameters, $enabledParameter = false, array $aliasMap = [])
     {
@@ -117,6 +123,8 @@ class DoctrineMongoDBMappingsPass extends RegisterMappingsPass
      *                                    enable the mapping. Set to false to not do any check,
      *                                    optional.
      * @param string[] $aliasMap          Map of alias to namespace.
+     *
+     * @return DoctrineMongoDBMappingsPass
      */
     public static function createStaticPhpMappingDriver(array $namespaces, array $directories, array $managerParameters = [], $enabledParameter = false, array $aliasMap = [])
     {

--- a/DependencyInjection/Compiler/ServiceRepositoryCompilerPass.php
+++ b/DependencyInjection/Compiler/ServiceRepositoryCompilerPass.php
@@ -8,6 +8,7 @@ use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\Compiler\ServiceLocatorTagPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
+
 use function array_combine;
 use function array_keys;
 use function array_map;

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -12,6 +12,7 @@ use Symfony\Bridge\Doctrine\DataFixtures\ContainerAwareLoader;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
+
 use function class_parents;
 use function count;
 use function in_array;

--- a/DependencyInjection/DoctrineMongoDBExtension.php
+++ b/DependencyInjection/DoctrineMongoDBExtension.php
@@ -23,6 +23,7 @@ use Symfony\Component\DependencyInjection\DefinitionDecorator;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\Messenger\MessageBusInterface;
+
 use function array_keys;
 use function array_merge;
 use function class_exists;
@@ -54,12 +55,14 @@ class DoctrineMongoDBExtension extends AbstractDoctrineExtension
             $keys                         = array_keys($config['connections']);
             $config['default_connection'] = reset($keys);
         }
+
         $container->setParameter('doctrine_mongodb.odm.default_connection', $config['default_connection']);
 
         if (empty($config['default_document_manager'])) {
             $keys                               = array_keys($config['document_managers']);
             $config['default_document_manager'] = reset($keys);
         }
+
         $container->setParameter('doctrine_mongodb.odm.default_document_manager', $config['default_document_manager']);
 
         if (! empty($config['types'])) {
@@ -122,6 +125,8 @@ class DoctrineMongoDBExtension extends AbstractDoctrineExtension
      *
      * @param array            $options   The available configuration options
      * @param ContainerBuilder $container A ContainerBuilder instance
+     *
+     * @return array<string, mixed>
      */
     protected function overrideParameters($options, ContainerBuilder $container)
     {
@@ -173,6 +178,7 @@ class DoctrineMongoDBExtension extends AbstractDoctrineExtension
             );
             $dms[$name] = sprintf('doctrine_mongodb.odm.%s_document_manager', $name);
         }
+
         $container->setParameter('doctrine_mongodb.odm.document_managers', $dms);
     }
 
@@ -265,6 +271,7 @@ class DoctrineMongoDBExtension extends AbstractDoctrineExtension
             if ($odmConfigDef->hasMethodCall($method)) {
                 $odmConfigDef->removeMethodCall($method);
             }
+
             $odmConfigDef->addMethodCall($method, [$arg]);
         }
 
@@ -420,36 +427,53 @@ class DoctrineMongoDBExtension extends AbstractDoctrineExtension
 
                 $this->aliasMap = array_merge($call[1][0], $this->aliasMap);
             }
+
             $method = $odmConfigDef->removeMethodCall('setDocumentNamespaces');
         }
+
         $odmConfigDef->addMethodCall('setDocumentNamespaces', [$this->aliasMap]);
     }
 
+    /**
+     * {@inheritDoc}
+     */
     protected function getObjectManagerElementName($name)
     {
         return 'doctrine_mongodb.odm.' . $name;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     protected function getMappingObjectDefaultName()
     {
         return 'Document';
     }
 
+    /**
+     * {@inheritDoc}
+     */
     protected function getMappingResourceConfigDirectory()
     {
         return 'Resources/config/doctrine';
     }
 
+    /**
+     * {@inheritDoc}
+     */
     protected function getMappingResourceExtension()
     {
         return 'mongodb';
     }
 
-    protected function getMetadataDriverClass(string $driverType) : string
+    protected function getMetadataDriverClass(string $driverType): string
     {
         return '%' . $this->getObjectManagerElementName('metadata.' . $driverType . '.class') . '%';
     }
 
+    /**
+     * {@inheritDoc}
+     */
     public function getAlias()
     {
         return 'doctrine_mongodb';

--- a/DoctrineMongoDBBundle.php
+++ b/DoctrineMongoDBBundle.php
@@ -17,6 +17,8 @@ use Symfony\Bridge\Doctrine\DependencyInjection\Security\UserProvider\EntityFact
 use Symfony\Component\DependencyInjection\Compiler\PassConfig;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
+
+use function assert;
 use function spl_autoload_register;
 use function spl_autoload_unregister;
 
@@ -44,6 +46,9 @@ class DoctrineMongoDBBundle extends Bundle
         $container->getExtension('security')->addUserProviderFactory(new EntityFactory('mongodb', 'doctrine_mongodb.odm.security.user.provider'));
     }
 
+    /**
+     * {@inheritDoc}
+     */
     public function getContainerExtension()
     {
         return new DoctrineMongoDBExtension();
@@ -51,14 +56,14 @@ class DoctrineMongoDBBundle extends Bundle
 
     public function boot()
     {
-        /** @var ManagerRegistry $registry */
         $registry = $this->container->get('doctrine_mongodb');
+        assert($registry instanceof ManagerRegistry);
 
         $this->registerAutoloader($registry->getManager());
         $this->registerCommandLoggers();
     }
 
-    private function registerAutoloader(DocumentManager $documentManager) : void
+    private function registerAutoloader(DocumentManager $documentManager): void
     {
         $configuration = $documentManager->getConfiguration();
         if ($configuration->getAutoGenerateProxyClasses() !== Configuration::AUTOGENERATE_FILE_NOT_EXISTS) {
@@ -70,7 +75,7 @@ class DoctrineMongoDBBundle extends Bundle
         spl_autoload_register($this->autoloader);
     }
 
-    private function unregisterAutoloader() : void
+    private function unregisterAutoloader(): void
     {
         if ($this->autoloader === null) {
             return;
@@ -80,13 +85,13 @@ class DoctrineMongoDBBundle extends Bundle
         $this->autoloader = null;
     }
 
-    private function registerCommandLoggers() : void
+    private function registerCommandLoggers(): void
     {
         $commandLoggerRegistry = $this->container->get('doctrine_mongodb.odm.command_logger_registry');
         $commandLoggerRegistry->register();
     }
 
-    private function unregisterCommandLoggers() : void
+    private function unregisterCommandLoggers(): void
     {
         $commandLoggerRegistry = $this->container->get('doctrine_mongodb.odm.command_logger_registry');
         $commandLoggerRegistry->unregister();

--- a/Form/ChoiceList/MongoDBQueryBuilderLoader.php
+++ b/Form/ChoiceList/MongoDBQueryBuilderLoader.php
@@ -9,6 +9,7 @@ use Doctrine\ODM\MongoDB\Query\Builder;
 use Doctrine\Persistence\ObjectManager;
 use Symfony\Bridge\Doctrine\Form\ChoiceList\EntityLoaderInterface;
 use Symfony\Component\Form\Exception\UnexpectedTypeException;
+
 use function array_values;
 
 /**

--- a/Form/DoctrineMongoDBExtension.php
+++ b/Form/DoctrineMongoDBExtension.php
@@ -20,6 +20,9 @@ class DoctrineMongoDBExtension extends AbstractExtension
         $this->registry = $registry;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     protected function loadTypes()
     {
         return [
@@ -27,6 +30,9 @@ class DoctrineMongoDBExtension extends AbstractExtension
         ];
     }
 
+    /**
+     * {@inheritDoc}
+     */
     protected function loadTypeGuesser()
     {
         return new DoctrineMongoDBTypeGuesser($this->registry);

--- a/Form/DoctrineMongoDBTypeGuesser.php
+++ b/Form/DoctrineMongoDBTypeGuesser.php
@@ -18,6 +18,7 @@ use Symfony\Component\Form\FormTypeGuesserInterface;
 use Symfony\Component\Form\Guess\Guess;
 use Symfony\Component\Form\Guess\TypeGuess;
 use Symfony\Component\Form\Guess\ValueGuess;
+
 use function array_key_exists;
 use function method_exists;
 
@@ -80,6 +81,7 @@ class DoctrineMongoDBTypeGuesser implements FormTypeGuesserInterface
                     [],
                     Guess::MEDIUM_CONFIDENCE
                 );
+
             case 'bool':
             case 'boolean':
                 return new TypeGuess(
@@ -87,6 +89,7 @@ class DoctrineMongoDBTypeGuesser implements FormTypeGuesserInterface
                     [],
                     Guess::HIGH_CONFIDENCE
                 );
+
             case 'date':
             case 'timestamp':
                 return new TypeGuess(
@@ -94,12 +97,14 @@ class DoctrineMongoDBTypeGuesser implements FormTypeGuesserInterface
                     [],
                     Guess::HIGH_CONFIDENCE
                 );
+
             case 'float':
                 return new TypeGuess(
                     $this->typeFQCN ? NumberType::class : 'number',
                     [],
                     Guess::MEDIUM_CONFIDENCE
                 );
+
             case 'int':
             case 'integer':
                 return new TypeGuess(
@@ -107,6 +112,7 @@ class DoctrineMongoDBTypeGuesser implements FormTypeGuesserInterface
                     [],
                     Guess::MEDIUM_CONFIDENCE
                 );
+
             case 'string':
                 return new TypeGuess(
                     $this->typeFQCN ? TextType::class : 'text',
@@ -182,6 +188,11 @@ class DoctrineMongoDBTypeGuesser implements FormTypeGuesserInterface
         }
     }
 
+    /**
+     * @param string $class
+     *
+     * @return array{ClassMetadata, string}|null
+     */
     protected function getMetadata($class)
     {
         if (array_key_exists($class, $this->cache)) {

--- a/Form/Type/DocumentType.php
+++ b/Form/Type/DocumentType.php
@@ -11,6 +11,7 @@ use InvalidArgumentException;
 use Symfony\Bridge\Doctrine\Form\Type\DoctrineType;
 use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+
 use function interface_exists;
 
 /**
@@ -19,7 +20,7 @@ use function interface_exists;
 class DocumentType extends DoctrineType
 {
     /**
-     * @see Symfony\Bridge\Doctrine\Form\Type\DoctrineType::getLoader()
+     * {@inheritDoc}
      */
     public function getLoader(ObjectManager $manager, $queryBuilder, $class)
     {

--- a/Loader/SymfonyFixturesLoader.php
+++ b/Loader/SymfonyFixturesLoader.php
@@ -12,6 +12,7 @@ use LogicException;
 use ReflectionClass;
 use RuntimeException;
 use Symfony\Bridge\Doctrine\DataFixtures\ContainerAwareLoader;
+
 use function array_key_exists;
 use function array_values;
 use function get_class;

--- a/ManagerConfigurator.php
+++ b/ManagerConfigurator.php
@@ -58,7 +58,7 @@ class ManagerConfigurator
      *
      * @throws MappingException
      */
-    public static function loadTypes(array $types) : void
+    public static function loadTypes(array $types): void
     {
         foreach ($types as $typeName => $typeConfig) {
             if (Type::hasType($typeName)) {

--- a/ManagerRegistry.php
+++ b/ManagerRegistry.php
@@ -8,11 +8,18 @@ use Doctrine\ODM\MongoDB\MongoDBException;
 use Symfony\Bridge\Doctrine\ManagerRegistry as BaseManagerRegistry;
 use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 use Symfony\Component\DependencyInjection\ContainerInterface;
+
 use function array_keys;
 use function class_uses;
 
 class ManagerRegistry extends BaseManagerRegistry
 {
+    /**
+     * @param string $name
+     * @param string $defaultConnection
+     * @param string $defaultManager
+     * @param string $proxyInterfaceName
+     */
     public function __construct($name, array $connections, array $managers, $defaultConnection, $defaultManager, $proxyInterfaceName, ?ContainerInterface $container = null)
     {
         $parentTraits = class_uses(parent::class);

--- a/Repository/ContainerRepositoryFactory.php
+++ b/Repository/ContainerRepositoryFactory.php
@@ -12,6 +12,7 @@ use Doctrine\ODM\MongoDB\Repository\RepositoryFactory;
 use Doctrine\Persistence\ObjectRepository;
 use Psr\Container\ContainerInterface;
 use RuntimeException;
+
 use function class_exists;
 use function is_a;
 use function spl_object_hash;
@@ -36,10 +37,7 @@ final class ContainerRepositoryFactory implements RepositoryFactory
         $this->container = $container;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getRepository(DocumentManager $documentManager, string $documentName) : ObjectRepository
+    public function getRepository(DocumentManager $documentManager, string $documentName): ObjectRepository
     {
         $metadata             = $documentManager->getClassMetadata($documentName);
         $customRepositoryName = $metadata->customRepositoryClassName;
@@ -71,7 +69,7 @@ final class ContainerRepositoryFactory implements RepositoryFactory
         return $this->getOrCreateRepository($documentManager, $metadata);
     }
 
-    private function getOrCreateRepository(DocumentManager $documentManager, ClassMetadata $metadata)
+    private function getOrCreateRepository(DocumentManager $documentManager, ClassMetadata $metadata): ObjectRepository
     {
         $repositoryHash = $metadata->getName() . spl_object_hash($documentManager);
         if (isset($this->managedRepositories[$repositoryHash])) {

--- a/Repository/ServiceRepositoryTrait.php
+++ b/Repository/ServiceRepositoryTrait.php
@@ -7,6 +7,8 @@ namespace Doctrine\Bundle\MongoDBBundle\Repository;
 use Doctrine\ODM\MongoDB\DocumentManager;
 use Doctrine\Persistence\ManagerRegistry;
 use LogicException;
+
+use function assert;
 use function sprintf;
 
 trait ServiceRepositoryTrait
@@ -16,8 +18,8 @@ trait ServiceRepositoryTrait
      */
     public function __construct(ManagerRegistry $registry, $documentClass)
     {
-        /** @var DocumentManager $manager */
         $manager = $registry->getManagerForClass($documentClass);
+        assert($manager instanceof DocumentManager || $manager === null);
 
         if ($manager === null) {
             throw new LogicException(sprintf(

--- a/Tests/CacheWarmer/HydratorCacheWarmerTest.php
+++ b/Tests/CacheWarmer/HydratorCacheWarmerTest.php
@@ -10,9 +10,11 @@ use Doctrine\Bundle\MongoDBBundle\Tests\TestCase;
 use Doctrine\ODM\MongoDB\Configuration;
 use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\DependencyInjection\ContainerInterface;
-use const DIRECTORY_SEPARATOR;
+
 use function sys_get_temp_dir;
 use function unlink;
+
+use const DIRECTORY_SEPARATOR;
 
 class HydratorCacheWarmerTest extends TestCase
 {
@@ -22,7 +24,7 @@ class HydratorCacheWarmerTest extends TestCase
     /** @var HydratorCacheWarmer */
     private $warmer;
 
-    protected function setUp() : void
+    protected function setUp(): void
     {
         $this->container = new Container();
         $this->container->setParameter('doctrine_mongodb.odm.hydrator_dir', sys_get_temp_dir());
@@ -31,18 +33,18 @@ class HydratorCacheWarmerTest extends TestCase
         $dm = $this->createTestDocumentManager([__DIR__ . '/../Fixtures/Validator']);
 
         $registryStub = $this->getMockBuilder(ManagerRegistry::class)->disableOriginalConstructor()->getMock();
-        $registryStub->method('getManagers')->willReturn([ $dm ]);
+        $registryStub->method('getManagers')->willReturn([$dm]);
         $this->container->set('doctrine_mongodb', $registryStub);
 
         $this->warmer = new HydratorCacheWarmer($this->container);
     }
 
-    public function testWarmerNotOptional()
+    public function testWarmerNotOptional(): void
     {
         $this->assertFalse($this->warmer->isOptional());
     }
 
-    public function testWarmerExecuted()
+    public function testWarmerExecuted(): void
     {
         $hydratorFilename = $this->getHydratorFilename();
 
@@ -57,7 +59,7 @@ class HydratorCacheWarmerTest extends TestCase
     /**
      * @dataProvider provideWarmerNotExecuted
      */
-    public function testWarmerNotExecuted($autoGenerate)
+    public function testWarmerNotExecuted(int $autoGenerate): void
     {
         $this->container->setParameter('doctrine_mongodb.odm.auto_generate_hydrator_classes', $autoGenerate);
         $hydratorFilename = $this->getHydratorFilename();
@@ -70,7 +72,10 @@ class HydratorCacheWarmerTest extends TestCase
         }
     }
 
-    public function provideWarmerNotExecuted()
+    /**
+     * @return array<array{int}>
+     */
+    public function provideWarmerNotExecuted(): array
     {
         return [
             [ Configuration::AUTOGENERATE_ALWAYS ],
@@ -79,7 +84,7 @@ class HydratorCacheWarmerTest extends TestCase
         ];
     }
 
-    private function getHydratorFilename() : string
+    private function getHydratorFilename(): string
     {
         return sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'DoctrineBundleMongoDBBundleTestsFixturesValidatorDocumentHydrator.php';
     }

--- a/Tests/CacheWarmer/PersistentCollectionCacheWarmerTest.php
+++ b/Tests/CacheWarmer/PersistentCollectionCacheWarmerTest.php
@@ -11,6 +11,7 @@ use Doctrine\ODM\MongoDB\PersistentCollection\PersistentCollectionGenerator;
 use Doctrine\Persistence\ManagerRegistry;
 use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\DependencyInjection\ContainerInterface;
+
 use function sys_get_temp_dir;
 
 class PersistentCollectionCacheWarmerTest extends TestCase
@@ -23,7 +24,7 @@ class PersistentCollectionCacheWarmerTest extends TestCase
     /** @var PersistentCollectionCacheWarmer */
     private $warmer;
 
-    protected function setUp() : void
+    protected function setUp(): void
     {
         $this->container = new Container();
         $this->container->setParameter('doctrine_mongodb.odm.persistent_collection_dir', sys_get_temp_dir());
@@ -35,18 +36,18 @@ class PersistentCollectionCacheWarmerTest extends TestCase
         $dm->getConfiguration()->setPersistentCollectionGenerator($this->generatorMock);
 
         $registryStub = $this->getMockBuilder(ManagerRegistry::class)->getMock();
-        $registryStub->method('getManagers')->willReturn([ $dm ]);
+        $registryStub->method('getManagers')->willReturn([$dm]);
         $this->container->set('doctrine_mongodb', $registryStub);
 
         $this->warmer = new PersistentCollectionCacheWarmer($this->container);
     }
 
-    public function testWarmerNotOptional()
+    public function testWarmerNotOptional(): void
     {
         $this->assertFalse($this->warmer->isOptional());
     }
 
-    public function testWarmerExecuted()
+    public function testWarmerExecuted(): void
     {
         $this->generatorMock->expects($this->exactly(2))->method('generateClass');
         $this->warmer->warmUp('meh');
@@ -55,14 +56,14 @@ class PersistentCollectionCacheWarmerTest extends TestCase
     /**
      * @dataProvider provideWarmerNotExecuted
      */
-    public function testWarmerNotExecuted($autoGenerate)
+    public function testWarmerNotExecuted(int $autoGenerate): void
     {
         $this->container->setParameter('doctrine_mongodb.odm.auto_generate_persistent_collection_classes', $autoGenerate);
         $this->generatorMock->expects($this->exactly(0))->method('generateClass');
         $this->warmer->warmUp('meh');
     }
 
-    public function provideWarmerNotExecuted()
+    public function provideWarmerNotExecuted(): array
     {
         return [
             [ Configuration::AUTOGENERATE_ALWAYS ],

--- a/Tests/CacheWarmer/ProxyCacheWarmerTest.php
+++ b/Tests/CacheWarmer/ProxyCacheWarmerTest.php
@@ -13,6 +13,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use ReflectionObject;
 use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\DependencyInjection\ContainerInterface;
+
 use function sys_get_temp_dir;
 
 class ProxyCacheWarmerTest extends TestCase
@@ -26,7 +27,7 @@ class ProxyCacheWarmerTest extends TestCase
     /** @var ProxyCacheWarmer */
     private $warmer;
 
-    protected function setUp() : void
+    protected function setUp(): void
     {
         $this->container = new Container();
         $this->container->setParameter('doctrine_mongodb.odm.proxy_dir', sys_get_temp_dir());
@@ -41,18 +42,18 @@ class ProxyCacheWarmerTest extends TestCase
         $p->setValue($dm, $this->proxyMock);
 
         $registryStub = $this->getMockBuilder(ManagerRegistry::class)->disableOriginalConstructor()->getMock();
-        $registryStub->method('getManagers')->willReturn([ $dm ]);
+        $registryStub->method('getManagers')->willReturn([$dm]);
         $this->container->set('doctrine_mongodb', $registryStub);
 
         $this->warmer = new ProxyCacheWarmer($this->container);
     }
 
-    public function testWarmerNotOptional()
+    public function testWarmerNotOptional(): void
     {
         $this->assertFalse($this->warmer->isOptional());
     }
 
-    public function testWarmerExecuted()
+    public function testWarmerExecuted(): void
     {
         $this->container->setParameter('doctrine_mongodb.odm.auto_generate_proxy_classes', Configuration::AUTOGENERATE_FILE_NOT_EXISTS);
 
@@ -63,7 +64,7 @@ class ProxyCacheWarmerTest extends TestCase
         $this->warmer->warmUp('meh');
     }
 
-    public function testWarmerNotExecuted()
+    public function testWarmerNotExecuted(): void
     {
         $this->container->setParameter('doctrine_mongodb.odm.auto_generate_proxy_classes', Configuration::AUTOGENERATE_EVAL);
         $this->proxyMock->expects($this->exactly(0))->method('generateProxyClasses');

--- a/Tests/Command/LoadDataFixturesDoctrineODMCommandTest.php
+++ b/Tests/Command/LoadDataFixturesDoctrineODMCommandTest.php
@@ -12,7 +12,7 @@ use Symfony\Component\HttpKernel\KernelInterface;
 
 class LoadDataFixturesDoctrineODMCommandTest extends TestCase
 {
-    protected function setUp() : void
+    protected function setUp(): void
     {
         $registry = $this->createMock(ManagerRegistry::class);
         $kernel   = $this->createMock(KernelInterface::class);
@@ -21,7 +21,7 @@ class LoadDataFixturesDoctrineODMCommandTest extends TestCase
         $this->command = new LoadDataFixturesDoctrineODMCommand($registry, $kernel, $loader);
     }
 
-    public function testCommandIsEnabledWithDependency()
+    public function testCommandIsEnabledWithDependency(): void
     {
         $this->assertTrue($this->command->isEnabled());
     }

--- a/Tests/ContainerTest.php
+++ b/Tests/ContainerTest.php
@@ -10,6 +10,7 @@ use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
+
 use function sys_get_temp_dir;
 
 class ContainerTest extends TestCase
@@ -20,7 +21,7 @@ class ContainerTest extends TestCase
     /** @var DoctrineMongoDBExtension */
     private $extension;
 
-    protected function setUp() : void
+    protected function setUp(): void
     {
         $this->container = new ContainerBuilder(new ParameterBag([
             'kernel.bundles'         => [],
@@ -40,7 +41,7 @@ class ContainerTest extends TestCase
     /**
      * @dataProvider provideLoggerConfigs
      */
-    public function testLoggerConfig(bool $expected, array $config, bool $debug)
+    public function testLoggerConfig(bool $expected, array $config, bool $debug): void
     {
         $this->container->setParameter('kernel.debug', $debug);
         $this->extension->load([$config], $this->container);
@@ -54,7 +55,10 @@ class ContainerTest extends TestCase
         $this->container->get('doctrine_mongodb.odm.command_logger_registry');
     }
 
-    public function provideLoggerConfigs()
+    /**
+     * @return array<string, array{expected: bool, config: array, debug: bool}>
+     */
+    public function provideLoggerConfigs(): array
     {
         $config = ['connections' => ['default' => []]];
 
@@ -89,7 +93,7 @@ class ContainerTest extends TestCase
     /**
      * @dataProvider provideDataCollectorConfigs
      */
-    public function testDataCollectorConfig(bool $expected, array $config, bool $debug)
+    public function testDataCollectorConfig(bool $expected, array $config, bool $debug): void
     {
         $this->container->setParameter('kernel.debug', $debug);
         $this->extension->load([$config], $this->container);
@@ -106,7 +110,10 @@ class ContainerTest extends TestCase
         $this->container->get('doctrine_mongodb.odm.command_logger_registry');
     }
 
-    public function provideDataCollectorConfigs()
+    /**
+     * @return array<string, array{expected: bool, config: array, debug: bool}>
+     */
+    public function provideDataCollectorConfigs(): array
     {
         $config = ['connections' => ['default' => []]];
 

--- a/Tests/DataCollector/CommandDataCollectorTest.php
+++ b/Tests/DataCollector/CommandDataCollectorTest.php
@@ -12,6 +12,9 @@ use Symfony\Component\HttpFoundation\Response;
 
 class CommandDataCollectorTest extends TestCase
 {
+    /**
+     * @doesNotPerformAssertions
+     */
     public function testCollector(): void
     {
         $collector = new CommandDataCollector(new CommandLogger());

--- a/Tests/DataCollector/CommandDataCollectorTest.php
+++ b/Tests/DataCollector/CommandDataCollectorTest.php
@@ -12,7 +12,7 @@ use Symfony\Component\HttpFoundation\Response;
 
 class CommandDataCollectorTest extends TestCase
 {
-    public function testCollector()
+    public function testCollector(): void
     {
         $collector = new CommandDataCollector(new CommandLogger());
 

--- a/Tests/DependencyInjection/AbstractMongoDBExtensionTest.php
+++ b/Tests/DependencyInjection/AbstractMongoDBExtensionTest.php
@@ -29,6 +29,7 @@ use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\Security\Core\User\UserInterface;
+
 use function array_map;
 use function array_search;
 use function class_implements;
@@ -37,9 +38,9 @@ use function reset;
 
 abstract class AbstractMongoDBExtensionTest extends TestCase
 {
-    abstract protected function loadFromFile(ContainerBuilder $container, $file);
+    abstract protected function loadFromFile(ContainerBuilder $container, string $file): void;
 
-    public function testDependencyInjectionConfigurationDefaults()
+    public function testDependencyInjectionConfigurationDefaults(): void
     {
         $container = $this->getContainer();
         $loader    = new DoctrineMongoDBExtension();
@@ -96,7 +97,7 @@ abstract class AbstractMongoDBExtensionTest extends TestCase
         $this->assertEquals('doctrine_mongodb.odm.default_configuration', (string) $arguments[1]);
     }
 
-    public function testSingleDocumentManagerConfiguration()
+    public function testSingleDocumentManagerConfiguration(): void
     {
         $container = $this->getContainer();
         $loader    = new DoctrineMongoDBExtension();
@@ -136,7 +137,7 @@ abstract class AbstractMongoDBExtensionTest extends TestCase
         $this->assertEquals('doctrine_mongodb.odm.default_configuration', (string) $arguments[1]);
     }
 
-    public function testLoadSimpleSingleConnection()
+    public function testLoadSimpleSingleConnection(): void
     {
         $container = $this->getContainer();
         $loader    = new DoctrineMongoDBExtension();
@@ -180,7 +181,7 @@ abstract class AbstractMongoDBExtensionTest extends TestCase
         $this->assertEquals('doctrine_mongodb.odm.default_connection.event_manager', (string) $container->getAlias('doctrine_mongodb.odm.event_manager'));
     }
 
-    public function testLoadSingleConnection()
+    public function testLoadSingleConnection(): void
     {
         $container = $this->getContainer();
         $loader    = new DoctrineMongoDBExtension();
@@ -216,7 +217,7 @@ abstract class AbstractMongoDBExtensionTest extends TestCase
         $this->assertEquals('doctrine_mongodb.odm.default_connection.event_manager', (string) $container->getAlias('doctrine_mongodb.odm.event_manager'));
     }
 
-    public function testLoadMultipleConnections()
+    public function testLoadMultipleConnections(): void
     {
         $container = $this->getContainer();
         $loader    = new DoctrineMongoDBExtension();
@@ -272,7 +273,7 @@ abstract class AbstractMongoDBExtensionTest extends TestCase
         $this->assertEquals('doctrine_mongodb.odm.conn2_connection.event_manager', (string) $container->getAlias('doctrine_mongodb.odm.event_manager'));
     }
 
-    public function testBundleDocumentAliases()
+    public function testBundleDocumentAliases(): void
     {
         $container = $this->getContainer();
         $loader    = new DoctrineMongoDBExtension();
@@ -288,7 +289,7 @@ abstract class AbstractMongoDBExtensionTest extends TestCase
         $this->assertEquals('DoctrineMongoDBBundle\Tests\DependencyInjection\Fixtures\Bundles\XmlBundle\Document', $calls[0][1][0]['XmlBundle']);
     }
 
-    public function testXmlBundleMappingDetection()
+    public function testXmlBundleMappingDetection(): void
     {
         $container = $this->getContainer('XmlBundle');
         $loader    = new DoctrineMongoDBExtension();
@@ -302,7 +303,7 @@ abstract class AbstractMongoDBExtensionTest extends TestCase
         $this->assertEquals('DoctrineMongoDBBundle\Tests\DependencyInjection\Fixtures\Bundles\XmlBundle\Document', $calls[0][1][1]);
     }
 
-    public function testAnnotationsBundleMappingDetection()
+    public function testAnnotationsBundleMappingDetection(): void
     {
         $container = $this->getContainer('AnnotationsBundle');
         $loader    = new DoctrineMongoDBExtension();
@@ -316,7 +317,7 @@ abstract class AbstractMongoDBExtensionTest extends TestCase
         $this->assertEquals('DoctrineMongoDBBundle\Tests\DependencyInjection\Fixtures\Bundles\AnnotationsBundle\Document', $calls[0][1][1]);
     }
 
-    public function testDocumentManagerMetadataCacheDriverConfiguration()
+    public function testDocumentManagerMetadataCacheDriverConfiguration(): void
     {
         $container = $this->getContainer();
         $loader    = new DoctrineMongoDBExtension();
@@ -335,7 +336,7 @@ abstract class AbstractMongoDBExtensionTest extends TestCase
         $this->assertEquals('%doctrine_mongodb.odm.cache.apc.class%', $definition->getClass());
     }
 
-    public function testDocumentManagerMemcachedMetadataCacheDriverConfiguration()
+    public function testDocumentManagerMemcachedMetadataCacheDriverConfiguration(): void
     {
         $container = $this->getContainer();
         $loader    = new DoctrineMongoDBExtension();
@@ -363,7 +364,7 @@ abstract class AbstractMongoDBExtensionTest extends TestCase
         $this->assertEquals(11211, $calls[0][1][1]);
     }
 
-    public function testDependencyInjectionImportsOverrideDefaults()
+    public function testDependencyInjectionImportsOverrideDefaults(): void
     {
         $container = $this->getContainer();
         $loader    = new DoctrineMongoDBExtension();
@@ -380,7 +381,7 @@ abstract class AbstractMongoDBExtensionTest extends TestCase
         $this->assertTrue((bool) $container->getParameter('doctrine_mongodb.odm.auto_generate_proxy_classes'));
     }
 
-    public function testResolveTargetDocument()
+    public function testResolveTargetDocument(): void
     {
         $container = $this->getContainer();
         $loader    = new DoctrineMongoDBExtension();
@@ -402,7 +403,7 @@ abstract class AbstractMongoDBExtensionTest extends TestCase
         }
     }
 
-    public function testFilters()
+    public function testFilters(): void
     {
         $container = $this->getContainer();
         $loader    = new DoctrineMongoDBExtension();
@@ -432,7 +433,7 @@ abstract class AbstractMongoDBExtensionTest extends TestCase
         $this->assertEquals($enabledFilters, $definition->getArgument(0), 'Only enabled filters are passed to the ManagerConfigurator.');
     }
 
-    public function testCustomTypes()
+    public function testCustomTypes(): void
     {
         $container = $this->getContainer();
         $loader    = new DoctrineMongoDBExtension();
@@ -460,7 +461,7 @@ abstract class AbstractMongoDBExtensionTest extends TestCase
      * @param string $methodName
      * @param array  $params
      */
-    private function assertDefinitionMethodCallAny(Definition $definition, $methodName, array $params)
+    private function assertDefinitionMethodCallAny(Definition $definition, $methodName, array $params): void
     {
         $calls     = $definition->getMethodCalls();
         $called    = false;
@@ -498,7 +499,7 @@ abstract class AbstractMongoDBExtensionTest extends TestCase
      * @param string $methodName
      * @param array  $params
      */
-    private function assertDefinitionMethodCallOnce(Definition $definition, $methodName, array $params)
+    private function assertDefinitionMethodCallOnce(Definition $definition, $methodName, array $params): void
     {
         $calls  = $definition->getMethodCalls();
         $called = false;
@@ -524,7 +525,7 @@ abstract class AbstractMongoDBExtensionTest extends TestCase
         $this->fail("Method '" . $methodName . "' is expected to be called once, but it was never called.");
     }
 
-    protected function getContainer($bundle = 'XmlBundle')
+    protected function getContainer(string $bundle = 'XmlBundle'): ContainerBuilder
     {
         require_once __DIR__ . '/Fixtures/Bundles/' . $bundle . '/' . $bundle . '.php';
 

--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -20,12 +20,13 @@ use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 use Symfony\Component\Config\Definition\Processor;
 use Symfony\Component\Config\Util\XmlUtils;
 use Symfony\Component\Yaml\Yaml;
+
 use function array_key_exists;
 use function file_get_contents;
 
 class ConfigurationTest extends TestCase
 {
-    public function testDefaults()
+    public function testDefaults(): void
     {
         $processor     = new Processor();
         $configuration = new Configuration(false);
@@ -46,7 +47,7 @@ class ConfigurationTest extends TestCase
             'hydrator_namespace'             => 'Hydrators',
             'default_commit_options'         => [],
             'persistent_collection_dir'      => '%kernel.cache_dir%/doctrine/odm/mongodb/PersistentCollections',
-            'persistent_collection_namespace'=> 'PersistentCollections',
+            'persistent_collection_namespace' => 'PersistentCollections',
             'types'                          => [],
         ];
 
@@ -56,7 +57,7 @@ class ConfigurationTest extends TestCase
     /**
      * @dataProvider provideFullConfiguration
      */
-    public function testFullConfiguration($config)
+    public function testFullConfiguration(array $config): void
     {
         $processor     = new Processor();
         $configuration = new Configuration(false);
@@ -75,7 +76,7 @@ class ConfigurationTest extends TestCase
             'proxy_dir'                      => '%kernel.cache_dir%/doctrine/odm/mongodb/Test_Proxies',
             'proxy_namespace'                => 'Test_Proxies',
             'persistent_collection_dir'      => '%kernel.cache_dir%/doctrine/odm/mongodb/Test_Pcolls',
-            'persistent_collection_namespace'=> 'Test_Pcolls',
+            'persistent_collection_namespace' => 'Test_Pcolls',
             'default_commit_options' => [
                 'j' => false,
                 'timeout' => 10,
@@ -194,7 +195,10 @@ class ConfigurationTest extends TestCase
         $this->assertEquals($expected, $options);
     }
 
-    public function provideFullConfiguration()
+    /**
+     * @return array<mixed[]>
+     */
+    public function provideFullConfiguration(): array
     {
         $yaml = Yaml::parse(file_get_contents(__DIR__ . '/Fixtures/config/yml/full.yml'));
         $yaml = $yaml['doctrine_mongodb'];
@@ -214,7 +218,7 @@ class ConfigurationTest extends TestCase
      *
      * @dataProvider provideMergeOptions
      */
-    public function testMergeOptions(array $configs, array $expected)
+    public function testMergeOptions(array $configs, array $expected): void
     {
         $processor     = new Processor();
         $configuration = new Configuration(false);
@@ -225,7 +229,10 @@ class ConfigurationTest extends TestCase
         }
     }
 
-    public function provideMergeOptions()
+    /**
+     * @return array<mixed[]>
+     */
+    public function provideMergeOptions(): array
     {
         $cases = [];
 
@@ -335,7 +342,7 @@ class ConfigurationTest extends TestCase
      *
      * @dataProvider provideNormalizeOptions
      */
-    public function testNormalizeOptions(array $config, array $expected)
+    public function testNormalizeOptions(array $config, array $expected): void
     {
         $processor     = new Processor();
         $configuration = new Configuration(false);
@@ -346,7 +353,10 @@ class ConfigurationTest extends TestCase
         }
     }
 
-    public function provideNormalizeOptions()
+    /**
+     * @return array<mixed[]>
+     */
+    public function provideNormalizeOptions(): array
     {
         $cases = [];
 
@@ -418,7 +428,7 @@ class ConfigurationTest extends TestCase
         return $cases;
     }
 
-    public function testPasswordAndUsernameShouldBeUnsetIfNull()
+    public function testPasswordAndUsernameShouldBeUnsetIfNull(): void
     {
         $config = [
             'connections' => [
@@ -455,7 +465,7 @@ class ConfigurationTest extends TestCase
         $this->assertEquals([], $options['connections']['conn3']['options']);
     }
 
-    public function testInvalidReplicaSetValue()
+    public function testInvalidReplicaSetValue(): void
     {
         $config = [
             'connections' => [
@@ -475,7 +485,7 @@ class ConfigurationTest extends TestCase
         $processor->processConfiguration($configuration, [$config]);
     }
 
-    public function testNullReplicaSetValue()
+    public function testNullReplicaSetValue(): void
     {
         $config = [
             'connections' => [
@@ -495,7 +505,7 @@ class ConfigurationTest extends TestCase
     /**
      * @dataProvider provideExceptionConfiguration
      */
-    public function testFixtureLoaderValidation($config)
+    public function testFixtureLoaderValidation(array $config): void
     {
         $processor     = new Processor();
         $configuration = new Configuration(false);
@@ -503,7 +513,10 @@ class ConfigurationTest extends TestCase
         $processor->processConfiguration($configuration, [$config]);
     }
 
-    public function provideExceptionConfiguration()
+    /**
+     * @return array<mixed[]>
+     */
+    public function provideExceptionConfiguration(): array
     {
         $yaml = Yaml::parse(file_get_contents(__DIR__ . '/Fixtures/config/yml/exception.yml'));
         $yaml = $yaml['doctrine_mongodb'];

--- a/Tests/DependencyInjection/DoctrineMongoDBExtensionTest.php
+++ b/Tests/DependencyInjection/DoctrineMongoDBExtensionTest.php
@@ -13,6 +13,7 @@ use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\Messenger\MessageBusInterface;
+
 use function array_merge;
 use function class_exists;
 use function interface_exists;
@@ -20,7 +21,7 @@ use function sys_get_temp_dir;
 
 class DoctrineMongoDBExtensionTest extends TestCase
 {
-    public static function buildConfiguration(array $settings = [])
+    public static function buildConfiguration(array $settings = []): array
     {
         return [
             array_merge(
@@ -33,7 +34,7 @@ class DoctrineMongoDBExtensionTest extends TestCase
         ];
     }
 
-    public function buildMinimalContainer()
+    public function buildMinimalContainer(): ContainerBuilder
     {
         return new ContainerBuilder(new ParameterBag([
             'kernel.root_dir'        => __DIR__,
@@ -49,7 +50,7 @@ class DoctrineMongoDBExtensionTest extends TestCase
     /**
      * @dataProvider parameterProvider
      */
-    public function testParameterOverride($option, $parameter, $value)
+    public function testParameterOverride(string $option, string $parameter, string $value): void
     {
         $container = $this->buildMinimalContainer();
         $container->setParameter('kernel.debug', false);
@@ -60,7 +61,10 @@ class DoctrineMongoDBExtensionTest extends TestCase
         $this->assertEquals($value, $container->getParameter('doctrine_mongodb.odm.' . $parameter));
     }
 
-    private function getContainer($bundles = 'OtherXmlBundle')
+    /**
+     * @param string|string[] $bundles
+     */
+    private function getContainer($bundles = 'OtherXmlBundle'): ContainerBuilder
     {
         $bundles = (array) $bundles;
 
@@ -83,7 +87,7 @@ class DoctrineMongoDBExtensionTest extends TestCase
         ]));
     }
 
-    public function parameterProvider()
+    public function parameterProvider(): array
     {
         return [
             ['proxy_namespace', 'proxy_namespace', 'foo'],
@@ -91,7 +95,7 @@ class DoctrineMongoDBExtensionTest extends TestCase
         ];
     }
 
-    public function getAutomappingConfigurations()
+    public function getAutomappingConfigurations(): array
     {
         return [
             [
@@ -137,7 +141,7 @@ class DoctrineMongoDBExtensionTest extends TestCase
     /**
      * @dataProvider getAutomappingConfigurations
      */
-    public function testAutomapping(array $documentManagers)
+    public function testAutomapping(array $documentManagers): void
     {
         $container = $this->getContainer([
             'OtherXmlBundle',
@@ -184,7 +188,7 @@ class DoctrineMongoDBExtensionTest extends TestCase
         );
     }
 
-    public function testFactoriesAreRegistered()
+    public function testFactoriesAreRegistered(): void
     {
         $container = $this->getContainer();
 
@@ -220,7 +224,7 @@ class DoctrineMongoDBExtensionTest extends TestCase
         ]);
     }
 
-    public function testPublicServicesAndAliases()
+    public function testPublicServicesAndAliases(): void
     {
         $loader = new DoctrineMongoDBExtension();
         $loader->load(self::buildConfiguration(), $container = $this->buildMinimalContainer());
@@ -230,11 +234,12 @@ class DoctrineMongoDBExtensionTest extends TestCase
         $this->assertTrue($container->getAlias('doctrine_mongodb.odm.document_manager')->isPublic());
     }
 
-    public function testMessengerIntegration()
+    public function testMessengerIntegration(): void
     {
         if (! interface_exists(MessageBusInterface::class)) {
             $this->markTestSkipped('Symfony Messenger component is not installed');
         }
+
         if (! class_exists(DoctrineClearEntityManagerWorkerSubscriber::class)) {
             $this->markTestSkipped('DoctrineClearEntityManagerWorkerSubscriber is not available in symfony/doctrine-bridge');
         }
@@ -246,7 +251,7 @@ class DoctrineMongoDBExtensionTest extends TestCase
         $this->assertCount(1, $subscriber->getArguments());
     }
 
-    private function assertDICDefinitionMethodCall(Definition $definition, string $methodName, array $params = []) : void
+    private function assertDICDefinitionMethodCall(Definition $definition, string $methodName, array $params = []): void
     {
         $calls = $definition->getMethodCalls();
 

--- a/Tests/DependencyInjection/XmlMongoDBExtensionTest.php
+++ b/Tests/DependencyInjection/XmlMongoDBExtensionTest.php
@@ -10,7 +10,7 @@ use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 
 class XmlMongoDBExtensionTest extends AbstractMongoDBExtensionTest
 {
-    protected function loadFromFile(ContainerBuilder $container, $file)
+    protected function loadFromFile(ContainerBuilder $container, string $file): void
     {
         $loadXml = new XmlFileLoader($container, new FileLocator(__DIR__ . '/Fixtures/config/xml'));
         $loadXml->load($file . '.xml');

--- a/Tests/DependencyInjection/YamlMongoDBExtensionTest.php
+++ b/Tests/DependencyInjection/YamlMongoDBExtensionTest.php
@@ -10,7 +10,7 @@ use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 
 class YamlMongoDBExtensionTest extends AbstractMongoDBExtensionTest
 {
-    protected function loadFromFile(ContainerBuilder $container, $file)
+    protected function loadFromFile(ContainerBuilder $container, string $file): void
     {
         $loadYaml = new YamlFileLoader($container, new FileLocator(__DIR__ . '/Fixtures/config/yml'));
         $loadYaml->load($file . '.yml');

--- a/Tests/FixtureIntegrationTest.php
+++ b/Tests/FixtureIntegrationTest.php
@@ -21,7 +21,9 @@ use Symfony\Component\DependencyInjection\Alias;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Kernel;
 use Symfony\Component\Routing\RouteCollectionBuilder;
+
 use function array_map;
+use function assert;
 use function get_class;
 use function rand;
 use function sprintf;
@@ -29,10 +31,10 @@ use function sys_get_temp_dir;
 
 class FixtureIntegrationTest extends TestCase
 {
-    public function testFixturesLoader() : void
+    public function testFixturesLoader(): void
     {
         $kernel = new IntegrationTestKernel('dev', false);
-        $kernel->addServices(static function (ContainerBuilder $c) : void {
+        $kernel->addServices(static function (ContainerBuilder $c): void {
             $c->autowire(OtherFixtures::class)
                 ->addTag(FixturesCompilerPass::FIXTURE_TAG);
 
@@ -44,8 +46,8 @@ class FixtureIntegrationTest extends TestCase
         $kernel->boot();
         $container = $kernel->getContainer();
 
-        /** @var ContainerAwareLoader $loader */
         $loader = $container->get('test.doctrine_mongodb.odm.symfony.fixtures.loader');
+        assert($loader instanceof ContainerAwareLoader);
 
         $actualFixtures = $loader->getFixtures();
         $this->assertCount(2, $actualFixtures);
@@ -60,12 +62,12 @@ class FixtureIntegrationTest extends TestCase
         $this->assertInstanceOf(WithDependenciesFixtures::class, $actualFixtures[1]);
     }
 
-    public function testFixturesLoaderWhenFixtureHasDependencyThatIsNotYetLoaded() : void
+    public function testFixturesLoaderWhenFixtureHasDependencyThatIsNotYetLoaded(): void
     {
         // See https://github.com/doctrine/DoctrineFixturesBundle/issues/215
 
         $kernel = new IntegrationTestKernel('dev', false);
-        $kernel->addServices(static function (ContainerBuilder $c) : void {
+        $kernel->addServices(static function (ContainerBuilder $c): void {
             $c->autowire(WithDependenciesFixtures::class)
                 ->addTag(FixturesCompilerPass::FIXTURE_TAG);
 
@@ -77,8 +79,8 @@ class FixtureIntegrationTest extends TestCase
         $kernel->boot();
         $container = $kernel->getContainer();
 
-        /** @var ContainerAwareLoader $loader */
         $loader = $container->get('test.doctrine_mongodb.odm.symfony.fixtures.loader');
+        assert($loader instanceof ContainerAwareLoader);
 
         $actualFixtures = $loader->getFixtures();
         $this->assertCount(2, $actualFixtures);
@@ -93,10 +95,10 @@ class FixtureIntegrationTest extends TestCase
         $this->assertInstanceOf(WithDependenciesFixtures::class, $actualFixtures[1]);
     }
 
-    public function testExceptionIfDependentFixtureNotWired() : void
+    public function testExceptionIfDependentFixtureNotWired(): void
     {
         $kernel = new IntegrationTestKernel('dev', false);
-        $kernel->addServices(static function (ContainerBuilder $c) : void {
+        $kernel->addServices(static function (ContainerBuilder $c): void {
             $c->autowire(DependentOnRequiredConstructorArgsFixtures::class)
                 ->addTag(FixturesCompilerPass::FIXTURE_TAG);
 
@@ -112,16 +114,16 @@ class FixtureIntegrationTest extends TestCase
             RequiredConstructorArgsFixtures::class
         ));
 
-        /** @var ContainerAwareLoader $loader */
         $loader = $container->get('test.doctrine_mongodb.odm.symfony.fixtures.loader');
+        assert($loader instanceof ContainerAwareLoader);
 
         $loader->getFixtures();
     }
 
-    public function testFixturesLoaderWithGroupsOptionViaInterface() : void
+    public function testFixturesLoaderWithGroupsOptionViaInterface(): void
     {
         $kernel = new IntegrationTestKernel('dev', false);
-        $kernel->addServices(static function (ContainerBuilder $c) : void {
+        $kernel->addServices(static function (ContainerBuilder $c): void {
             // has a "staging" group via the getGroups() method
             $c->autowire(OtherFixtures::class)
                 ->addTag(FixturesCompilerPass::FIXTURE_TAG);
@@ -135,8 +137,8 @@ class FixtureIntegrationTest extends TestCase
         $kernel->boot();
         $container = $kernel->getContainer();
 
-        /** @var ContainerAwareLoader $loader */
         $loader = $container->get('test.doctrine_mongodb.odm.symfony.fixtures.loader');
+        assert($loader instanceof ContainerAwareLoader);
 
         $actualFixtures = $loader->getFixtures(['staging']);
         $this->assertCount(1, $actualFixtures);
@@ -150,10 +152,10 @@ class FixtureIntegrationTest extends TestCase
         $this->assertInstanceOf(OtherFixtures::class, $actualFixtures[0]);
     }
 
-    public function testFixturesLoaderWithGroupsOptionViaTag() : void
+    public function testFixturesLoaderWithGroupsOptionViaTag(): void
     {
         $kernel = new IntegrationTestKernel('dev', false);
-        $kernel->addServices(static function (ContainerBuilder $c) : void {
+        $kernel->addServices(static function (ContainerBuilder $c): void {
             // has a "staging" group via the getGroups() method
             $c->autowire(OtherFixtures::class)
                 ->addTag(FixturesCompilerPass::FIXTURE_TAG, ['group' => 'group1'])
@@ -168,8 +170,8 @@ class FixtureIntegrationTest extends TestCase
         $kernel->boot();
         $container = $kernel->getContainer();
 
-        /** @var ContainerAwareLoader $loader */
         $loader = $container->get('test.doctrine_mongodb.odm.symfony.fixtures.loader');
+        assert($loader instanceof ContainerAwareLoader);
 
         $this->assertCount(1, $loader->getFixtures(['staging']));
         $this->assertCount(1, $loader->getFixtures(['group1']));
@@ -177,10 +179,10 @@ class FixtureIntegrationTest extends TestCase
         $this->assertCount(0, $loader->getFixtures(['group3']));
     }
 
-    public function testLoadFixturesViaGroupWithMissingDependency() : void
+    public function testLoadFixturesViaGroupWithMissingDependency(): void
     {
         $kernel = new IntegrationTestKernel('dev', false);
-        $kernel->addServices(static function (ContainerBuilder $c) : void {
+        $kernel->addServices(static function (ContainerBuilder $c): void {
             // has a "staging" group via the getGroups() method
             $c->autowire(OtherFixtures::class)
                 ->addTag(FixturesCompilerPass::FIXTURE_TAG);
@@ -194,8 +196,8 @@ class FixtureIntegrationTest extends TestCase
         $kernel->boot();
         $container = $kernel->getContainer();
 
-        /** @var ContainerAwareLoader $loader */
         $loader = $container->get('test.doctrine_mongodb.odm.symfony.fixtures.loader');
+        assert($loader instanceof ContainerAwareLoader);
 
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage(sprintf(
@@ -208,10 +210,10 @@ class FixtureIntegrationTest extends TestCase
         $loader->getFixtures(['missingDependencyGroup']);
     }
 
-    public function testLoadFixturesViaGroupWithFulfilledDependency() : void
+    public function testLoadFixturesViaGroupWithFulfilledDependency(): void
     {
         $kernel = new IntegrationTestKernel('dev', false);
-        $kernel->addServices(static function (ContainerBuilder $c) : void {
+        $kernel->addServices(static function (ContainerBuilder $c): void {
             // has a "staging" group via the getGroups() method
             $c->autowire(OtherFixtures::class)
                 ->addTag(FixturesCompilerPass::FIXTURE_TAG);
@@ -225,8 +227,8 @@ class FixtureIntegrationTest extends TestCase
         $kernel->boot();
         $container = $kernel->getContainer();
 
-        /** @var ContainerAwareLoader $loader */
         $loader = $container->get('test.doctrine_mongodb.odm.symfony.fixtures.loader');
+        assert($loader instanceof ContainerAwareLoader);
 
         $actualFixtures = $loader->getFixtures(['fulfilledDependencyGroup']);
 
@@ -241,10 +243,10 @@ class FixtureIntegrationTest extends TestCase
         ], $actualFixtureClasses);
     }
 
-    public function testLoadFixturesByShortName() : void
+    public function testLoadFixturesByShortName(): void
     {
         $kernel = new IntegrationTestKernel('dev', false);
-        $kernel->addServices(static function (ContainerBuilder $c) : void {
+        $kernel->addServices(static function (ContainerBuilder $c): void {
             // has a "staging" group via the getGroups() method
             $c->autowire(OtherFixtures::class)
                 ->addTag(FixturesCompilerPass::FIXTURE_TAG);
@@ -258,8 +260,8 @@ class FixtureIntegrationTest extends TestCase
         $kernel->boot();
         $container = $kernel->getContainer();
 
-        /** @var ContainerAwareLoader $loader */
         $loader = $container->get('test.doctrine_mongodb.odm.symfony.fixtures.loader');
+        assert($loader instanceof ContainerAwareLoader);
 
         $actualFixtures = $loader->getFixtures(['OtherFixtures']);
 
@@ -291,12 +293,12 @@ class IntegrationTestKernel extends Kernel
         parent::__construct($environment, $debug);
     }
 
-    protected function getContainerClass() : string
+    protected function getContainerClass(): string
     {
         return 'test' . $this->randomKey . parent::getContainerClass();
     }
 
-    public function registerBundles() : array
+    public function registerBundles(): array
     {
         return [
             new FrameworkBundle(),
@@ -305,6 +307,9 @@ class IntegrationTestKernel extends Kernel
         ];
     }
 
+    /**
+     * @return void
+     */
     protected function build(ContainerBuilder $container)
     {
         $container->prependExtensionConfig('doctrine_mongodb', [
@@ -313,16 +318,16 @@ class IntegrationTestKernel extends Kernel
         ]);
     }
 
-    public function addServices(callable $callback) : void
+    public function addServices(callable $callback): void
     {
         $this->servicesCallback = $callback;
     }
 
-    protected function configureRoutes(RouteCollectionBuilder $routes) : void
+    protected function configureRoutes(RouteCollectionBuilder $routes): void
     {
     }
 
-    protected function configureContainer(ContainerBuilder $c, LoaderInterface $loader) : void
+    protected function configureContainer(ContainerBuilder $c, LoaderInterface $loader): void
     {
         $c->loadFromExtension('framework', [
             'secret' => 'foo',
@@ -333,12 +338,12 @@ class IntegrationTestKernel extends Kernel
         $callback($c);
     }
 
-    public function getCacheDir() : string
+    public function getCacheDir(): string
     {
         return sys_get_temp_dir() . '/doctrine_mongodb_odm_bundle' . $this->randomKey;
     }
 
-    public function getLogDir() : string
+    public function getLogDir(): string
     {
         return sys_get_temp_dir();
     }

--- a/Tests/Fixtures/Filter/BasicFilter.php
+++ b/Tests/Fixtures/Filter/BasicFilter.php
@@ -9,7 +9,7 @@ use Doctrine\ODM\MongoDB\Query\Filter\BsonFilter;
 
 final class BasicFilter extends BsonFilter
 {
-    public function addFilterCriteria(ClassMetadata $class) : array
+    public function addFilterCriteria(ClassMetadata $class): array
     {
         return [];
     }

--- a/Tests/Fixtures/Filter/ComplexFilter.php
+++ b/Tests/Fixtures/Filter/ComplexFilter.php
@@ -9,7 +9,7 @@ use Doctrine\ODM\MongoDB\Query\Filter\BsonFilter;
 
 final class ComplexFilter extends BsonFilter
 {
-    public function addFilterCriteria(ClassMetadata $class) : array
+    public function addFilterCriteria(ClassMetadata $class): array
     {
         return [];
     }

--- a/Tests/Fixtures/Filter/DisabledFilter.php
+++ b/Tests/Fixtures/Filter/DisabledFilter.php
@@ -9,7 +9,7 @@ use Doctrine\ODM\MongoDB\Query\Filter\BsonFilter;
 
 final class DisabledFilter extends BsonFilter
 {
-    public function addFilterCriteria(ClassMetadata $class) : array
+    public function addFilterCriteria(ClassMetadata $class): array
     {
         return [];
     }

--- a/Tests/Fixtures/FooBundle/DataFixtures/DependentOnRequiredConstructorArgsFixtures.php
+++ b/Tests/Fixtures/FooBundle/DataFixtures/DependentOnRequiredConstructorArgsFixtures.php
@@ -10,12 +10,12 @@ use Doctrine\Persistence\ObjectManager;
 
 class DependentOnRequiredConstructorArgsFixtures implements ODMFixtureInterface, DependentFixtureInterface
 {
-    public function load(ObjectManager $manager) : void
+    public function load(ObjectManager $manager): void
     {
         // ...
     }
 
-    public function getDependencies() : array
+    public function getDependencies(): array
     {
         return [RequiredConstructorArgsFixtures::class];
     }

--- a/Tests/Fixtures/FooBundle/DataFixtures/OtherFixtures.php
+++ b/Tests/Fixtures/FooBundle/DataFixtures/OtherFixtures.php
@@ -10,12 +10,12 @@ use Doctrine\Persistence\ObjectManager;
 
 class OtherFixtures implements ODMFixtureInterface, FixtureGroupInterface
 {
-    public function load(ObjectManager $manager) : void
+    public function load(ObjectManager $manager): void
     {
         // ...
     }
 
-    public static function getGroups() : array
+    public static function getGroups(): array
     {
         return ['staging', 'fulfilledDependencyGroup'];
     }

--- a/Tests/Fixtures/FooBundle/DataFixtures/RequiredConstructorArgsFixtures.php
+++ b/Tests/Fixtures/FooBundle/DataFixtures/RequiredConstructorArgsFixtures.php
@@ -9,11 +9,14 @@ use Doctrine\Persistence\ObjectManager;
 
 class RequiredConstructorArgsFixtures implements ODMFixtureInterface
 {
+    /**
+     * @param mixed $fooRequiredArg
+     */
     public function __construct($fooRequiredArg)
     {
     }
 
-    public function load(ObjectManager $manager) : void
+    public function load(ObjectManager $manager): void
     {
         // ...
     }

--- a/Tests/Fixtures/FooBundle/DataFixtures/WithDependenciesFixtures.php
+++ b/Tests/Fixtures/FooBundle/DataFixtures/WithDependenciesFixtures.php
@@ -11,17 +11,17 @@ use Doctrine\Persistence\ObjectManager;
 
 class WithDependenciesFixtures implements ODMFixtureInterface, DependentFixtureInterface, FixtureGroupInterface
 {
-    public function load(ObjectManager $manager) : void
+    public function load(ObjectManager $manager): void
     {
         // ...
     }
 
-    public function getDependencies() : array
+    public function getDependencies(): array
     {
         return [OtherFixtures::class];
     }
 
-    public static function getGroups() : array
+    public static function getGroups(): array
     {
         return ['missingDependencyGroup', 'fulfilledDependencyGroup'];
     }

--- a/Tests/Fixtures/Form/Category.php
+++ b/Tests/Fixtures/Form/Category.php
@@ -24,7 +24,7 @@ class Category
      */
     public $documents;
 
-    public function __construct($name)
+    public function __construct(string $name)
     {
         $this->name      = $name;
         $this->documents = new ArrayCollection();

--- a/Tests/Fixtures/Form/Document.php
+++ b/Tests/Fixtures/Form/Document.php
@@ -6,6 +6,7 @@ namespace Doctrine\Bundle\MongoDBBundle\Tests\Fixtures\Form;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use MongoDB\BSON\ObjectId;
 
 /** @ODM\Document */
 class Document
@@ -25,6 +26,10 @@ class Document
      */
     public $categories;
 
+    /**
+     * @param ObjectId $id
+     * @param string   $name
+     */
     public function __construct($id, $name)
     {
         $this->id         = $id;

--- a/Tests/Fixtures/Security/User.php
+++ b/Tests/Fixtures/Security/User.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\Bundle\MongoDBBundle\Tests\Fixtures\Security;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use MongoDB\BSON\ObjectId;
 use Symfony\Component\Security\Core\User\UserInterface;
 
 /** @ODM\Document */
@@ -16,34 +17,38 @@ class User implements UserInterface
     /** @ODM\Field(type="string") */
     public $name;
 
+    /**
+     * @param ObjectId $id
+     * @param string   $name
+     */
     public function __construct($id, $name)
     {
         $this->id   = $id;
         $this->name = $name;
     }
 
-    public function getRoles()
+    public function getRoles(): void
     {
     }
 
-    public function getPassword()
+    public function getPassword(): void
     {
     }
 
-    public function getSalt()
+    public function getSalt(): void
     {
     }
 
-    public function getUsername()
+    public function getUsername(): string
     {
         return $this->name;
     }
 
-    public function eraseCredentials()
+    public function eraseCredentials(): void
     {
     }
 
-    public function equals(UserInterface $user)
+    public function equals(UserInterface $user): void
     {
     }
 }

--- a/Tests/Fixtures/Validator/Document.php
+++ b/Tests/Fixtures/Validator/Document.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\Bundle\MongoDBBundle\Tests\Fixtures\Validator;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use MongoDB\BSON\ObjectId;
 
 /** @ODM\Document(collection="DoctrineMongoDBBundle_Tests_Validator_Document") */
 class Document
@@ -30,6 +31,9 @@ class Document
     /** @ODM\EmbedMany(targetDocument="Doctrine\Bundle\MongoDBBundle\Tests\Fixtures\Validator\EmbeddedDocument") */
     public $embedMany = [];
 
+    /**
+     * @param ObjectId $id
+     */
     public function __construct($id)
     {
         $this->id = $id;

--- a/Tests/Form/Type/DocumentTypeTest.php
+++ b/Tests/Form/Type/DocumentTypeTest.php
@@ -16,8 +16,10 @@ use MongoDB\BSON\ObjectId;
 use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\FormType;
+use Symfony\Component\Form\FormExtensionInterface;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\Form\Test\TypeTestCase;
+
 use function array_merge;
 use function method_exists;
 
@@ -31,7 +33,7 @@ class DocumentTypeTest extends TypeTestCase
 
     private $typeFQCN;
 
-    protected function setUp() : void
+    protected function setUp(): void
     {
         $this->typeFQCN = method_exists(AbstractType::class, 'getBlockPrefix');
 
@@ -43,7 +45,7 @@ class DocumentTypeTest extends TypeTestCase
         parent::setUp();
     }
 
-    protected function tearDown() : void
+    protected function tearDown(): void
     {
         $documentClasses = [
             Document::class,
@@ -57,7 +59,7 @@ class DocumentTypeTest extends TypeTestCase
         parent::tearDown();
     }
 
-    public function testDocumentManagerOptionSetsEmOption()
+    public function testDocumentManagerOptionSetsEmOption(): void
     {
         $field = $this->factory->createNamed('name', $this->typeFQCN ? DocumentType::class : 'document', null, [
             'class' => Document::class,
@@ -67,7 +69,7 @@ class DocumentTypeTest extends TypeTestCase
         $this->assertSame($this->dm, $field->getConfig()->getOption('em'));
     }
 
-    public function testDocumentManagerInstancePassedAsOption()
+    public function testDocumentManagerInstancePassedAsOption(): void
     {
         $field = $this->factory->createNamed('name', $this->typeFQCN ? DocumentType::class : 'document', null, [
             'class' => Document::class,
@@ -77,7 +79,7 @@ class DocumentTypeTest extends TypeTestCase
         $this->assertSame($this->dm, $field->getConfig()->getOption('em'));
     }
 
-    public function testSettingDocumentManagerAndEmOptionShouldThrowException()
+    public function testSettingDocumentManagerAndEmOptionShouldThrowException(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->factory->createNamed('name', $this->typeFQCN ? DocumentType::class : 'document', null, [
@@ -86,7 +88,7 @@ class DocumentTypeTest extends TypeTestCase
         ]);
     }
 
-    public function testManyToManyReferences()
+    public function testManyToManyReferences(): void
     {
         $categoryOne = new Category('one');
         $this->dm->persist($categoryOne);
@@ -120,7 +122,10 @@ class DocumentTypeTest extends TypeTestCase
         $this->assertFalse($categoryView->children[1]->vars['checked']);
     }
 
-    protected function createRegistryMock($name, $dm)
+    /**
+     * @return MockObject&ManagerRegistry
+     */
+    protected function createRegistryMock(string $name, DocumentManager $dm): MockObject
     {
         $registry = $this->createMock(ManagerRegistry::class);
         $registry
@@ -132,7 +137,7 @@ class DocumentTypeTest extends TypeTestCase
     }
 
     /**
-     * @see \Symfony\Component\Form\Tests\FormIntegrationTestCase::getExtensions()
+     * @return FormExtensionInterface[]
      */
     protected function getExtensions()
     {

--- a/Tests/Form/Type/GuesserTestType.php
+++ b/Tests/Form/Type/GuesserTestType.php
@@ -11,6 +11,9 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class GuesserTestType extends AbstractType
 {
+    /**
+     * @return void
+     */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
@@ -27,6 +30,9 @@ class GuesserTestType extends AbstractType
             ->add('nonMappedField');
     }
 
+    /**
+     * @return void
+     */
     public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults([
@@ -34,12 +40,15 @@ class GuesserTestType extends AbstractType
         ])->setRequired('dm');
     }
 
+    /**
+     * {@inheritDoc}
+     */
     public function getBlockPrefix()
     {
         return 'guesser_test';
     }
 
-    public function getName()
+    public function getName(): string
     {
         return $this->getBlockPrefix();
     }

--- a/Tests/Form/Type/TypeGuesserTest.php
+++ b/Tests/Form/Type/TypeGuesserTest.php
@@ -57,6 +57,9 @@ class TypeGuesserTest extends TypeTestCase
         parent::tearDown();
     }
 
+    /**
+     * @group legacy
+     */
     public function testTypesShouldBeGuessedCorrectly(): void
     {
         $form = $this->factory->create($this->typeFQCN ? GuesserTestType::class : new GuesserTestType(), null, ['dm' => $this->dm]);

--- a/Tests/Form/Type/TypeGuesserTest.php
+++ b/Tests/Form/Type/TypeGuesserTest.php
@@ -13,7 +13,10 @@ use Doctrine\ODM\MongoDB\DocumentManager;
 use Doctrine\Persistence\ManagerRegistry;
 use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormExtensionInterface;
+use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\Test\TypeTestCase;
+
 use function array_merge;
 use function method_exists;
 
@@ -27,7 +30,7 @@ class TypeGuesserTest extends TypeTestCase
 
     private $typeFQCN;
 
-    protected function setUp() : void
+    protected function setUp(): void
     {
         $this->typeFQCN = method_exists(AbstractType::class, 'getBlockPrefix');
 
@@ -39,7 +42,7 @@ class TypeGuesserTest extends TypeTestCase
         parent::setUp();
     }
 
-    protected function tearDown() : void
+    protected function tearDown(): void
     {
         $documentClasses = [
             Document::class,
@@ -54,7 +57,7 @@ class TypeGuesserTest extends TypeTestCase
         parent::tearDown();
     }
 
-    public function testTypesShouldBeGuessedCorrectly()
+    public function testTypesShouldBeGuessedCorrectly(): void
     {
         $form = $this->factory->create($this->typeFQCN ? GuesserTestType::class : new GuesserTestType(), null, ['dm' => $this->dm]);
         $this->assertType('text', $form->get('name'));
@@ -70,12 +73,15 @@ class TypeGuesserTest extends TypeTestCase
         $this->assertType('text', $form->get('nonMappedField'));
     }
 
-    protected function assertType($type, $form)
+    protected function assertType(string $type, FormInterface $form): void
     {
         $this->assertEquals($type, $this->typeFQCN ? $form->getConfig()->getType()->getBlockPrefix() : $form->getConfig()->getType()->getName());
     }
 
-    protected function createRegistryMock($name, $dm)
+    /**
+     * @return MockObject&ManagerRegistry
+     */
+    protected function createRegistryMock(string $name, DocumentManager $dm): MockObject
     {
         $registry = $this->createMock(ManagerRegistry::class);
         $registry
@@ -90,7 +96,7 @@ class TypeGuesserTest extends TypeTestCase
     }
 
     /**
-     * @see Symfony\Component\Form\Tests\FormIntegrationTestCase::getExtensions()
+     * @return FormExtensionInterface[]
      */
     protected function getExtensions()
     {

--- a/Tests/Mapping/Driver/AbstractDriverTest.php
+++ b/Tests/Mapping/Driver/AbstractDriverTest.php
@@ -5,13 +5,14 @@ declare(strict_types=1);
 namespace Doctrine\Bundle\MongoDBBundle\Tests\Mapping\Driver;
 
 use Doctrine\Persistence\Mapping\Driver\FileDriver;
+use Doctrine\Persistence\Mapping\Driver\FileLocator;
 use Doctrine\Persistence\Mapping\MappingException;
 use PHPUnit\Framework\TestCase;
 use ReflectionProperty;
 
 abstract class AbstractDriverTest extends TestCase
 {
-    public function testFindMappingFile()
+    public function testFindMappingFile(): void
     {
         $driver = $this->getDriver([
             'foo' => 'MyNamespace\MyBundle\DocumentFoo',
@@ -26,7 +27,7 @@ abstract class AbstractDriverTest extends TestCase
         );
     }
 
-    public function testFindMappingFileInSubnamespace()
+    public function testFindMappingFileInSubnamespace(): void
     {
         $driver = $this->getDriver([$this->getFixtureDir() => 'MyNamespace\MyBundle\Document']);
 
@@ -38,7 +39,7 @@ abstract class AbstractDriverTest extends TestCase
         );
     }
 
-    public function testFindMappingFileNamespacedFoundFileNotFound()
+    public function testFindMappingFileNamespacedFoundFileNotFound(): void
     {
         $driver = $this->getDriver([$this->getFixtureDir() => 'MyNamespace\MyBundle\Document']);
 
@@ -49,7 +50,7 @@ abstract class AbstractDriverTest extends TestCase
         $locator->findMappingFile('MyNamespace\MyBundle\Document\Missing');
     }
 
-    public function testFindMappingNamespaceNotFound()
+    public function testFindMappingNamespaceNotFound(): void
     {
         $driver = $this->getDriver([$this->getFixtureDir() => 'MyNamespace\MyBundle\Document']);
 
@@ -66,7 +67,7 @@ abstract class AbstractDriverTest extends TestCase
 
     abstract protected function getDriver(array $paths = []);
 
-    private function getDriverLocator(FileDriver $driver)
+    private function getDriverLocator(FileDriver $driver): FileLocator
     {
         $ref = new ReflectionProperty($driver, 'locator');
         $ref->setAccessible(true);

--- a/Tests/Mapping/Driver/XmlDriverTest.php
+++ b/Tests/Mapping/Driver/XmlDriverTest.php
@@ -8,16 +8,25 @@ use Doctrine\Bundle\MongoDBBundle\Mapping\Driver\XmlDriver;
 
 class XmlDriverTest extends AbstractDriverTest
 {
+    /**
+     * @return string
+     */
     protected function getFileExtension()
     {
         return '.mongodb.xml';
     }
 
+    /**
+     * @return string
+     */
     protected function getFixtureDir()
     {
         return __DIR__ . '/Fixtures/xml';
     }
 
+    /**
+     * @return XmlDriver
+     */
     protected function getDriver(array $prefixes = [])
     {
         return new XmlDriver($prefixes, $this->getFileExtension());

--- a/Tests/Repository/ContainerRepositoryFactoryTest.php
+++ b/Tests/Repository/ContainerRepositoryFactoryTest.php
@@ -18,12 +18,13 @@ use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
 use RuntimeException;
 use stdClass;
+
 use function sprintf;
 use function sys_get_temp_dir;
 
 class ContainerRepositoryFactoryTest extends TestCase
 {
-    public function testGetRepositoryReturnsService()
+    public function testGetRepositoryReturnsService(): void
     {
         $dm        = $this->createDocumentManager([CoolDocument::class => 'my_repo']);
         $repo      = new StubRepository($dm, $dm->getUnitOfWork(), new ClassMetadata(CoolDocument::class));
@@ -33,7 +34,7 @@ class ContainerRepositoryFactoryTest extends TestCase
         $this->assertSame($repo, $factory->getRepository($dm, CoolDocument::class));
     }
 
-    public function testGetRepositoryReturnsDocumentRepository()
+    public function testGetRepositoryReturnsDocumentRepository(): void
     {
         $container = $this->createContainer([]);
         $dm        = $this->createDocumentManager([BoringDocument::class => null]);
@@ -45,7 +46,7 @@ class ContainerRepositoryFactoryTest extends TestCase
         $this->assertSame($actualRepo, $factory->getRepository($dm, BoringDocument::class));
     }
 
-    public function testCustomRepositoryIsReturned()
+    public function testCustomRepositoryIsReturned(): void
     {
         $container = $this->createContainer([]);
         $dm        = $this->createDocumentManager([
@@ -59,7 +60,7 @@ class ContainerRepositoryFactoryTest extends TestCase
         $this->assertSame($actualRepo, $factory->getRepository($dm, CustomNormalRepoDocument::class));
     }
 
-    public function testServiceRepositoriesMustExtendDocumentRepository()
+    public function testServiceRepositoriesMustExtendDocumentRepository(): void
     {
         $repo = new stdClass();
 
@@ -76,7 +77,7 @@ class ContainerRepositoryFactoryTest extends TestCase
         $factory->getRepository($dm, CoolDocument::class);
     }
 
-    public function testRepositoryMatchesServiceInterfaceButServiceNotFound()
+    public function testRepositoryMatchesServiceInterfaceButServiceNotFound(): void
     {
         $container = $this->createContainer([]);
 
@@ -97,7 +98,7 @@ class ContainerRepositoryFactoryTest extends TestCase
         $factory->getRepository($dm, CoolDocument::class);
     }
 
-    public function testCustomRepositoryIsNotAValidClass()
+    public function testCustomRepositoryIsNotAValidClass(): void
     {
         $container = $this->createContainer([]);
 

--- a/Tests/ServiceRepositoryTest.php
+++ b/Tests/ServiceRepositoryTest.php
@@ -27,6 +27,7 @@ use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
+
 use function sprintf;
 use function sys_get_temp_dir;
 
@@ -35,7 +36,7 @@ class ServiceRepositoryTest extends TestCase
     /** @var ContainerBuilder */
     private $container;
 
-    protected function setUp() : void
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -91,7 +92,7 @@ class ServiceRepositoryTest extends TestCase
         $this->container->compile();
     }
 
-    public function testRepositoryServiceWiring()
+    public function testRepositoryServiceWiring(): void
     {
         $dm = $this->container->get('doctrine_mongodb.odm.document_manager');
 
@@ -135,7 +136,7 @@ class ServiceRepositoryTest extends TestCase
         $this->assertInstanceOf(Builder::class, $customServiceGridFSRepo->createQueryBuilder());
     }
 
-    public function testInstantiatingServiceRepositoryForUnmappedClass()
+    public function testInstantiatingServiceRepositoryForUnmappedClass(): void
     {
         $this->expectExceptionMessage(sprintf(
             'Could not find the document manager for class "%s".'

--- a/Tests/TestCase.php
+++ b/Tests/TestCase.php
@@ -10,14 +10,15 @@ use Doctrine\ODM\MongoDB\Configuration;
 use Doctrine\ODM\MongoDB\DocumentManager;
 use Doctrine\ODM\MongoDB\Mapping\Driver\AnnotationDriver;
 use PHPUnit\Framework\TestCase as BaseTestCase;
+
 use function sys_get_temp_dir;
 
 class TestCase extends BaseTestCase
 {
     /**
-     * @return DocumentManager
+     * @param string[] $paths
      */
-    public static function createTestDocumentManager($paths = [])
+    public static function createTestDocumentManager(array $paths = []): DocumentManager
     {
         $config = new Configuration();
         $config->setAutoGenerateProxyClasses(Configuration::AUTOGENERATE_FILE_NOT_EXISTS);

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "doctrine/data-fixtures": "<1.3"
     },
     "require-dev": {
-        "doctrine/coding-standard": "^6.0",
+        "doctrine/coding-standard": "^8.2",
         "doctrine/data-fixtures": "^1.3",
         "phpunit/phpunit": "^8.5 || ^9.3",
         "squizlabs/php_codesniffer": "^3.5",

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -15,13 +15,15 @@
 
     <rule ref="Doctrine">
         <!-- Traversable type hints often end up as mixed[], so we skip them for now -->
-        <exclude name="SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingTraversablePropertyTypeHintSpecification" />
-        <exclude name="SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingTraversableParameterTypeHintSpecification" />
-        <exclude name="SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingTraversableReturnTypeHintSpecification" />
+        <exclude name="SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingTraversableTypeHintSpecification" />
+        <exclude name="SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingTraversableTypeHintSpecification" />
+        <exclude name="SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingTraversableTypeHintSpecification" />
 
         <!-- Will cause BC breaks to method signatures - disabled for now -->
-        <exclude name="SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingParameterTypeHint" />
-        <exclude name="SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingReturnTypeHint" />
+        <exclude name="SlevomatCodingStandard.ControlStructures.RequireNullCoalesceEqualOperator.RequiredNullCoalesceEqualOperator"/> <!-- PHP 7.4 required-->
+        <exclude name="SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint"/> <!-- PHP 7.4 required-->
+        <exclude name="SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingNativeTypeHint"/> <!-- we can do it in doctrine-bundle 3.0-->
+        <exclude name="SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint"/> <!-- we can do it in doctrine-bundle 3.0 -->
 
         <!-- Disabled to avoid class renaming - to be handled in a separate PR -->
         <exclude name="SlevomatCodingStandard.Classes.SuperfluousAbstractClassNaming" />
@@ -30,17 +32,8 @@
         <exclude name="SlevomatCodingStandard.Classes.SuperfluousTraitNaming" />
     </rule>
 
-    <rule ref="SlevomatCodingStandard.Classes.UnusedPrivateElements">
-        <properties>
-            <property name="alwaysUsedPropertiesAnnotations" type="array" value="
-                @ODM\Id,
-                @ODM\Field,
-                @ODM\EmbedOne,
-                @ODM\EmbedMany,
-                @ODM\ReferenceOne,
-                @ODM\ReferenceMany
-            "/>
-        </properties>
+    <rule ref="SlevomatCodingStandard.Classes.UnusedPrivateElements.UnusedProperty">
+        <exclude-pattern>Tests/DependencyInjection/Fixtures/*</exclude-pattern>
     </rule>
 
     <rule ref="PSR1.Classes.ClassDeclaration.MultipleClasses">
@@ -51,7 +44,7 @@
         <exclude-pattern>Tests/*</exclude-pattern>
     </rule>
 
-    <rule ref="SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingPropertyTypeHint">
+    <rule ref="SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingAnyTypeHint">
         <exclude-pattern>Tests/*</exclude-pattern>
     </rule>
 </ruleset>


### PR DESCRIPTION
This tries to use `doctrine/coding-standard` 8, to be able to allow php 8.

Tests should pass after merging https://github.com/doctrine/DoctrineMongoDBBundle/pull/659 that fixes some deprecations.