### PR TITLE
Remove phpunit deprecations

### DIFF
--- a/Tests/CacheWarmer/HydratorCacheWarmerTest.php
+++ b/Tests/CacheWarmer/HydratorCacheWarmerTest.php
@@ -11,6 +11,7 @@ use Doctrine\ODM\MongoDB\Configuration;
 use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
+use function method_exists;
 use function sys_get_temp_dir;
 use function unlink;
 
@@ -66,10 +67,22 @@ class HydratorCacheWarmerTest extends TestCase
 
         try {
             $this->warmer->warmUp('meh');
-            $this->assertFileNotExists($hydratorFilename);
+            // Replace by "assertFileDoesNotExist" when PHPUnit 9 is minimum
+            $this->assertFileDoesNotExistWithBC($hydratorFilename);
         } finally {
             @unlink($hydratorFilename);
         }
+    }
+
+    private function assertFileDoesNotExistWithBC(string $filename): void
+    {
+        if (! method_exists($this, 'assertFileDoesNotExist')) {
+            $this->assertFileNotExists($filename);
+
+            return;
+        }
+
+        $this->assertFileDoesNotExist($filename);
     }
 
     /**

--- a/Tests/DataCollector/CommandDataCollectorTest.php
+++ b/Tests/DataCollector/CommandDataCollectorTest.php
@@ -12,9 +12,6 @@ use Symfony\Component\HttpFoundation\Response;
 
 class CommandDataCollectorTest extends TestCase
 {
-    /**
-     * @doesNotPerformAssertions
-     */
     public function testCollector(): void
     {
         $collector = new CommandDataCollector(new CommandLogger());


### PR DESCRIPTION
There are some warnings about the deprecated `assertFileNotExists` method and a risky one about a test marked as `@doesNotPerformAssertions` but it actually performs an assertion.