### PR TITLE
Add psalm to CI

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -14,6 +14,8 @@ jobs:
   phpunit:
     name: "PHPUnit"
     runs-on: "${{ matrix.os }}"
+    env:
+      SYMFONY_REQUIRE: ${{matrix.symfony-require}}
 
     strategy:
       matrix:
@@ -74,8 +76,8 @@ jobs:
           coverage: "pcov"
           ini-values: "zend.assertions=1"
 
-      - name: "Install Symfony"
-        run: "composer require symfony/symfony:${{ matrix.symfony-version }} --no-update"
+      - name: "Globally install symfony/flex"
+        run: "composer global require --no-progress --no-scripts --no-plugins symfony/flex"
 
       - name: "Set minimum-stability to stable in Composer"
         run: "composer config minimum-stability stable"

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -1,0 +1,36 @@
+name: "Static Analysis"
+
+on:
+  pull_request:
+    branches:
+      - "*.x"
+  push:
+
+jobs:
+  static-analysis-psalm:
+    name: "Static Analysis with Psalm"
+    runs-on: "ubuntu-20.04"
+
+    strategy:
+      matrix:
+        php-version:
+          - "8.0"
+
+    steps:
+      - name: "Checkout code"
+        uses: "actions/checkout@v2"
+
+      - name: "Install PHP"
+        uses: "shivammathur/setup-php@v2"
+        with:
+          coverage: "none"
+          php-version: "${{ matrix.php-version }}"
+
+      - name: "Set minimum-stability to stable in Composer"
+        run: "composer config minimum-stability stable"
+
+      - name: "Install dependencies with Composer"
+        uses: "ramsey/composer-install@v1"
+
+      - name: "Run a static analysis with vimeo/psalm"
+        run: "vendor/bin/psalm --show-info=false --stats --output-format=github --threads=$(nproc) --php-version=${{ matrix.php-version }}"

--- a/DependencyInjection/Compiler/DoctrineMongoDBMappingsPass.php
+++ b/DependencyInjection/Compiler/DoctrineMongoDBMappingsPass.php
@@ -53,9 +53,9 @@ class DoctrineMongoDBMappingsPass extends RegisterMappingsPass
      *                                    your bundle uses. This compiler pass will automatically
      *                                    append the parameter name for the default entity manager
      *                                    to this list.
-     * @param string   $enabledParameter  Service container parameter that must be present to
-     *                                    enable the mapping. Set to false to not do any check,
-     *                                    optional.
+     * @param bool     $enabledParameter  Service container parameter that must be present to
+     *                                      enable the mapping. Set to false to not do any check,
+     *                                      optional.
      * @param string[] $aliasMap          Map of alias to namespace.
      *
      * @return DoctrineMongoDBMappingsPass
@@ -75,9 +75,9 @@ class DoctrineMongoDBMappingsPass extends RegisterMappingsPass
      *                                    your bundle uses. This compiler pass will automatically
      *                                    append the parameter name for the default entity manager
      *                                    to this list.
-     * @param string   $enabledParameter  Service container parameter that must be present to
-     *                                    enable the mapping. Set to false to not do any check,
-     *                                    optional.
+     * @param bool     $enabledParameter  Service container parameter that must be present to
+     *                                      enable the mapping. Set to false to not do any check,
+     *                                      optional.
      * @param string[] $aliasMap          Map of alias to namespace.
      *
      * @return DoctrineMongoDBMappingsPass
@@ -98,9 +98,9 @@ class DoctrineMongoDBMappingsPass extends RegisterMappingsPass
      *                                    your bundle uses. This compiler pass will automatically
      *                                    append the parameter name for the default entity manager
      *                                    to this list.
-     * @param string   $enabledParameter  Service container parameter that must be present to
-     *                                    enable the mapping. Set to false to not do any check,
-     *                                    optional.
+     * @param bool     $enabledParameter  Service container parameter that must be present to
+     *                                      enable the mapping. Set to false to not do any check,
+     *                                      optional.
      * @param string[] $aliasMap          Map of alias to namespace.
      *
      * @return DoctrineMongoDBMappingsPass
@@ -119,9 +119,9 @@ class DoctrineMongoDBMappingsPass extends RegisterMappingsPass
      *                                    your bundle uses. This compiler pass will automatically
      *                                    append the parameter name for the default entity manager
      *                                    to this list.
-     * @param string   $enabledParameter  Service container parameter that must be present to
-     *                                    enable the mapping. Set to false to not do any check,
-     *                                    optional.
+     * @param bool     $enabledParameter  Service container parameter that must be present to
+     *                                      enable the mapping. Set to false to not do any check,
+     *                                      optional.
      * @param string[] $aliasMap          Map of alias to namespace.
      *
      * @return DoctrineMongoDBMappingsPass

