### PR TITLE
Deprecate some unused `DoctrineODMCommand` methods

### DIFF
--- a/Command/DoctrineODMCommand.php
+++ b/Command/DoctrineODMCommand.php
@@ -8,11 +8,10 @@ use Doctrine\Bundle\MongoDBBundle\ManagerRegistry;
 use Doctrine\ODM\MongoDB\Tools\Console\Helper\DocumentManagerHelper;
 use Doctrine\Persistence\ObjectManager;
 use InvalidArgumentException;
+use LogicException;
 use RuntimeException;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\Console\Command\Command;
-use Symfony\Component\DependencyInjection\ContainerAwareInterface;
-use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
@@ -20,31 +19,72 @@ use function assert;
 use function sprintf;
 use function str_replace;
 use function strtolower;
+use function trigger_deprecation;
 
 use const DIRECTORY_SEPARATOR;
 
 /**
  * Base class for Doctrine ODM console commands to extend.
+ *
+ * @internal since version 5.0
  */
-abstract class DoctrineODMCommand extends Command implements ContainerAwareInterface
+abstract class DoctrineODMCommand extends Command
 {
-    use ContainerAwareTrait;
+    /** @var ContainerInterface|null */
+    protected $container;
 
     /** @var ManagerRegistry|null */
     private $managerRegistry;
 
     public function __construct(?ManagerRegistry $registry = null)
     {
-        parent::__construct(null);
+        parent::__construct();
 
         $this->managerRegistry = $registry;
     }
 
     /**
+     * @deprecated since version 4.4
+     */
+    public function setContainer(?ContainerInterface $container = null)
+    {
+        trigger_deprecation(
+            'doctrine/mongodb-odm-bundle',
+            '4.4',
+            'The "%s" method is deprecated and will be dropped in DoctrineMongoDBBundle 5.0.',
+            __METHOD__
+        );
+
+        $this->container = $container;
+    }
+
+    /**
+     * @deprecated since version 4.4
+     *
      * @return ContainerInterface
+     *
+     * @throws LogicException
      */
     protected function getContainer()
     {
+        trigger_deprecation(
+            'doctrine/mongodb-odm-bundle',
+            '4.4',
+            'The "%s" method is deprecated and will be dropped in DoctrineMongoDBBundle 5.0.',
+            __METHOD__
+        );
+
+        if ($this->container === null) {
+            $application = $this->getApplication();
+            if ($application === null) {
+                throw new LogicException('The container cannot be retrieved as the application instance is not yet set.');
+            }
+
+            assert($application instanceof Application);
+
+            $this->container = $application->getKernel()->getContainer();
+        }
+
         return $this->container;
     }
 
@@ -59,10 +99,19 @@ abstract class DoctrineODMCommand extends Command implements ContainerAwareInter
     }
 
     /**
+     * @deprecated since version 4.4
+     *
      * @return ObjectManager[]
      */
     protected function getDoctrineDocumentManagers()
     {
+        trigger_deprecation(
+            'doctrine/mongodb-odm-bundle',
+            '4.4',
+            'The "%s" method is deprecated and will be dropped in DoctrineMongoDBBundle 5.0.',
+            __METHOD__
+        );
+
         return $this->getManagerRegistry()->getManagers();
     }
 
@@ -82,12 +131,21 @@ abstract class DoctrineODMCommand extends Command implements ContainerAwareInter
     }
 
     /**
+     * @deprecated since version 4.4
+     *
      * @param string $bundleName
      *
      * @return Bundle
      */
     protected function findBundle($bundleName)
     {
+        trigger_deprecation(
+            'doctrine/mongodb-odm-bundle',
+            '4.4',
+            'The "%s" method is deprecated and will be dropped in DoctrineMongoDBBundle 5.0.',
+            __METHOD__
+        );
+
         $foundBundle = false;
 
         $application = $this->getApplication();
@@ -113,12 +171,21 @@ abstract class DoctrineODMCommand extends Command implements ContainerAwareInter
     /**
      * Transform classname to a path $foundBundle substract it to get the destination
      *
+     * @deprecated since version 4.4
+     *
      * @param Bundle $bundle
      *
      * @return string
      */
     protected function findBasePathForBundle($bundle)
     {
+        trigger_deprecation(
+            'doctrine/mongodb-odm-bundle',
+            '4.4',
+            'The "%s" method is deprecated and will be dropped in DoctrineMongoDBBundle 5.0.',
+            __METHOD__
+        );
+
         $path        = str_replace('\\', DIRECTORY_SEPARATOR, $bundle->getNamespace());
         $search      = str_replace('\\', DIRECTORY_SEPARATOR, $bundle->getPath());
         $destination = str_replace(DIRECTORY_SEPARATOR . $path, '', $search, $c);

--- a/Command/InfoDoctrineODMCommand.php
+++ b/Command/InfoDoctrineODMCommand.php
@@ -32,11 +32,11 @@ class InfoDoctrineODMCommand extends DoctrineODMCommand
 The <info>doctrine:mongodb:mapping:info</info> shows basic information about which
 documents exist and possibly if their mapping information contains errors or not.
 
-  <info>./app/console doctrine:mongodb:mapping:info</info>
+  <info>./bin/console doctrine:mongodb:mapping:info</info>
 
 If you are using multiple document managers you can pick your choice with the <info>--dm</info> option:
 
-  <info>./app/console doctrine:mongodb:mapping:info --dm=default</info>
+  <info>./bin/console doctrine:mongodb:mapping:info --dm=default</info>
 EOT
         );
     }

