### PR TITLE
Remove deprecated code

### DIFF
--- a/Form/DoctrineMongoDBTypeGuesser.php
+++ b/Form/DoctrineMongoDBTypeGuesser.php
@@ -8,7 +8,6 @@ use Doctrine\Bundle\MongoDBBundle\Form\Type\DocumentType;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
 use Doctrine\Persistence\ManagerRegistry;
 use Doctrine\Persistence\Mapping\MappingException;
-use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\Extension\Core\Type\CollectionType;
 use Symfony\Component\Form\Extension\Core\Type\DateTimeType;
@@ -21,7 +20,6 @@ use Symfony\Component\Form\Guess\TypeGuess;
 use Symfony\Component\Form\Guess\ValueGuess;
 
 use function array_key_exists;
-use function method_exists;
 
 /**
  * Tries to guess form types according to ODM mappings
@@ -34,13 +32,9 @@ class DoctrineMongoDBTypeGuesser implements FormTypeGuesserInterface
     /** @var array */
     private $cache = [];
 
-    /** @var bool */
-    private $typeFQCN;
-
     public function __construct(ManagerRegistry $registry)
     {
         $this->registry = $registry;
-        $this->typeFQCN = method_exists(AbstractType::class, 'getBlockPrefix');
     }
 
     /**
@@ -64,7 +58,7 @@ class DoctrineMongoDBTypeGuesser implements FormTypeGuesserInterface
             $mapping  = $metadata->getFieldMapping($property);
 
             return new TypeGuess(
-                $this->typeFQCN ? DocumentType::class : 'document',
+                DocumentType::class,
                 [
                     'class' => $mapping['targetDocument'],
                     'multiple' => $multiple,
@@ -78,7 +72,7 @@ class DoctrineMongoDBTypeGuesser implements FormTypeGuesserInterface
         switch ($fieldMapping['type']) {
             case 'collection':
                 return new TypeGuess(
-                    $this->typeFQCN ? CollectionType::class : 'collection',
+                    CollectionType::class,
                     [],
                     Guess::MEDIUM_CONFIDENCE
                 );
@@ -86,7 +80,7 @@ class DoctrineMongoDBTypeGuesser implements FormTypeGuesserInterface
             case 'bool':
             case 'boolean':
                 return new TypeGuess(
-                    $this->typeFQCN ? CheckboxType::class : 'checkbox',
+                    CheckboxType::class,
                     [],
                     Guess::HIGH_CONFIDENCE
                 );
@@ -94,14 +88,14 @@ class DoctrineMongoDBTypeGuesser implements FormTypeGuesserInterface
             case 'date':
             case 'timestamp':
                 return new TypeGuess(
-                    $this->typeFQCN ? DateTimeType::class : 'datetime',
+                    DateTimeType::class,
                     [],
                     Guess::HIGH_CONFIDENCE
                 );
 
             case 'float':
                 return new TypeGuess(
-                    $this->typeFQCN ? NumberType::class : 'number',
+                    NumberType::class,
                     [],
                     Guess::MEDIUM_CONFIDENCE
                 );
@@ -109,14 +103,14 @@ class DoctrineMongoDBTypeGuesser implements FormTypeGuesserInterface
             case 'int':
             case 'integer':
                 return new TypeGuess(
-                    $this->typeFQCN ? IntegerType::class : 'integer',
+                    IntegerType::class,
                     [],
                     Guess::MEDIUM_CONFIDENCE
                 );
 
             case 'string':
                 return new TypeGuess(
-                    $this->typeFQCN ? TextType::class : 'text',
+                    TextType::class,
                     [],
                     Guess::MEDIUM_CONFIDENCE
                 );

--- a/Loader/SymfonyFixturesLoader.php
+++ b/Loader/SymfonyFixturesLoader.php
@@ -31,7 +31,7 @@ final class SymfonyFixturesLoader extends ContainerAwareLoader implements Symfon
      *
      * @param array $fixtures
      */
-    public function addFixtures(array $fixtures)
+    public function addFixtures(array $fixtures): void
     {
         // Because parent::addFixture may call $this->createFixture
         // we cannot call $this->addFixture in this loop
@@ -48,7 +48,7 @@ final class SymfonyFixturesLoader extends ContainerAwareLoader implements Symfon
         }
     }
 
