### PR TITLE
add attribute driver support

### DIFF
--- a/DependencyInjection/Compiler/DoctrineMongoDBMappingsPass.php
+++ b/DependencyInjection/Compiler/DoctrineMongoDBMappingsPass.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\Bundle\MongoDBBundle\DependencyInjection\Compiler;
 
 use Doctrine\ODM\MongoDB\Mapping\Driver\AnnotationDriver;
+use Doctrine\ODM\MongoDB\Mapping\Driver\AttributeDriver;
 use Doctrine\ODM\MongoDB\Mapping\Driver\XmlDriver;
 use Doctrine\Persistence\Mapping\Driver\PHPDriver;
 use Doctrine\Persistence\Mapping\Driver\StaticPHPDriver;
@@ -108,6 +109,27 @@ class DoctrineMongoDBMappingsPass extends RegisterMappingsPass
     public static function createAnnotationMappingDriver(array $namespaces, array $directories, array $managerParameters, $enabledParameter = false, array $aliasMap = [])
     {
         $driver = new Definition(AnnotationDriver::class, [new Reference('annotation_reader'), $directories]);
+
+        return new DoctrineMongoDBMappingsPass($driver, $namespaces, $managerParameters, $enabledParameter, $aliasMap);
+    }
+
+    /**
+     * @param array        $namespaces        List of namespaces that are handled with attribute mapping
+     * @param array        $directories       List of directories to look for attribute mapping files
+     * @param string[]     $managerParameters List of parameters that could which object manager name
+     *                                        your bundle uses. This compiler pass will automatically
+     *                                        append the parameter name for the default entity manager
+     *                                        to this list.
+     * @param string|false $enabledParameter  Service container parameter that must be present to
+     *                                        enable the mapping. Set to false to not do any check,
+     *                                        optional.
+     * @param string[]     $aliasMap          Map of alias to namespace.
+     *
+     * @return DoctrineMongoDBMappingsPass
+     */
+    public static function createAttributeMappingDriver(array $namespaces, array $directories, array $managerParameters, $enabledParameter = false, array $aliasMap = [])
+    {
+        $driver = new Definition(AttributeDriver::class, [$directories, new Reference('doctrine_mongodb.odm.metadata.attribute_reader')]);
 
         return new DoctrineMongoDBMappingsPass($driver, $namespaces, $managerParameters, $enabledParameter, $aliasMap);
     }

--- a/Resources/config/mongodb.xml
+++ b/Resources/config/mongodb.xml
@@ -32,6 +32,8 @@
         <!-- metadata -->
         <parameter key="doctrine_mongodb.odm.metadata.driver_chain.class">Doctrine\Persistence\Mapping\Driver\MappingDriverChain</parameter>
         <parameter key="doctrine_mongodb.odm.metadata.annotation.class">Doctrine\ODM\MongoDB\Mapping\Driver\AnnotationDriver</parameter>
+        <parameter key="doctrine_mongodb.odm.metadata.attribute.class">Doctrine\ODM\MongoDB\Mapping\Driver\AttributeDriver</parameter>
+        <parameter key="doctrine_mongodb.odm.metadata.attribute_reader.class">Doctrine\ODM\MongoDB\Mapping\Driver\AttributeReader</parameter>
         <parameter key="doctrine_mongodb.odm.metadata.xml.class">Doctrine\Bundle\MongoDBBundle\Mapping\Driver\XmlDriver</parameter>
 
         <!-- directories -->
@@ -115,6 +117,11 @@
             <argument>%doctrine_mongodb.odm.document_dirs%</argument>
         </service>
         <service id="doctrine_mongodb.odm.metadata.annotation_reader" alias="annotation_reader" />