--- a/Tests/Command/CommandTestKernel.php
+++ b/Tests/Command/CommandTestKernel.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Bundle\MongoDBBundle\Tests\Command;
+
+use Doctrine\Bundle\MongoDBBundle\DependencyInjection\Compiler\FixturesCompilerPass;
+use Doctrine\Bundle\MongoDBBundle\DoctrineMongoDBBundle;
+use Doctrine\Bundle\MongoDBBundle\Tests\Fixtures\CommandBundle\CommandBundle;
+use Doctrine\Bundle\MongoDBBundle\Tests\Fixtures\CommandBundle\DataFixtures\OtherFixtures;
+use Doctrine\Bundle\MongoDBBundle\Tests\Fixtures\CommandBundle\DataFixtures\UserFixtures;
+use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
+use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
+use Symfony\Component\Config\Loader\LoaderInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\HttpKernel\Kernel;
+use Symfony\Component\Routing\Loader\Configurator\RouteConfigurator;
+use Symfony\Component\Routing\RouteCollectionBuilder;
+
+use function sys_get_temp_dir;
+
+final class CommandTestKernel extends Kernel
+{
+    use MicroKernelTrait;
+
+    public function registerBundles(): array
+    {
+        return [
+            new FrameworkBundle(),
+            new DoctrineMongoDBBundle(),
+            new CommandBundle(),
+        ];
+    }
+
+    /**
+     * @param RouteConfigurator|RouteCollectionBuilder $routes
+     */
+    public function configureRoutes($routes): void
+    {
+    }
+
+    protected function configureContainer(ContainerBuilder $container, LoaderInterface $loader): void
+    {
+        $container->loadFromExtension('framework', [
+            'secret' => 'foo',
+            'router' => ['utf8' => false],
+        ]);
+
+        $container->loadFromExtension('doctrine_mongodb', [
+            'connections' => ['default' => []],
+            'document_managers' => [
+                'command_test' => [
+                    'connection' => 'default',
+                    'mappings' => ['CommandBundle' => null],
+                ],
+                'command_test_without_documents' => ['connection' => 'default'],
+            ],
+        ]);
+
+        $container
+            ->autowire(UserFixtures::class)
+            ->addTag(FixturesCompilerPass::FIXTURE_TAG, ['group' => 'test_group']);
+
+        $container
+            ->autowire(OtherFixtures::class)
+            ->addTag(FixturesCompilerPass::FIXTURE_TAG);
+    }
+
+    public function getCacheDir(): string
+    {
+        return sys_get_temp_dir() . '/doctrine_mongodb_odm_bundle';
+    }
+
+    public function getLogDir(): string
+    {
+        return sys_get_temp_dir();
+    }
+}