-    public function addFixture(FixtureInterface $fixture)
+    public function addFixture(FixtureInterface $fixture): void
     {
         $class                        = get_class($fixture);
         $this->loadedFixtures[$class] = $fixture;

--- a/ManagerConfigurator.php
+++ b/ManagerConfigurator.php
@@ -36,10 +36,8 @@ class ManagerConfigurator
 
     /**
      * Enable filters for an given document manager
-     *
-     * @return null
      */
-    private function enableFilters(DocumentManager $documentManager)
+    private function enableFilters(DocumentManager $documentManager): void
     {
         if (empty($this->enabledFilters)) {
             return;

--- a/Tests/Form/Type/DocumentTypeTest.php
+++ b/Tests/Form/Type/DocumentTypeTest.php
@@ -14,29 +14,23 @@ use Doctrine\Persistence\ManagerRegistry;
 use InvalidArgumentException;
 use MongoDB\BSON\ObjectId;
 use PHPUnit\Framework\MockObject\MockObject;
-use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\FormType;
 use Symfony\Component\Form\FormExtensionInterface;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\Form\Test\TypeTestCase;
 
 use function array_merge;
-use function method_exists;
 
 class DocumentTypeTest extends TypeTestCase
 {
     /** @var DocumentManager */
     private $dm;
 
-    /** @var MockObject */
+    /** @var MockObject&ManagerRegistry */
     private $dmRegistry;
-
-    private $typeFQCN;
 
     protected function setUp(): void
     {
-        $this->typeFQCN = method_exists(AbstractType::class, 'getBlockPrefix');
-
         $this->dm         = TestCase::createTestDocumentManager([
             __DIR__ . '/../../Fixtures/Form/Document',
         ]);
@@ -61,7 +55,7 @@ class DocumentTypeTest extends TypeTestCase
 
     public function testDocumentManagerOptionSetsEmOption(): void
     {
-        $field = $this->factory->createNamed('name', $this->typeFQCN ? DocumentType::class : 'document', null, [
+        $field = $this->factory->createNamed('name', DocumentType::class, null, [
             'class' => Document::class,
             'document_manager' => 'default',
         ]);
@@ -71,7 +65,7 @@ class DocumentTypeTest extends TypeTestCase
 
     public function testDocumentManagerInstancePassedAsOption(): void
     {
-        $field = $this->factory->createNamed('name', $this->typeFQCN ? DocumentType::class : 'document', null, [
+        $field = $this->factory->createNamed('name', DocumentType::class, null, [
             'class' => Document::class,
             'document_manager' => $this->dm,
         ]);
@@ -82,7 +76,7 @@ class DocumentTypeTest extends TypeTestCase
     public function testSettingDocumentManagerAndEmOptionShouldThrowException(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->factory->createNamed('name', $this->typeFQCN ? DocumentType::class : 'document', null, [
+        $this->factory->createNamed('name', DocumentType::class, null, [
             'document_manager' => 'default',
             'em' => 'default',
         ]);
@@ -101,10 +95,10 @@ class DocumentTypeTest extends TypeTestCase
 
         $this->dm->flush();
 
-        $form = $this->factory->create($this->typeFQCN ? FormType::class : 'form', $document)
+        $form = $this->factory->create(FormType::class, $document)
             ->add(
                 'categories',
-                $this->typeFQCN ? DocumentType::class : 'document',
+                DocumentType::class,
                 [
                     'class' => Category::class,
                     'multiple' => true,

--- a/Tests/Form/Type/TypeGuesserTest.php
+++ b/Tests/Form/Type/TypeGuesserTest.php
@@ -12,28 +12,22 @@ use Doctrine\Bundle\MongoDBBundle\Tests\TestCase;
 use Doctrine\ODM\MongoDB\DocumentManager;
 use Doctrine\Persistence\ManagerRegistry;
 use PHPUnit\Framework\MockObject\MockObject;
-use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormExtensionInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\Test\TypeTestCase;
 
 use function array_merge;
-use function method_exists;
 
 class TypeGuesserTest extends TypeTestCase
 {
     /** @var DocumentManager */
     private $dm;
 
-    /** @var MockObject */
+    /** @var MockObject&ManagerRegistry */
     private $dmRegistry;
-
-    private $typeFQCN;
 
     protected function setUp(): void
     {
-        $this->typeFQCN = method_exists(AbstractType::class, 'getBlockPrefix');
-
         $this->dm         = TestCase::createTestDocumentManager([
             __DIR__ . '/../../Fixtures/Form/Guesser',
         ]);
@@ -62,7 +56,7 @@ class TypeGuesserTest extends TypeTestCase
      */
     public function testTypesShouldBeGuessedCorrectly(): void
     {
-        $form = $this->factory->create($this->typeFQCN ? GuesserTestType::class : new GuesserTestType(), null, ['dm' => $this->dm]);
+        $form = $this->factory->create(GuesserTestType::class, null, ['dm' => $this->dm]);
         $this->assertType('text', $form->get('name'));
         $this->assertType('document', $form->get('categories'));
         $this->assertType('datetime', $form->get('date'));
@@ -76,7 +70,7 @@ class TypeGuesserTest extends TypeTestCase
 
     protected function assertType(string $type, FormInterface $form): void
     {
-        $this->assertEquals($type, $this->typeFQCN ? $form->getConfig()->getType()->getBlockPrefix() : $form->getConfig()->getType()->getName());
+        $this->assertEquals($type, $form->getConfig()->getType()->getBlockPrefix());
     }
 
     /**


### PR DESCRIPTION
`FormTypeInterface::getBlockPrefix` was added in symfony/symfony 3.0, see https://github.com/symfony/symfony/blob/3.0/UPGRADE-3.0.md#form and we dropped support for 3.4 some time ago.

I've added another commit adding return types.