+        <service id="doctrine_mongodb.odm.metadata.attribute" class="%doctrine_mongodb.odm.metadata.attribute.class%">
+            <argument>%doctrine_mongodb.odm.document_dirs%</argument>
+            <argument type="service" id="doctrine_mongodb.odm.metadata.attribute_reader" />
+        </service>
+        <service id="doctrine_mongodb.odm.metadata.attribute_reader" class="%doctrine_mongodb.odm.metadata.attribute_reader.class%" />
         <service id="doctrine_mongodb.odm.metadata.xml" class="%doctrine_mongodb.odm.metadata.xml.class%">
             <argument>%doctrine_mongodb.odm.xml_mapping_dirs%</argument>
         </service>

--- a/Resources/doc/.doctor-rst.yaml
+++ b/Resources/doc/.doctor-rst.yaml
@@ -34,13 +34,13 @@ rules:
     no_app_bundle: ~
 
     versionadded_directive_major_version:
-        major_version: 3
+        major_version: 4
 
     versionadded_directive_min_version:
-        min_version: '3.0'
+        min_version: '4.0'
 
     deprecated_directive_major_version:
-        major_version: 3
+        major_version: 4
 
     deprecated_directive_min_version:
-        min_version: '3.0'
+        min_version: '4.0'

--- a/Resources/doc/config.rst
+++ b/Resources/doc/config.rst
@@ -126,7 +126,7 @@ Explicit definition of all the mapped documents is the only necessary
 configuration for the ODM and there are several configuration options that you
 can control. The following configuration options exist for a mapping:
 
-- ``type`` One of ``annotation``, ``xml``, ``yml``, ``php`` or ``staticphp``.
+- ``type`` One of ``annotation``, ``attribute``, ``xml``, ``php`` or ``staticphp``.
   This specifies which type of metadata type your mapping uses.
 
 - ``dir`` Path to the mapping or document files (depending on the driver). If
@@ -176,7 +176,7 @@ The following configuration shows a bunch of mapping examples:
                     mappings:
                         MyBundle1: ~
                         MyBundle2: xml
-                        MyBundle3: { type: annotation, dir: Documents/ }
+                        MyBundle3: { type: attribute, dir: Documents/ }
                         MyBundle4: { type: xml, dir: Resources/config/doctrine/mapping }
                         MyBundle5:
                             type: xml
@@ -202,7 +202,7 @@ The following configuration shows a bunch of mapping examples:
                 <doctrine_mongodb:document-manager id="default">
                     <doctrine_mongodb:mapping name="MyBundle1" />
                     <doctrine_mongodb:mapping name="MyBundle2" type="yml" />
-                    <doctrine_mongodb:mapping name="MyBundle3" type="annotation" dir="Documents/" />
+                    <doctrine_mongodb:mapping name="MyBundle3" type="attribute" dir="Documents/" />
                     <doctrine_mongodb:mapping name="MyNundle4" type="xml" dir="Resources/config/doctrine/mapping" />
                     <doctrine_mongodb:mapping name="MyBundle5" type="xml" dir="my-bundle-mappings-dir" alias="BundleAlias" />
                     <doctrine_mongodb:mapping name="doctrine_extensions"

--- a/Resources/doc/config.rst
+++ b/Resources/doc/config.rst
@@ -177,8 +177,9 @@ The following configuration shows a bunch of mapping examples:
                         MyBundle1: ~
                         MyBundle2: xml
                         MyBundle3: { type: attribute, dir: Documents/ }
-                        MyBundle4: { type: xml, dir: Resources/config/doctrine/mapping }
-                        MyBundle5:
+                        MyBundle4: { type: annotation, dir: Documents/Legacy/ }
+                        MyBundle5: { type: xml, dir: Resources/config/doctrine/mapping }
+                        MyBundle6:
                             type: xml
                             dir: my-bundle-mappings-dir
                             alias: BundleAlias
@@ -203,8 +204,9 @@ The following configuration shows a bunch of mapping examples:
                     <doctrine_mongodb:mapping name="MyBundle1" />
                     <doctrine_mongodb:mapping name="MyBundle2" type="yml" />
                     <doctrine_mongodb:mapping name="MyBundle3" type="attribute" dir="Documents/" />
