### PR TITLE
Add Configless Metadata Cache

### DIFF
--- a/CacheWarmer/HydratorCacheWarmer.php
+++ b/CacheWarmer/HydratorCacheWarmer.php
@@ -23,6 +23,8 @@ use function sprintf;
  *
  * In the process of generating hydrators the cache for all the metadata is primed also,
  * since this information is necessary to build the hydrators in the first place.
+ *
+ * @internal
  */
 class HydratorCacheWarmer implements CacheWarmerInterface
 {

--- a/CacheWarmer/MetadataCacheWarmer.php
+++ b/CacheWarmer/MetadataCacheWarmer.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Bundle\MongoDBBundle\CacheWarmer;
+
+use Doctrine\Persistence\ObjectManager;
+use Symfony\Bundle\FrameworkBundle\CacheWarmer\AbstractPhpFileCacheWarmer;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+
+use function is_file;
+
+/** @internal */
+final class MetadataCacheWarmer extends AbstractPhpFileCacheWarmer
+{
+    /** @var ObjectManager */
+    private $objectManager;
+
+    /** @var string */
+    private $phpArrayFile;
+
+    public function __construct(ObjectManager $objectManager, string $phpArrayFile)
+    {
+        $this->objectManager = $objectManager;
+        $this->phpArrayFile  = $phpArrayFile;
+
+        parent::__construct($phpArrayFile);
+    }
+
+    /**
+     * It must not be optional because it should be called before ProxyCacheWarmer which is not optional.
+     */
+    public function isOptional(): bool
+    {
+        return false;
+    }
+
+    /** @param string $cacheDir */
+    protected function doWarmUp($cacheDir, ArrayAdapter $arrayAdapter): bool
+    {
+        // cache already warmed up, no need to do it again
+        if (is_file($this->phpArrayFile)) {
+            return false;
+        }
+
+        $this->objectManager->getMetadataFactory()->getAllMetadata();
+
+        return true;
+    }
+}

--- a/CacheWarmer/PersistentCollectionCacheWarmer.php
+++ b/CacheWarmer/PersistentCollectionCacheWarmer.php
@@ -24,6 +24,8 @@ use function sprintf;
  *
  * In the process of generating persistent collections the cache for all the metadata is primed also,
  * since this information is necessary to build the persistent collections in the first place.
+ *
+ * @internal
  */
 class PersistentCollectionCacheWarmer implements CacheWarmerInterface
 {

--- a/CacheWarmer/ProxyCacheWarmer.php
+++ b/CacheWarmer/ProxyCacheWarmer.php
@@ -25,6 +25,8 @@ use function sprintf;
  *
  * In the process of generating proxies the cache for all the metadata is primed also,
  * since this information is necessary to build the proxies in the first place.
+ *
+ * @internal
  */
 class ProxyCacheWarmer implements CacheWarmerInterface
 {

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -191,7 +191,7 @@ class Configuration implements ConfigurationInterface
                                 ->end()
                             ->end()
                             ->arrayNode('metadata_cache_driver')
-                                ->addDefaultsIfNotSet()
+                                ->setDeprecated('doctrine/mongodb-odm-bundle', '4.4')
                                 ->beforeNormalization()
                                     ->ifString()
                                     ->then(static function ($v) {

--- a/Resources/doc/config.rst
+++ b/Resources/doc/config.rst
@@ -23,7 +23,6 @@ Sample Configuration
                         filter-name:
                             class: Class\Example\Filter\ODM\ExampleFilter
                             enabled: true
-                    metadata_cache_driver: array # array, apc, apcu, memcache, memcached, redis, wincache, zenddata, xcache
 
     .. code-block:: xml
 
@@ -43,7 +42,6 @@ Sample Configuration
                 <doctrine_mongodb:document-manager id="default">
                     <doctrine_mongodb:mapping name="AcmeDemoBundle" />
                     <doctrine_mongodb:filter name="filter-name" enabled="true" class="Class\Example\Filter\ODM\ExampleFilter" />
-                    <doctrine_mongodb:metadata-cache-driver type="array" />
                 </doctrine_mongodb:document-manager>
             </doctrine_mongodb:config>
         </container>
@@ -65,58 +63,6 @@ Sample Configuration
             connections:
                 default:
                     server: '%env(resolve:MONGODB_URL)%'
-
-If you wish to use memcache to cache your metadata, you need to configure the
-``Memcache`` instance; for example, you can do the following:
-
-.. configuration-block::
-
-    .. code-block:: yaml
-
-        # app/config/config.yml
-        doctrine_mongodb:
-            default_database: hello_%kernel.environment%
-            connections:
-                default:
-                    server: mongodb://localhost:27017
-                    options: {}
-            document_managers:
-                default:
-                    mappings:
-                        AcmeDemoBundle: ~
-                    metadata_cache_driver:
-                        type: memcache
-                        class: Doctrine\Common\Cache\MemcacheCache
-                        host: localhost
-                        port: 11211
-                        instance_class: Memcache
-
-    .. code-block:: xml
-
-        <?xml version="1.0" ?>
-
-        <container xmlns="http://symfony.com/schema/dic/services"
-            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-            xmlns:doctrine_mongodb="http://symfony.com/schema/dic/doctrine/odm/mongodb"
-            xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd
-                                http://symfony.com/schema/dic/doctrine/odm/mongodb https://symfony.com/schema/dic/doctrine/odm/mongodb/mongodb-1.0.xsd">
-
-            <doctrine_mongodb:config default-database="hello_%kernel.environment%">
-                <doctrine_mongodb:document-manager id="default">
-                    <doctrine_mongodb:mapping name="AcmeDemoBundle" />
-                    <doctrine_mongodb:metadata-cache-driver type="memcache">
-                        <doctrine_mongodb:class>Doctrine\Common\Cache\MemcacheCache</doctrine_mongodb:class>
-                        <doctrine_mongodb:host>localhost</doctrine_mongodb:host>
-                        <doctrine_mongodb:port>11211</doctrine_mongodb:port>
-                        <doctrine_mongodb:instance-class>Memcache</doctrine_mongodb:instance-class>
-                    </doctrine_mongodb:metadata-cache-driver>
-                </doctrine_mongodb:document-manager>
-                <doctrine_mongodb:connection id="default" server="mongodb://localhost:27017">
-                    <doctrine_mongodb:options>
-                    </doctrine_mongodb:options>
-                </doctrine_mongodb:connection>
-            </doctrine_mongodb:config>
-        </container>
 
 
 Mapping Configuration
@@ -321,7 +267,6 @@ following syntax:
             default_database: hello_%kernel.environment%
             default_connection: conn2
             default_document_manager: dm2
-            metadata_cache_driver: apc
             connections:
                 conn1:
                     server: mongodb://localhost:27017
@@ -331,7 +276,6 @@ following syntax:
                 dm1:
                     connection: conn1
                     database: db1
-                    metadata_cache_driver: xcache
                     mappings:
                         AcmeDemoBundle: ~
                 dm2:
@@ -364,7 +308,7 @@ following syntax:
                     <doctrine_mongodb:options>
                     </doctrine_mongodb:options>
                 </doctrine_mongodb:connection>
-                <doctrine_mongodb:document-manager id="dm1" metadata-cache-driver="xcache" connection="conn1" database="db1">
+                <doctrine_mongodb:document-manager id="dm1" connection="conn1" database="db1">
                     <doctrine_mongodb:mapping name="AcmeDemoBundle" />
                 </doctrine_mongodb:document-manager>
                 <doctrine_mongodb:document-manager id="dm2" connection="conn2" database="db2">
@@ -550,12 +494,6 @@ Full Default Configuration
                     persistent_collection_factory:     ~
                     logging:                           true
                     auto_mapping:                      false
-                    metadata_cache_driver:
-                        type:                 ~
-                        class:                ~
-                        host:                 ~
-                        port:                 ~
-                        instance_class:       ~
                     mappings:
 
                         # Prototype
@@ -639,12 +577,6 @@ Full Default Configuration
                                            logging="true"
                                            auto-mapping="false"
                 >
-                    <doctrine:metadata-cache-driver type="">
-                        <doctrine:class></doctrine:class>
-                        <doctrine:host></doctrine:host>
-                        <doctrine:port></doctrine:port>
-                        <doctrine:instance-class></doctrine:instance-class>
-                    </doctrine:metadata-cache-driver>
                     <doctrine:mapping name="name"
                                       type=""
                                       dir=""

--- a/Tests/DependencyInjection/AbstractMongoDBExtensionTest.php
+++ b/Tests/DependencyInjection/AbstractMongoDBExtensionTest.php
@@ -10,11 +10,6 @@ use Doctrine\Bundle\MongoDBBundle\Tests\Fixtures\Filter\BasicFilter;
 use Doctrine\Bundle\MongoDBBundle\Tests\Fixtures\Filter\ComplexFilter;
 use Doctrine\Bundle\MongoDBBundle\Tests\Fixtures\Filter\DisabledFilter;
 use Doctrine\Bundle\MongoDBBundle\Tests\TestCase;
-use Doctrine\Common\Cache\ApcCache;
-use Doctrine\Common\Cache\ArrayCache;
-use Doctrine\Common\Cache\MemcacheCache;
-use Doctrine\Common\Cache\MemcachedCache;
-use Doctrine\Common\Cache\XcacheCache;
 use Doctrine\Common\EventSubscriber;
 use Doctrine\ODM\MongoDB\Configuration;
 use Doctrine\ODM\MongoDB\DocumentManager;
@@ -23,6 +18,8 @@ use Doctrine\Persistence\Mapping\Driver\MappingDriverChain;
 use MongoDB\Client;
 use PHPUnit\Framework\AssertionFailedError;
 use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntityValidator;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+use Symfony\Component\Cache\Adapter\PhpArrayAdapter;
 use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
@@ -52,13 +49,6 @@ abstract class AbstractMongoDBExtensionTest extends TestCase
         $this->assertEquals(DocumentManager::class, $container->getParameter('doctrine_mongodb.odm.document_manager.class'));
         $this->assertEquals('MongoDBODMProxies', $container->getParameter('doctrine_mongodb.odm.proxy_namespace'));
         $this->assertEquals(Configuration::AUTOGENERATE_EVAL, $container->getParameter('doctrine_mongodb.odm.auto_generate_proxy_classes'));
-        $this->assertEquals(ArrayCache::class, $container->getParameter('doctrine_mongodb.odm.cache.array.class'));
-        $this->assertEquals(ApcCache::class, $container->getParameter('doctrine_mongodb.odm.cache.apc.class'));
-        $this->assertEquals(MemcacheCache::class, $container->getParameter('doctrine_mongodb.odm.cache.memcache.class'));
-        $this->assertEquals('localhost', $container->getParameter('doctrine_mongodb.odm.cache.memcache_host'));
-        $this->assertEquals('11211', $container->getParameter('doctrine_mongodb.odm.cache.memcache_port'));
-        $this->assertEquals('Memcache', $container->getParameter('doctrine_mongodb.odm.cache.memcache_instance.class'));
-        $this->assertEquals(XcacheCache::class, $container->getParameter('doctrine_mongodb.odm.cache.xcache.class'));
         $this->assertEquals(MappingDriverChain::class, $container->getParameter('doctrine_mongodb.odm.metadata.driver_chain.class'));
         $this->assertEquals(AnnotationDriver::class, $container->getParameter('doctrine_mongodb.odm.metadata.annotation.class'));
         $this->assertEquals(XmlDriver::class, $container->getParameter('doctrine_mongodb.odm.metadata.xml.class'));
@@ -317,51 +307,53 @@ abstract class AbstractMongoDBExtensionTest extends TestCase
         $this->assertEquals('DoctrineMongoDBBundle\Tests\DependencyInjection\Fixtures\Bundles\AnnotationsBundle\Document', $calls[0][1][1]);
     }
 
-    public function testDocumentManagerMetadataCacheDriverConfiguration(): void
+    /**
+     * @dataProvider metadataCacheProvider
+     */
+    public function testAutomaticMetadataCacheConfiguration(string $config, bool $debug, string $expectedClass): void
     {
         $container = $this->getContainer();
-        $loader    = new DoctrineMongoDBExtension();
+        $container->setParameter('kernel.debug', $debug);
+
+        $loader = new DoctrineMongoDBExtension();
         $container->registerExtension($loader);
 
-        $this->loadFromFile($container, 'mongodb_service_multiple_connections');
-
-        $container->getCompilerPassConfig()->setOptimizationPasses([]);
-        $container->getCompilerPassConfig()->setRemovingPasses([]);
-        $container->compile();
-
-        $definition = $container->getDefinition('doctrine_mongodb.odm.dm1_metadata_cache');
-        $this->assertEquals('%doctrine_mongodb.odm.cache.xcache.class%', $definition->getClass());
-
-        $definition = $container->getDefinition('doctrine_mongodb.odm.dm2_metadata_cache');
-        $this->assertEquals('%doctrine_mongodb.odm.cache.apc.class%', $definition->getClass());
-    }
-
-    public function testDocumentManagerMemcachedMetadataCacheDriverConfiguration(): void
-    {
-        $container = $this->getContainer();
-        $loader    = new DoctrineMongoDBExtension();
-        $container->registerExtension($loader);
-
-        $this->loadFromFile($container, 'mongodb_service_simple_single_connection');
+        $this->loadFromFile($container, $config);
 
         $container->getCompilerPassConfig()->setOptimizationPasses([]);
         $container->getCompilerPassConfig()->setRemovingPasses([]);
         $container->compile();
 
         $definition = $container->getDefinition('doctrine_mongodb.odm.default_metadata_cache');
-        $this->assertEquals(MemcachedCache::class, $definition->getClass());
+        $this->assertEquals($expectedClass, $definition->getClass());
+    }
 
-        $calls = $definition->getMethodCalls();
-        $this->assertEquals('setMemcached', $calls[0][0]);
-        $this->assertEquals('doctrine_mongodb.odm.default_memcached_instance', (string) $calls[0][1][0]);
+    public static function metadataCacheProvider(): array
+    {
+        return [
+            'No cache configured' => [
+                'config' => 'mongodb_service_single_connection',
+                'debug' => false,
+                'expectedClass' => PhpArrayAdapter::class,
+            ],
+            'No cache configured, debug mode' => [
+                'config' => 'mongodb_service_single_connection',
+                'debug' => true,
+                'expectedClass' => ArrayAdapter::class,
+            ],
+        ];
+    }
 
-        $definition = $container->getDefinition('doctrine_mongodb.odm.default_memcached_instance');
-        $this->assertEquals('Memcached', $definition->getClass());
-
-        $calls = $definition->getMethodCalls();
-        $this->assertEquals('addServer', $calls[0][0]);
-        $this->assertEquals('localhost', $calls[0][1][0]);
-        $this->assertEquals(11211, $calls[0][1][1]);
+    /**
+     * @group legacy
+     */
+    public function testDeprecatedMetadataCacheConfiguration(): void
+    {
+        $this->testAutomaticMetadataCacheConfiguration(
+            'mongodb_service_single_connection_cache',
+            false,
+            ArrayAdapter::class
+        );
     }
 
     public function testDependencyInjectionImportsOverrideDefaults(): void

--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -56,6 +56,7 @@ class ConfigurationTest extends TestCase
 
     /**
      * @dataProvider provideFullConfiguration
+     * @group legacy
      */
     public function testFullConfiguration(array $config): void
     {
@@ -143,13 +144,7 @@ class ConfigurationTest extends TestCase
                             ],
                         ],
                     ],
-                    'metadata_cache_driver' => [
-                        'type'           => 'memcached',
-                        'class'          => 'fooClass',
-                        'host'           => 'host_val',
-                        'port'           => 1234,
-                        'instance_class' => 'instance_val',
-                    ],
+                    'metadata_cache_driver' => ['type' => 'array'],
                     'mappings' => [
                         'FooBundle' => [
                             'type'    => 'annotation',
@@ -171,7 +166,7 @@ class ConfigurationTest extends TestCase
                     'persistent_collection_factory' => null,
                     'auto_mapping' => false,
                     'filters'      => [],
-                    'metadata_cache_driver' => ['type' => 'apc'],
+                    'metadata_cache_driver' => ['type' => 'array'],
                     'mappings' => [
                         'BarBundle' => [
                             'type'      => 'yml',
@@ -276,7 +271,7 @@ class ConfigurationTest extends TestCase
                 ['document_managers' => ['default' => ['mappings' => ['foomap' => ['type' => 'val1'], 'barmap' => ['dir' => 'val2']]]]],
                 ['document_managers' => ['default' => ['mappings' => ['barmap' => ['prefix' => 'val3']]]]],
             ],
-            ['document_managers' => ['default' => ['metadata_cache_driver' => ['type' => 'array'], 'logging' => '%kernel.debug%', 'profiler' => ['enabled' => '%kernel.debug%', 'pretty' => '%kernel.debug%'], 'auto_mapping' => false, 'default_document_repository_class' => DocumentRepository::class, 'default_gridfs_repository_class' => DefaultGridFSRepository::class, 'repository_factory' => 'doctrine_mongodb.odm.container_repository_factory', 'persistent_collection_factory' => null, 'filters' => [], 'mappings' => ['foomap' => ['type' => 'val1', 'mapping' => true], 'barmap' => ['prefix' => 'val3', 'mapping' => true]]]]],
+            ['document_managers' => ['default' => ['logging' => '%kernel.debug%', 'profiler' => ['enabled' => '%kernel.debug%', 'pretty' => '%kernel.debug%'], 'auto_mapping' => false, 'default_document_repository_class' => DocumentRepository::class, 'default_gridfs_repository_class' => DefaultGridFSRepository::class, 'repository_factory' => 'doctrine_mongodb.odm.container_repository_factory', 'persistent_collection_factory' => null, 'filters' => [], 'mappings' => ['foomap' => ['type' => 'val1', 'mapping' => true], 'barmap' => ['prefix' => 'val3', 'mapping' => true]]]]],
         ];
 
         // connections are merged non-recursively.
@@ -327,8 +322,8 @@ class ConfigurationTest extends TestCase
             ],
             [
                 'document_managers' => [
-                    'foodm' => ['database' => 'val1', 'metadata_cache_driver' => ['type' => 'array'], 'logging' => '%kernel.debug%', 'profiler' => ['enabled' => '%kernel.debug%', 'pretty' => '%kernel.debug%'], 'auto_mapping' => false, 'default_document_repository_class' => DocumentRepository::class, 'default_gridfs_repository_class' => DefaultGridFSRepository::class, 'repository_factory' => 'doctrine_mongodb.odm.container_repository_factory', 'persistent_collection_factory' => null, 'filters' => [], 'mappings' => []],
-                    'bardm' => ['database' => 'val3', 'metadata_cache_driver' => ['type' => 'array'], 'logging' => '%kernel.debug%', 'profiler' => ['enabled' => '%kernel.debug%', 'pretty' => '%kernel.debug%'], 'auto_mapping' => false, 'default_document_repository_class' => DocumentRepository::class, 'default_gridfs_repository_class' => DefaultGridFSRepository::class, 'repository_factory' => 'doctrine_mongodb.odm.container_repository_factory', 'persistent_collection_factory' => null, 'filters' => [], 'mappings' => []],
+                    'foodm' => ['database' => 'val1', 'logging' => '%kernel.debug%', 'profiler' => ['enabled' => '%kernel.debug%', 'pretty' => '%kernel.debug%'], 'auto_mapping' => false, 'default_document_repository_class' => DocumentRepository::class, 'default_gridfs_repository_class' => DefaultGridFSRepository::class, 'repository_factory' => 'doctrine_mongodb.odm.container_repository_factory', 'persistent_collection_factory' => null, 'filters' => [], 'mappings' => []],
+                    'bardm' => ['database' => 'val3', 'logging' => '%kernel.debug%', 'profiler' => ['enabled' => '%kernel.debug%', 'pretty' => '%kernel.debug%'], 'auto_mapping' => false, 'default_document_repository_class' => DocumentRepository::class, 'default_gridfs_repository_class' => DefaultGridFSRepository::class, 'repository_factory' => 'doctrine_mongodb.odm.container_repository_factory', 'persistent_collection_factory' => null, 'filters' => [], 'mappings' => []],
                 ],
             ],
         ];
@@ -386,8 +381,8 @@ class ConfigurationTest extends TestCase
             ],
             [
                 'document_managers' => [
-                    'foo' => ['connection' => 'conn1', 'metadata_cache_driver' => ['type' => 'array'], 'logging' => '%kernel.debug%', 'profiler' => ['enabled' => '%kernel.debug%', 'pretty' => '%kernel.debug%'], 'auto_mapping' => false, 'default_document_repository_class' => DocumentRepository::class, 'default_gridfs_repository_class' => DefaultGridFSRepository::class, 'repository_factory' => 'doctrine_mongodb.odm.container_repository_factory', 'persistent_collection_factory' => null, 'filters' => [], 'mappings' => []],
-                    'bar' => ['connection' => 'conn2', 'metadata_cache_driver' => ['type' => 'array'], 'logging' => '%kernel.debug%', 'profiler' => ['enabled' => '%kernel.debug%', 'pretty' => '%kernel.debug%'], 'auto_mapping' => false, 'default_document_repository_class' => DocumentRepository::class, 'default_gridfs_repository_class' => DefaultGridFSRepository::class, 'repository_factory' => 'doctrine_mongodb.odm.container_repository_factory', 'persistent_collection_factory' => null,'filters' => [], 'mappings' => []],
+                    'foo' => ['connection' => 'conn1', 'logging' => '%kernel.debug%', 'profiler' => ['enabled' => '%kernel.debug%', 'pretty' => '%kernel.debug%'], 'auto_mapping' => false, 'default_document_repository_class' => DocumentRepository::class, 'default_gridfs_repository_class' => DefaultGridFSRepository::class, 'repository_factory' => 'doctrine_mongodb.odm.container_repository_factory', 'persistent_collection_factory' => null, 'filters' => [], 'mappings' => []],
+                    'bar' => ['connection' => 'conn2', 'logging' => '%kernel.debug%', 'profiler' => ['enabled' => '%kernel.debug%', 'pretty' => '%kernel.debug%'], 'auto_mapping' => false, 'default_document_repository_class' => DocumentRepository::class, 'default_gridfs_repository_class' => DefaultGridFSRepository::class, 'repository_factory' => 'doctrine_mongodb.odm.container_repository_factory', 'persistent_collection_factory' => null,'filters' => [], 'mappings' => []],
                 ],
             ],
         ];
