### PR TITLE
Use proper config attribute in XML mapping

### DIFF
--- a/Resources/doc/first_steps.rst
+++ b/Resources/doc/first_steps.rst
@@ -60,8 +60,8 @@ in a number of different formats including XML or directly inside the
 
             <document name="App\Document\Product">
                 <id />
-                <field fieldName="name" type="string" />
-                <field fieldName="price" type="float" />
+                <field field-name="name" type="string" />
+                <field field-name="price" type="float" />
             </document>
         </doctrine-mongo-mapping>
 


### PR DESCRIPTION
Fix this code snippet
Reference to: `symfony console doctrine:mongodb:mapping:info`

The mapping file [...]/src/Resources/config/doctrine/Item.mongodb.xml is invalid: 
Line 7:0: Element '{http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping}field', attribute 'fieldName': The attribute 'fieldName' is not allowed.