--- a/DependencyInjection/DoctrineMongoDBExtension.php
+++ b/DependencyInjection/DoctrineMongoDBExtension.php
@@ -19,7 +19,6 @@ use Symfony\Component\DependencyInjection\Alias;
 use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
-use Symfony\Component\DependencyInjection\DefinitionDecorator;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\Messenger\MessageBusInterface;
@@ -263,7 +262,7 @@ class DoctrineMongoDBExtension extends AbstractDoctrineExtension
         $container
             ->setDefinition(
                 $managerConfiguratorName,
-                $this->getChildDefinitionOrDefinitionDecorator('doctrine_mongodb.odm.manager_configurator.abstract')
+                new ChildDefinition('doctrine_mongodb.odm.manager_configurator.abstract')
             )
             ->replaceArgument(0, $enabledFilters);
 
@@ -320,7 +319,7 @@ class DoctrineMongoDBExtension extends AbstractDoctrineExtension
             $eventManagerId = sprintf('doctrine_mongodb.odm.%s_connection.event_manager', $name);
             $container->setDefinition(
                 $eventManagerId,
-                $this->getChildDefinitionOrDefinitionDecorator('doctrine_mongodb.odm.connection.event_manager')
+                new ChildDefinition('doctrine_mongodb.odm.connection.event_manager')
             );
 
             $configurationId = sprintf('doctrine_mongodb.odm.%s_configuration', $name);
@@ -495,17 +494,5 @@ class DoctrineMongoDBExtension extends AbstractDoctrineExtension
     public function getXsdValidationBasePath()
     {
         return __DIR__ . '/../Resources/config/schema';
-    }
-
-    /**
-     * Instantiate new ChildDefinition if available, otherwise fall back to deprecated DefinitionDecorator
-     *
-     * @param string $id service ID passed to ctor
-     *
-     * @return ChildDefinition|DefinitionDecorator
-     */
-    private function getChildDefinitionOrDefinitionDecorator($id)
-    {
-        return class_exists(ChildDefinition::class) ? new ChildDefinition($id) : new DefinitionDecorator($id);
     }
 }