-                    <doctrine_mongodb:mapping name="MyNundle4" type="xml" dir="Resources/config/doctrine/mapping" />
-                    <doctrine_mongodb:mapping name="MyBundle5" type="xml" dir="my-bundle-mappings-dir" alias="BundleAlias" />
+                    <doctrine_mongodb:mapping name="MyBundle4" type="annotation" dir="Documents/Legacy/" />
+                    <doctrine_mongodb:mapping name="MyBundle5" type="xml" dir="Resources/config/doctrine/mapping" />
+                    <doctrine_mongodb:mapping name="MyBundle6" type="xml" dir="my-bundle-mappings-dir" alias="BundleAlias" />
                     <doctrine_mongodb:mapping name="doctrine_extensions"
                                               type="xml"
                                               dir="%kernel.project_dir%/src/vendor/DoctrineExtensions/lib/DoctrineExtensions/Documents"

--- a/Resources/doc/cookbook/registration_form.rst
+++ b/Resources/doc/cookbook/registration_form.rst
@@ -11,65 +11,122 @@ The User Model
 
 We begin this tutorial with the model for a ``User`` document:
 
-.. code-block:: php
+.. configuration-block::
 
-    // src/Document/User.php
-    namespace App\Document;
+    .. code-block:: php-annotations
 
-    use Doctrine\Bundle\MongoDBBundle\Validator\Constraints\Unique as MongoDBUnique;
-    use Doctrine\ODM\MongoDB\Mapping\Annotations as MongoDB;
-    use Symfony\Component\Validator\Constraints as Assert;
+        // src/Document/User.php
+        namespace App\Document;
 
-    /**
-     * @MongoDB\Document(collection="users")
-     * @MongoDBUnique(fields="email")
-     */
-    class User
-    {
-        /**
-         * @MongoDB\Id
-         */
-        protected $id;
+        use Doctrine\Bundle\MongoDBBundle\Validator\Constraints\Unique as MongoDBUnique;
+        use Doctrine\ODM\MongoDB\Mapping\Annotations as MongoDB;
+        use Symfony\Component\Validator\Constraints as Assert;
 
         /**
-         * @MongoDB\Field(type="string")
-         * @Assert\NotBlank()
-         * @Assert\Email()
+         * @MongoDB\Document(collection="users")
+         * @MongoDB\Unique(fields="email")
          */
-        protected $email;
-
-        /**
-         * @MongoDB\Field(type="string")
-         * @Assert\NotBlank()
-         */
-        protected $password;
-
-        public function getId()
+        class User
         {
-            return $this->id;
+            /**
+             * @MongoDB\Id
+             */
+            protected $id;
+
+            /**
+             * @MongoDB\Field(type="string")
+             * @Assert\NotBlank()
+             * @Assert\Email()
+             */
+            protected $email;
+
+            /**
+             * @MongoDB\Field(type="string")
+             * @Assert\NotBlank()
+             */
+            protected $password;
+
+            public function getId()
+            {
+                return $this->id;
+            }
+
+            public function getEmail()
+            {
+                return $this->email;
+            }
+
+            public function setEmail($email)
+            {
+                $this->email = $email;
+            }
+
+            public function getPassword()
+            {
+                return $this->password;
+            }
+
+            // stupid simple encryption (please don't copy it!)
+            public function setPassword($password)
+            {
+                $this->password = sha1($password);
+            }
         }
 
-        public function getEmail()
-        {
-            return $this->email;
-        }
+    .. code-block:: php-attributes
 
-        public function setEmail($email)
-        {
-            $this->email = $email;
-        }
+        // src/Document/User.php
+        namespace App\Document;
 
-        public function getPassword()
-        {
-            return $this->password;
-        }
+        use Doctrine\Bundle\MongoDBBundle\Validator\Constraints\Unique as MongoDBUnique;
+        use Doctrine\ODM\MongoDB\Mapping\Annotations as MongoDB;
+        use Symfony\Component\Validator\Constraints as Assert;
 
-        // stupid simple encryption (please don't copy it!)
-        public function setPassword($password)
+        #[MongoDB\Document(collection: 'users')]
+        #[MongoDB\Unique(fields: 'email')]
+        class User
         {
-            $this->password = sha1($password);
+            /**
+             * @MongoDB\Id
+             */
+            #[MongoDB\Id]
+            protected string $id;
+
+            #[MongoDB\Field(type: 'string')]
+            #[Assert\NotBlank]
+            #[Assert\Email]
+            protected ?string $email = null;
+
+            #[MongoDB\Field(type: 'string')]
+            #[Assert\NotBlank]
+            protected ?string $password = null;
+
+            public function getId(): string
+            {
+                return $this->id;
+            }
+
+            public function getEmail(): ?string
+            {
+                return $this->email;
+            }
+
+            public function setEmail(?string $email): void
+            {
+                $this->email = $email;
+            }
+
+            public function getPassword(): ?string
+            {
+                return $this->password;
+            }
+
+            // stupid simple encryption (please don't copy it!)
+            public function setPassword(?string $password): void
+            {
+                $this->password = sha1($password);
+            }
         }
-    }
 
 This ``User`` document contains three fields and two of them (email and
 password) should be displayed in the form. The email property must be unique