@@ -410,7 +405,6 @@ class ConfigurationTest extends TestCase
                 'document_managers' => [
                     'foo' => [
                         'connection'   => 'conn1',
-                        'metadata_cache_driver' => ['type' => 'array'],
                         'default_document_repository_class' =>  DocumentRepository::class,
                         'default_gridfs_repository_class' => DefaultGridFSRepository::class,
                         'repository_factory' => 'doctrine_mongodb.odm.container_repository_factory',

--- a/Tests/DependencyInjection/Fixtures/config/xml/full.xml
+++ b/Tests/DependencyInjection/Fixtures/config/xml/full.xml
@@ -67,14 +67,9 @@
         <doctrine:document-manager
             id="dm1"
             repository-factory="doctrine_mongodb.odm.container_repository_factory"
+            metadata-cache-driver="array"
         >
             <doctrine:mapping name="FooBundle" type="annotation" />
-            <doctrine:metadata-cache-driver type="memcached">
-                <doctrine:class>fooClass</doctrine:class>
-                <doctrine:host>host_val</doctrine:host>
-                <doctrine:port>1234</doctrine:port>
-                <doctrine:instance-class>instance_val</doctrine:instance-class>
-            </doctrine:metadata-cache-driver>
             <doctrine:profiler enabled="true" pretty="false" />
             <doctrine:filter name="disabled_filter" enabled="false" class="Doctrine\Bundle\MongoDBBundle\Tests\Fixtures\Filter\DisabledFilter" />
             <doctrine:filter name="basic_filter" enabled="true" class="Doctrine\Bundle\MongoDBBundle\Tests\Fixtures\Filter\BasicFilter" />
@@ -90,7 +85,7 @@
             id="dm2"
             connection="dm2_connection"
             database="db1"
-            metadata-cache-driver="apc"
+            metadata-cache-driver="array"
             logging="true"
             repository-factory="doctrine_mongodb.odm.container_repository_factory"
             default-document-repository-class="Doctrine\Bundle\MongoDBBundle\Tests\Fixtures\Repository\CustomRepository"

--- a/Tests/DependencyInjection/Fixtures/config/xml/mongodb_service_multiple_connections.xml
+++ b/Tests/DependencyInjection/Fixtures/config/xml/mongodb_service_multiple_connections.xml
@@ -9,14 +9,12 @@
     <doctrine:mongodb
         default-document-manager="dm2"
         default-connection="conn1"
-        proxy-namespace="Proxies"
-        auto-generate-proxy-classes="true"
     >
         <doctrine:connection id="conn1" server="mongodb://localhost:27017" />
 
         <doctrine:connection id="conn2" server="mongodb://localhost:27017" />
 
-        <doctrine:document-manager id="dm1" metadata-cache-driver="xcache" connection="conn1" />
-        <doctrine:document-manager id="dm2" connection="conn2" metadata-cache-driver="apc" />
+        <doctrine:document-manager id="dm1" connection="conn1" />
+        <doctrine:document-manager id="dm2" connection="conn2" />
     </doctrine:mongodb>
 </container>

--- a/Tests/DependencyInjection/Fixtures/config/xml/mongodb_service_single_connection.xml
+++ b/Tests/DependencyInjection/Fixtures/config/xml/mongodb_service_single_connection.xml
@@ -9,14 +9,6 @@
     <doctrine:mongodb>
         <doctrine:connection id="default" server="mongodb://localhost:27017" />
 
-        <doctrine:document-manager id="default" connection="default">
-            <doctrine:metadata-cache-driver type="memcached">
-                <doctrine:class>Doctrine\Common\Cache\MemcacheCache</doctrine:class>
-                <doctrine:host>localhost</doctrine:host>
-                <doctrine:port>11211</doctrine:port>
-                <doctrine:instance-class>Memcached</doctrine:instance-class>
-            </doctrine:metadata-cache-driver>
-        </doctrine:document-manager>
-
+        <doctrine:document-manager id="default" connection="default" />
     </doctrine:mongodb>
 </container>

--- a/Tests/DependencyInjection/Fixtures/config/xml/mongodb_service_single_connection_cache.xml
+++ b/Tests/DependencyInjection/Fixtures/config/xml/mongodb_service_single_connection_cache.xml
@@ -6,9 +6,9 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd
                         http://symfony.com/schema/dic/doctrine/odm/mongodb http://symfony.com/schema/dic/doctrine/odm/mongodb/mongodb-1.0.xsd">
 
-    <doctrine:mongodb default_database="mydb">
-        <doctrine:connection server="mongodb://localhost:27017" id="default" />
+    <doctrine:mongodb>
+        <doctrine:connection id="default" server="mongodb://localhost:27017" />
 
-        <doctrine:document-manager id="default" connection="default" />
+        <doctrine:document-manager id="default" connection="default" metadata-cache-driver="array" />
     </doctrine:mongodb>
 </container>

--- a/Tests/DependencyInjection/Fixtures/config/yml/full.yml
+++ b/Tests/DependencyInjection/Fixtures/config/yml/full.yml
@@ -57,12 +57,7 @@ doctrine_mongodb:
             persistent_collection_factory: ~
             mappings:
                 FooBundle:   annotation
-            metadata_cache_driver:
-                type:                  memcached
-                class:                 fooClass
-                host:                  host_val
-                port:                  1234
-                instance_class:        instance_val
+            metadata_cache_driver: array
             profiler:
                 enabled: true
                 pretty:  false
@@ -95,5 +90,5 @@ doctrine_mongodb:
                     prefix: prefix_val
                     alias:  alias_val
                     is_bundle: false
-            metadata_cache_driver: apc
+            metadata_cache_driver: array
             logging: true

--- a/Tests/DependencyInjection/Fixtures/config/yml/mongodb_service_multiple_connections.yml
+++ b/Tests/DependencyInjection/Fixtures/config/yml/mongodb_service_multiple_connections.yml
@@ -9,7 +9,5 @@ doctrine_mongodb:
   document_managers:
     dm1:
       connection: conn1
-      metadata_cache_driver: xcache
     dm2:
       connection: conn2
-      metadata_cache_driver: apc

--- a/Tests/DependencyInjection/Fixtures/config/yml/mongodb_service_simple_single_connection.yml
+++ b/Tests/DependencyInjection/Fixtures/config/yml/mongodb_service_simple_single_connection.yml
@@ -4,10 +4,4 @@ doctrine_mongodb:
       server: mongodb://localhost:27017
   default_database: mydb
   document_managers:
-    default:
-      metadata_cache_driver:
-        type: memcached
-        class: Doctrine\Common\Cache\MemcachedCache
-        host: localhost
-        port: 11211
-        instance_class: Memcached
+    default: ~

--- a/Tests/DependencyInjection/Fixtures/config/yml/mongodb_service_single_connection_cache.yml
+++ b/Tests/DependencyInjection/Fixtures/config/yml/mongodb_service_single_connection_cache.yml
@@ -5,3 +5,4 @@ doctrine_mongodb:
   document_managers:
     default:
       connection: default
+      metadata_cache_driver: array

--- a/Tests/TestCase.php
+++ b/Tests/TestCase.php
@@ -5,11 +5,11 @@ declare(strict_types=1);
 namespace Doctrine\Bundle\MongoDBBundle\Tests;
 
 use Doctrine\Common\Annotations\AnnotationReader;
-use Doctrine\Common\Cache\ArrayCache;
 use Doctrine\ODM\MongoDB\Configuration;
 use Doctrine\ODM\MongoDB\DocumentManager;
 use Doctrine\ODM\MongoDB\Mapping\Driver\AnnotationDriver;
 use PHPUnit\Framework\TestCase as BaseTestCase;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
 
 use function sys_get_temp_dir;
 
@@ -27,7 +27,7 @@ class TestCase extends BaseTestCase
         $config->setProxyNamespace('SymfonyTests\Doctrine');
         $config->setHydratorNamespace('SymfonyTests\Doctrine');
         $config->setMetadataDriverImpl(new AnnotationDriver(new AnnotationReader(), $paths));
-        $config->setMetadataCacheImpl(new ArrayCache());
+        $config->setMetadataCache(new ArrayAdapter());
 
         return DocumentManager::create(null, $config);
     }

--- a/UPGRADE-4.4.md
+++ b/UPGRADE-4.4.md
@@ -1,0 +1,13 @@
+UPGRADE FROM 4.x to 4.4
+=======================
+
+* The `metadata_cache_driver` configuration was deprecated. The bundle
+  automatically registers an `ArrayAdapter` or a `PhpArrayAdapter` based on the
+  `kernel.debug` flag.
+* Due to the deprecation of doctrine/cache, the bundle will attempt to create
+  the requested cache. For the `apcu`, `array`, `memcached`, `redis`, and
+  `service` drivers we are able to do this transparently. For other adapters,
+  you may need to add an explicit dependency on `doctrine/cache` 1.11 to ensure
+  you still have the desired cache. However, you should be able to drop the
+  cache configuration entirely and take advantage of the automatic
+  configuration.

--- a/UPGRADE-5.0.md
+++ b/UPGRADE-5.0.md
@@ -1,0 +1,6 @@
+UPGRADE FROM 4.x to 5.0
+=======================
+
+* The `metadata_cache_driver` configuration was dropped. The bundle
+  automatically registers an `ArrayAdapter` or a `PhpArrayAdapter` based on the
+  `kernel.debug` flag.

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "require": {
         "php": "^7.2 || ^8.0",
         "doctrine/annotations": "^1.2",
-        "doctrine/mongodb-odm": "^2.0.0",
+        "doctrine/mongodb-odm": "^2.3.0",
         "doctrine/persistence": "^1.3.6|^2.0",
         "psr/log": "^1.0",
         "symfony/console": "^4.3.3|^5.0",


### PR DESCRIPTION
This PR deprecates the `metadata_cache_driver` config key in favour of automatic configuration. In debug mode, it creates an ArrayAdapter, meaning that the cache is only valid per request. This is usually desired in a development environment. When debug is disabled, it creates a PhpArrayAdapter, backed by an array cache. The cache is warmed up and stored in the file system. Since this information shouldn't be shared between multiple instances of the code, it is only logical to store this in the cache folder in an efficient format. This also mirrors a decision made in the ORM bundle to deprecate the config.

Note: This PR contains a commit from #674. I'll rebase this PR once the other one has been merged.