--- a/Tests/Command/InfoDoctrineODMCommandTest.php
+++ b/Tests/Command/InfoDoctrineODMCommandTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Bundle\MongoDBBundle\Tests\Command;
+
+use Doctrine\Bundle\MongoDBBundle\Tests\Fixtures\CommandBundle\Document\User;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+use Throwable;
+
+final class InfoDoctrineODMCommandTest extends KernelTestCase
+{
+    public function testExecute(): void
+    {
+        $kernel      = new CommandTestKernel('test', false);
+        $application = new Application($kernel);
+
+        $command       = $application->find('doctrine:mongodb:mapping:info');
+        $commandTester = new CommandTester($command);
+        $commandTester->execute(['--dm' => 'command_test']);
+
+        $output = $commandTester->getDisplay();
+        $this->assertStringContainsString('Found 1 documents mapped in document manager command_test', $output);
+        $this->assertStringContainsString(User::class, $output);
+    }
+
+    public function testExecuteWithDocumentManagerWithoutDocuments(): void
+    {
+        $kernel      = new CommandTestKernel('test', false);
+        $application = new Application($kernel);
+
+        $command       = $application->find('doctrine:mongodb:mapping:info');
+        $commandTester = new CommandTester($command);
+
+        $this->expectException(Throwable::class);
+        $this->expectExceptionMessage('You do not have any mapped Doctrine MongoDB ODM documents for any of your bundles. Create a class inside the Document namespace of any of your bundles and provide mapping information for it with Annotations directly in the classes doc blocks or with XML in your bundles Resources/config/doctrine/metadata/mongodb directory');
+
+        $commandTester->execute(['--dm' => 'command_test_without_documents']);
+    }
+}

--- a/Tests/Command/LoadDataFixturesDoctrineODMCommandTest.php
+++ b/Tests/Command/LoadDataFixturesDoctrineODMCommandTest.php
@@ -5,27 +5,63 @@ declare(strict_types=1);
 namespace Doctrine\Bundle\MongoDBBundle\Tests\Command;
 
 use Doctrine\Bundle\MongoDBBundle\Command\LoadDataFixturesDoctrineODMCommand;
-use Doctrine\Bundle\MongoDBBundle\Loader\SymfonyFixturesLoaderInterface;
-use Doctrine\Bundle\MongoDBBundle\ManagerRegistry;
-use PHPUnit\Framework\TestCase;
-use Symfony\Component\HttpKernel\KernelInterface;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Console\Tester\CommandTester;
 
-class LoadDataFixturesDoctrineODMCommandTest extends TestCase
+class LoadDataFixturesDoctrineODMCommandTest extends KernelTestCase
 {
     /** @var LoadDataFixturesDoctrineODMCommand */
     private $command;
 
     protected function setUp(): void
     {
-        $registry = $this->createMock(ManagerRegistry::class);
-        $kernel   = $this->createMock(KernelInterface::class);
-        $loader   = $this->createMock(SymfonyFixturesLoaderInterface::class);
+        $kernel      = new CommandTestKernel('test', false);
+        $application = new Application($kernel);
 
-        $this->command = new LoadDataFixturesDoctrineODMCommand($registry, $kernel, $loader);
+        $this->command = $application->find('doctrine:mongodb:fixtures:load');
     }
 
-    public function testCommandIsEnabledWithDependency(): void
+    public function testIsInteractiveByDefault(): void
     {
-        $this->assertTrue($this->command->isEnabled());
+        $commandTester = new CommandTester($this->command);
+        $commandTester->execute([]);
+
+        $output = $commandTester->getDisplay();
+        $this->assertStringContainsString('Careful, database will be purged. Do you want to continue (y/N) ?', $output);
+    }
+
+    public function testGroup(): void
+    {
+        $commandTester = new CommandTester($this->command);
+        $commandTester->execute([
+            '--group' => ['test_group'],
+        ], ['interactive' => false]);
+
+        $output = $commandTester->getDisplay();
+        $this->assertStringContainsString('loading Doctrine\Bundle\MongoDBBundle\Tests\Fixtures\CommandBundle\DataFixtures\UserFixtures', $output);
+        $this->assertStringNotContainsString('loading Doctrine\Bundle\MongoDBBundle\Tests\Fixtures\CommandBundle\DataFixtures\OtherFixtures', $output);
+    }
+
+    public function testNonExistingGroup(): void
+    {
+        $commandTester = new CommandTester($this->command);
+        $commandTester->execute([
+            '--group' => ['non_existing_group'],
+        ], ['interactive' => false]);
+
+        $output = $commandTester->getDisplay();
+        $this->assertStringContainsString('Could not find any fixture services to load in the groups', $output);
+        $this->assertStringContainsString('(non_existing_group)', $output);
+    }
+
+    public function testExecute(): void
+    {
+        $commandTester = new CommandTester($this->command);
+        $commandTester->execute([], ['interactive' => false]);
+
+        $output = $commandTester->getDisplay();
+        $this->assertStringContainsString('loading Doctrine\Bundle\MongoDBBundle\Tests\Fixtures\CommandBundle\DataFixtures\UserFixtures', $output);
+        $this->assertStringContainsString('loading Doctrine\Bundle\MongoDBBundle\Tests\Fixtures\CommandBundle\DataFixtures\OtherFixtures', $output);
     }
 }