--- a/Resources/doc/first_steps.rst
+++ b/Resources/doc/first_steps.rst
@@ -46,7 +46,11 @@ For Doctrine to be able to do this, you have to create "metadata", or
 configuration that tells Doctrine exactly how the ``Product`` class and its
 properties should be *mapped* to MongoDB. This metadata can be specified
 in a number of different formats including XML or directly inside the
-``Product`` class via annotations:
+``Product`` class via annotations or PHP 8 attributes:
+
+.. versionadded:: 4.4
+
+    The attribute mapping support was added in Doctrine MongoDB ODM Bundle 4.4 and requires PHP 8.0 or newer.
 
 .. configuration-block::
 
@@ -65,7 +69,7 @@ in a number of different formats including XML or directly inside the
             </document>
         </doctrine-mongo-mapping>
 
-    .. code-block:: php
+    .. code-block:: php-annotations
 
         // src/Document/Product.php
         namespace App\Document;
@@ -91,6 +95,26 @@ in a number of different formats including XML or directly inside the
              * @MongoDB\Field(type="float")
              */
             protected $price;
+        }
+
+    .. code-block:: php-attributes
+
+        // src/Document/Product.php
+        namespace App\Document;
+
+        use Doctrine\ODM\MongoDB\Mapping\Annotations as MongoDB;
+
+        #[MongoDB\Document]
+        class Product
+        {
+            #[MongoDB\Id]
+            protected string $id;
+
+            #[MongoDB\Field(type: 'string')]
+            protected string $name;
+
+            #[MongoDB\Field(type: 'float')]
+            protected float $price;
         }
 
 .. seealso::
@@ -330,6 +354,20 @@ To do this, add the name of the repository class to your mapping definition.
         /**
          * @MongoDB\Document(repositoryClass=ProductRepository::class)
          */
+        class Product
+        {
+            // ...
+        }
+
+    .. code-block:: php-attributes
+
+        // src/Document/Product.php
+        namespace App\Document;
+
+        use App\Repository\ProductRepository;
+        use Doctrine\ODM\MongoDB\Mapping\Annotations as MongoDB;
+
+        #[MongoDB\Document(repositoryClass: ProductRepository::class)]
         class Product
         {
             // ...

--- a/Resources/doc/first_steps.rst
+++ b/Resources/doc/first_steps.rst
@@ -54,21 +54,6 @@ in a number of different formats including XML or directly inside the
 
 .. configuration-block::
 
-    .. code-block:: xml
-
-        <!-- src/Resources/config/doctrine/Product.mongodb.xml -->
-        <doctrine-mongo-mapping xmlns="http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping"
-              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-              xsi:schemaLocation="http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping
-                            https://doctrine-project.org/schemas/odm/doctrine-mongo-mapping.xsd">
-
-            <document name="App\Document\Product">
-                <id />
-                <field field-name="name" type="string" />
-                <field field-name="price" type="float" />
-            </document>
-        </doctrine-mongo-mapping>
-
     .. code-block:: php-annotations
 
         // src/Document/Product.php
@@ -116,6 +101,21 @@ in a number of different formats including XML or directly inside the
             #[MongoDB\Field(type: 'float')]
             protected float $price;
         }