--- a/DependencyInjection/DoctrineMongoDBExtension.php
+++ b/DependencyInjection/DoctrineMongoDBExtension.php
@@ -347,6 +347,7 @@ class DoctrineMongoDBExtension extends AbstractDoctrineExtension
 
     private function loadMessengerServices(ContainerBuilder $container)
     {
+        /** @psalm-suppress UndefinedClass Optional dependency */
         if (! interface_exists(MessageBusInterface::class) || ! class_exists(DoctrineClearEntityManagerWorkerSubscriber::class)) {
             return;
         }

--- a/Form/DoctrineMongoDBTypeGuesser.php
+++ b/Form/DoctrineMongoDBTypeGuesser.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\Bundle\MongoDBBundle\Form;
 
 use Doctrine\Bundle\MongoDBBundle\Form\Type\DocumentType;
+use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
 use Doctrine\Persistence\ManagerRegistry;
 use Doctrine\Persistence\Mapping\MappingException;
 use Symfony\Component\Form\AbstractType;

--- a/Tests/DependencyInjection/DoctrineMongoDBExtensionTest.php
+++ b/Tests/DependencyInjection/DoctrineMongoDBExtensionTest.php
@@ -236,6 +236,7 @@ class DoctrineMongoDBExtensionTest extends TestCase
 
     public function testMessengerIntegration(): void
     {
+        /** @psalm-suppress UndefinedClass Optional dependency */
         if (! interface_exists(MessageBusInterface::class)) {
             $this->markTestSkipped('Symfony Messenger component is not installed');
         }

--- a/Tests/Mapping/Driver/XmlDriverTest.php
+++ b/Tests/Mapping/Driver/XmlDriverTest.php
@@ -27,8 +27,8 @@ class XmlDriverTest extends AbstractDriverTest
     /**
      * @return XmlDriver
      */
-    protected function getDriver(array $prefixes = [])
+    protected function getDriver(array $paths = [])
     {
-        return new XmlDriver($prefixes, $this->getFileExtension());
+        return new XmlDriver($paths, $this->getFileExtension());
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "doctrine/data-fixtures": "<1.3"
     },
     "require-dev": {
-        "doctrine/coding-standard": "^8.2",
+        "doctrine/coding-standard": "^9.0",
         "doctrine/data-fixtures": "^1.3",
         "phpunit/phpunit": "^8.5 || ^9.3",
         "squizlabs/php_codesniffer": "^3.5",

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,8 @@
         "squizlabs/php_codesniffer": "^3.5",
         "symfony/form": "^4.3.3|^5.0",
         "symfony/phpunit-bridge": "^5.1",
-        "symfony/yaml": "^4.3.3|^5.0"
+        "symfony/yaml": "^4.3.3|^5.0",
+        "vimeo/psalm": "^4.8"
     },
     "suggest": {
         "doctrine/data-fixtures": "Load data fixtures"

--- a/composer.json
+++ b/composer.json
@@ -35,6 +35,8 @@
         "squizlabs/php_codesniffer": "^3.5",
         "symfony/form": "^4.3.3|^5.0",
         "symfony/phpunit-bridge": "^5.1",
+        "symfony/security-bundle": "^4.4|^5.0",
+        "symfony/validator": "^4.4|^5.0",
         "symfony/yaml": "^4.3.3|^5.0",
         "vimeo/psalm": "^4.8"
     },

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -30,6 +30,8 @@
         <exclude name="SlevomatCodingStandard.Classes.SuperfluousExceptionNaming" />
         <exclude name="SlevomatCodingStandard.Classes.SuperfluousInterfaceNaming" />
         <exclude name="SlevomatCodingStandard.Classes.SuperfluousTraitNaming" />
+
+        <exclude name="SlevomatCodingStandard.Classes.ModernClassNameReference" /> <!-- PHP 8.0 required-->
     </rule>
 
     <rule ref="PSR1.Classes.ClassDeclaration.MultipleClasses">

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -22,6 +22,8 @@
         <!-- <server name="DOCTRINE_MONGODB_ODM" value="/path/to/doctrine-mongodb-odm/lib" /> -->
         <!-- <server name="DOCTRINE_MONGODB" value="/path/to/doctrine-mongodb/lib" /> -->
         <!-- <server name="DOCTRINE_COMMON" value="/path/to/doctrine-common/lib" /> -->
+        <!-- Allow 1 direct deprecation until https://github.com/doctrine/DoctrineMongoDBBundle/pull/675 is merged -->
+        <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[direct]=1"/>
     </php>
 
     <filter>

--- a/psalm.xml
+++ b/psalm.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0"?>
+<psalm
+    errorLevel="7"
+    resolveFromConfigFile="true"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns="https://getpsalm.org/schema/config"
+    xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
+>
+    <projectFiles>
+        <directory name="APM" />
+        <directory name="CacheWarmer" />
+        <directory name="Command" />
+        <directory name="Cursor" />
+        <directory name="DataCollector" />
+        <directory name="DependencyInjection" />
+        <directory name="EventSubscriber" />
+        <directory name="Fixture" />
+        <directory name="Form" />
+        <directory name="Loader" />
+        <directory name="Mapping" />
+        <directory name="Repository" />
+        <directory name="Tests" />
+        <directory name="Validator" />
+        <file name="DoctrineMongoDBBundle.php" />
+        <file name="ManagerConfigurator.php" />
+        <file name="ManagerRegistry.php" />
+        <ignoreFiles>
+            <directory name="vendor" />
+        </ignoreFiles>
+    </projectFiles>
+</psalm>


### PR DESCRIPTION
this PR adds psalm at level 7 and fixes the issues found, `symfony/validator` and `symfony/security-bundle` have been added because they are used:

https://github.com/doctrine/DoctrineMongoDBBundle/blob/baddc63a027d2ef363359a6d527a2670512b8e8b/Tests/DependencyInjection/AbstractMongoDBExtensionTest.php#L25

which has a dependency on https://github.com/symfony/doctrine-bridge/blob/ed2e5a8a0987e6484ffac544918e1bd3da7ffb1c/Validator/Constraints/UniqueEntityValidator.php#L15-L18

https://github.com/doctrine/DoctrineMongoDBBundle/blob/baddc63a027d2ef363359a6d527a2670512b8e8b/Validator/Constraints/Unique.php#L7

depends on https://github.com/symfony/doctrine-bridge/blob/ed2e5a8a0987e6484ffac544918e1bd3da7ffb1c/Validator/Constraints/UniqueEntity.php#L14

And for security, we are using:

https://github.com/doctrine/DoctrineMongoDBBundle/blob/8db802c4d49ae63eef1a4a6b62eb8578391ed4a7/Tests/Fixtures/Security/User.php#L9

https://github.com/doctrine/DoctrineMongoDBBundle/blob/8db802c4d49ae63eef1a4a6b62eb8578391ed4a7/DoctrineMongoDBBundle.php#L16

which depends on https://github.com/symfony/doctrine-bridge/blob/ed2e5a8a0987e6484ffac544918e1bd3da7ffb1c/DependencyInjection/Security/UserProvider/EntityFactory.php#L14