--- a/Tests/Fixtures/CommandBundle/CommandBundle.php
+++ b/Tests/Fixtures/CommandBundle/CommandBundle.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Bundle\MongoDBBundle\Tests\Fixtures\CommandBundle;
+
+use Symfony\Component\HttpKernel\Bundle\Bundle;
+
+class CommandBundle extends Bundle
+{
+}

--- a/Tests/Fixtures/CommandBundle/DataFixtures/OtherFixtures.php
+++ b/Tests/Fixtures/CommandBundle/DataFixtures/OtherFixtures.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Bundle\MongoDBBundle\Tests\Fixtures\CommandBundle\DataFixtures;
+
+use Doctrine\Bundle\MongoDBBundle\Fixture\ODMFixtureInterface;
+use Doctrine\Persistence\ObjectManager;
+
+final class OtherFixtures implements ODMFixtureInterface
+{
+    public function load(ObjectManager $manager): void
+    {
+    }
+}

--- a/Tests/Fixtures/CommandBundle/DataFixtures/UserFixtures.php
+++ b/Tests/Fixtures/CommandBundle/DataFixtures/UserFixtures.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Bundle\MongoDBBundle\Tests\Fixtures\CommandBundle\DataFixtures;
+
+use Doctrine\Bundle\MongoDBBundle\Fixture\FixtureGroupInterface;
+use Doctrine\Bundle\MongoDBBundle\Fixture\ODMFixtureInterface;
+use Doctrine\Persistence\ObjectManager;
+
+final class UserFixtures implements ODMFixtureInterface, FixtureGroupInterface
+{
+    public function load(ObjectManager $manager): void
+    {
+    }
+
+    public static function getGroups(): array
+    {
+        return ['test_group'];
+    }
+}

--- a/Tests/Fixtures/CommandBundle/Document/User.php
+++ b/Tests/Fixtures/CommandBundle/Document/User.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Bundle\MongoDBBundle\Tests\Fixtures\CommandBundle\Document;
+
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+
+/**
+ * @ODM\Document
+ */
+class User
+{
+    /**
+     * @ODM\Id
+     *
+     * @var string|null
+     */
+    private $id;
+}

--- a/UPGRADE-4.4.md
+++ b/UPGRADE-4.4.md
@@ -5,3 +5,9 @@ UPGRADE FROM 4.x to 4.4
   `Doctrine\Bundle\MongoDBBundle\Cursor\TailableCursorProcessorInterface`
   interface have been deprecated. You should use
   [change streams](https://docs.mongodb.com/manual/changeStreams/) instead.
+* The `setContainer`, `getContainer`, `getDoctrineDocumentManagers`,
+  `findBundle` and `findBasePathForBundle` methods from
+  `Doctrine\Bundle\MongoDBBundle\Command\DoctrineODMCommand` have been
+  deprecated without replacement.
+* The `Doctrine\Bundle\MongoDBBundle\Command\DoctrineODMCommand` class has
+  been marked as `@internal`, you should not extend from this class.

--- a/UPGRADE-5.0.md
+++ b/UPGRADE-5.0.md
@@ -5,3 +5,9 @@ UPGRADE FROM 4.x to 5.0
   `Doctrine\Bundle\MongoDBBundle\Cursor\TailableCursorProcessorInterface`
   interface have been dropped. You should use
   [change streams](https://docs.mongodb.com/manual/changeStreams/) instead.
+* The `setContainer`, `getContainer`, `getDoctrineDocumentManagers`,
+  `findBundle` and `findBasePathForBundle` methods from
+  `Doctrine\Bundle\MongoDBBundle\Command\DoctrineODMCommand` have been
+  removed without replacement.
+* The `Doctrine\Bundle\MongoDBBundle\Command\DoctrineODMCommand` class is now
+  `@internal`, you should not extend from this class.

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "doctrine/mongodb-odm": "^2.0.0",
         "doctrine/persistence": "^1.3.6|^2.0",
         "psr/log": "^1.0",
-        "symfony/console": "^4.3.3|^5.0",
+        "symfony/console": "^4.4.6|^5.0",
         "symfony/dependency-injection": "^4.3.3|^5.0",
         "symfony/deprecation-contracts": "^2.1",
         "symfony/doctrine-bridge": "^4.3.3|^5.0",


### PR DESCRIPTION
This PR adds some functional tests to commands that are not proxied from `doctrine/mongodb-odm`.

It also removes implementing `ContainerAwareInterface` from `DoctrineODMCommand` and deprecates some methods that are not used anymore.