+
+    .. code-block:: xml
+
+        <!-- src/Resources/config/doctrine/Product.mongodb.xml -->
+        <doctrine-mongo-mapping xmlns="http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping"
+              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:schemaLocation="http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping
+                            https://doctrine-project.org/schemas/odm/doctrine-mongo-mapping.xsd">
+
+            <document name="App\Document\Product">
+                <id />
+                <field field-name="name" type="string" />
+                <field field-name="price" type="float" />
+            </document>
+        </doctrine-mongo-mapping>
 
 .. seealso::
 

--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -166,6 +166,10 @@ class ConfigurationTest extends TestCase
                             'type'    => 'annotation',
                             'mapping' => true,
                         ],
+                        'BarBundle' => [
+                            'type'    => 'attribute',
+                            'mapping' => true,
+                        ],
                     ],
                     'profiler' => [
                         'enabled' => true,

--- a/Tests/DependencyInjection/Fixtures/Bundles/AttributesBundle/AttributesBundle.php
+++ b/Tests/DependencyInjection/Fixtures/Bundles/AttributesBundle/AttributesBundle.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMongoDBBundle\Tests\DependencyInjection\Fixtures\Bundles\AttributesBundle;
+
+use Symfony\Component\HttpKernel\Bundle\Bundle;
+
+class AttributesBundle extends Bundle
+{
+}

--- a/Tests/DependencyInjection/Fixtures/Bundles/AttributesBundle/Document/Test.php
+++ b/Tests/DependencyInjection/Fixtures/Bundles/AttributesBundle/Document/Test.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMongoDBBundle\Tests\DependencyInjection\Fixtures\Bundles\AttributesBundle\Document;
+
+class Test
+{
+}

--- a/Tests/DependencyInjection/Fixtures/config/xml/full.xml
+++ b/Tests/DependencyInjection/Fixtures/config/xml/full.xml
@@ -80,6 +80,7 @@
             repository-factory="doctrine_mongodb.odm.container_repository_factory"
         >
             <doctrine:mapping name="FooBundle" type="annotation" />
+            <doctrine:mapping name="BarBundle" type="attribute" />
             <doctrine:metadata-cache-driver type="memcached">
                 <doctrine:class>fooClass</doctrine:class>
                 <doctrine:host>host_val</doctrine:host>

--- a/Tests/DependencyInjection/Fixtures/config/yml/full.yml
+++ b/Tests/DependencyInjection/Fixtures/config/yml/full.yml
@@ -68,6 +68,7 @@ doctrine_mongodb:
             persistent_collection_factory: ~
             mappings:
                 FooBundle:   annotation
+                BarBundle:   attribute
             metadata_cache_driver:
                 type:                  memcached
                 class:                 fooClass

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "keywords": ["persistence", "mongodb", "symfony"],
     "homepage": "http://www.doctrine-project.org",
     "license": "MIT",
-    "minimum-stability": "dev",
+    "minimum-stability": "stable",
     "authors": [
         {"name": "Bulat Shakirzyanov", "email": "mallluhuct@gmail.com"},
         {"name": "Kris Wallsmith", "email": "kris@symfony.com"},


### PR DESCRIPTION
This PR adds support for upcoming attribute mapping driver introduced in https://github.com/doctrine/mongodb-odm/pull/2344.