### PR TITLE
Enforce typehints in tests

### DIFF
--- a/Tests/CacheWarmer/PersistentCollectionCacheWarmerTest.php
+++ b/Tests/CacheWarmer/PersistentCollectionCacheWarmerTest.php
@@ -9,6 +9,7 @@ use Doctrine\Bundle\MongoDBBundle\Tests\TestCase;
 use Doctrine\ODM\MongoDB\Configuration;
 use Doctrine\ODM\MongoDB\PersistentCollection\PersistentCollectionGenerator;
 use Doctrine\Persistence\ManagerRegistry;
+use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
@@ -19,6 +20,7 @@ class PersistentCollectionCacheWarmerTest extends TestCase
     /** @var ContainerInterface */
     private $container;
 
+    /** @var PersistentCollectionGenerator&MockObject  */
     private $generatorMock;
 
     /** @var PersistentCollectionCacheWarmer */

--- a/Tests/Fixtures/Cache/Collections.php
+++ b/Tests/Fixtures/Cache/Collections.php
@@ -6,20 +6,37 @@ namespace Doctrine\Bundle\MongoDBBundle\Tests\Fixtures\Cache;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use MongoDB\BSON\ObjectId;
 
 /** @ODM\Document */
 class Collections
 {
-    /** @ODM\Id */
+    /**
+     * @ODM\Id
+     *
+     * @var ObjectId|null
+     */
     public $id;
 
-    /** @ODM\EmbedMany(collectionClass=SomeCollection::class) */
+    /**
+     * @ODM\EmbedMany(collectionClass=SomeCollection::class)
+     *
+     * @var SomeCollection
+     */
     public $coll;
 
-    /** @ODM\ReferenceMany(collectionClass=SomeCollection::class) */
+    /**
+     * @ODM\ReferenceMany(collectionClass=SomeCollection::class)
+     *
+     * @var SomeCollection
+     */
     public $refs;
 
-    /** @ODM\EmbedMany(collectionClass=AnotherCollection::class) */
+    /**
+     * @ODM\EmbedMany(collectionClass=AnotherCollection::class)
+     *
+     * @var AnotherCollection
+     */
     public $another;
 }
 

--- a/Tests/Fixtures/DataCollector/Category.php
+++ b/Tests/Fixtures/DataCollector/Category.php
@@ -5,14 +5,23 @@ declare(strict_types=1);
 namespace Doctrine\Bundle\MongoDBBundle\Tests\Fixtures\DataCollector;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use MongoDB\BSON\ObjectId;
 
 /** @ODM\Document */
 class Category
 {
-    /** @ODM\Id */
+    /**
+     * @ODM\Id
+     *
+     * @var ObjectId|null
+     */
     protected $id;
 
-    /** @ODM\Field(type="string") */
+    /**
+     * @ODM\Field(type="string")
+     *
+     * @var string
+     */
     public $name;
 
     public function __construct(string $name)

--- a/Tests/Fixtures/Form/Category.php
+++ b/Tests/Fixtures/Form/Category.php
@@ -5,15 +5,25 @@ declare(strict_types=1);
 namespace Doctrine\Bundle\MongoDBBundle\Tests\Fixtures\Form;
 
 use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use MongoDB\BSON\ObjectId;
 
 /** @ODM\Document */
 class Category
 {
-    /** @ODM\Id */
+    /**
+     * @ODM\Id
+     *
+     * @var ObjectId|null
+     */
     protected $id;
 
-    /** @ODM\Field(type="string") */
+    /**
+     * @ODM\Field(type="string")
+     *
+     * @var string
+     */
     public $name;
 
     /**
@@ -21,6 +31,8 @@ class Category
      *     targetDocument="Doctrine\Bundle\MongoDBBundle\Tests\Fixtures\Form\Document",
      *     mappedBy="categories"
      * )
+     *
+     * @var Collection<int, Document>
      */
     public $documents;
 
@@ -37,6 +49,6 @@ class Category
      **/
     public function __toString()
     {
-        return (string) $this->name;
+        return $this->name;
     }
 }

--- a/Tests/Fixtures/Form/Document.php
+++ b/Tests/Fixtures/Form/Document.php
@@ -5,16 +5,25 @@ declare(strict_types=1);
 namespace Doctrine\Bundle\MongoDBBundle\Tests\Fixtures\Form;
 
 use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use MongoDB\BSON\ObjectId;
 
 /** @ODM\Document */
 class Document
 {
-    /** @ODM\Id(strategy="none") */
+    /**
+     * @ODM\Id(strategy="none")
+     *
+     * @var ObjectId
+     */
     protected $id;
 
-    /** @ODM\Field(type="string") */
+    /**
+     * @ODM\Field(type="string")
+     *
+     * @var string
+     */
     public $name;
 
     /**
@@ -23,14 +32,12 @@ class Document
      *     inversedBy="documents",
      *     strategy="atomicSetArray"
      * )
+     *
+     * @var Collection<int, Category>
      */
     public $categories;
 
-    /**
-     * @param ObjectId $id
-     * @param string   $name
-     */
-    public function __construct($id, $name)
+    public function __construct(ObjectId $id, string $name)
     {
         $this->id         = $id;
         $this->name       = $name;
@@ -44,6 +51,6 @@ class Document
      **/
     public function __toString()
     {
-        return (string) $this->name;
+        return $this->name;
     }
 }

--- a/Tests/Fixtures/Form/Guesser.php
+++ b/Tests/Fixtures/Form/Guesser.php
@@ -4,23 +4,42 @@ declare(strict_types=1);
 
 namespace Doctrine\Bundle\MongoDBBundle\Tests\Fixtures\Form;
 
+use DateTime;
+use Doctrine\Common\Collections\Collection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use MongoDB\BSON\ObjectId;
 
 /**
  * @ODM\Document
  */
 class Guesser
 {
-    /** @ODM\Id(strategy="none") */
+    /**
+     * @ODM\Id(strategy="none")
+     *
+     * @var ObjectId|null
+     */
     protected $id;
 
-    /** @ODM\Field() */
+    /**
+     * @ODM\Field()
+     *
+     * @var string|null
+     */
     public $name;
 
-    /** @ODM\Field(type="date") */
+    /**
+     * @ODM\Field(type="date")
+     *
+     * @var DateTime|null
+     */
     public $date;
 
-    /** @ODM\Field(type="timestamp") */
+    /**
+     * @ODM\Field(type="timestamp")
+     *
+     * @var DateTime
+     */
     public $ts;
 
     /**
@@ -29,20 +48,39 @@ class Guesser
      *     inversedBy="documents",
      *     strategy="atomicSetArray"
      * )
+     *
+     * @var Collection<int, Category>
      */
     public $categories;
 
-    /** @ODM\Field(type="bool") */
+    /**
+     * @ODM\Field(type="bool")
+     *
+     * @var bool|null
+     */
     public $boolField;
 
-    /** @ODM\Field(type="float") */
+    /**
+     * @ODM\Field(type="float")
+     *
+     * @var float|null
+     */
     public $floatField;
 
-    /** @ODM\Field(type="int") */
+    /**
+     * @ODM\Field(type="int")
+     *
+     * @var int|null
+     */
     public $intField;
 
-    /** @ODM\Field(type="collection") */
+    /**
+     * @ODM\Field(type="collection")
+     *
+     * @var array
+     */
     public $collectionField;
 
+    /** @var mixed */
     public $nonMappedField;
 }

--- a/Tests/Fixtures/Security/User.php
+++ b/Tests/Fixtures/Security/User.php
@@ -11,17 +11,21 @@ use Symfony\Component\Security\Core\User\UserInterface;
 /** @ODM\Document */
 class User implements UserInterface
 {
-    /** @ODM\Id(strategy="none") */
+    /**
+     * @ODM\Id(strategy="none")
+     *
+     * @var ObjectId
+     */
     protected $id;
 
-    /** @ODM\Field(type="string") */
+    /**
+     * @ODM\Field(type="string")
+     *
+     * @var string
+     */
     public $name;
 
-    /**
-     * @param ObjectId $id
-     * @param string   $name
-     */
-    public function __construct($id, $name)
+    public function __construct(ObjectId $id, string $name)
     {
         $this->id   = $id;
         $this->name = $name;

--- a/Tests/Fixtures/Validator/Document.php
+++ b/Tests/Fixtures/Validator/Document.php
@@ -10,31 +10,56 @@ use MongoDB\BSON\ObjectId;
 /** @ODM\Document(collection="DoctrineMongoDBBundle_Tests_Validator_Document") */
 class Document
 {
-    /** @ODM\Id(strategy="none") */
+    /**
+     * @ODM\Id(strategy="none")
+     *
+     * @var ObjectId
+     */
     protected $id;
 
-    /** @ODM\Field(type="string") */
+    /**
+     * @ODM\Field(type="string")
+     *
+     * @var string
+     */
     public $name;
 
-    /** @ODM\Field(type="hash") */
+    /**
+     * @ODM\Field(type="hash")
+     *
+     * @var array
+     */
     public $hash;
 
-    /** @ODM\Field(type="collection") */
+    /**
+     * @ODM\Field(type="collection")
+     *
+     * @var array
+     */
     public $collection;
 
-    /** @ODM\ReferenceOne(targetDocument="Doctrine\Bundle\MongoDBBundle\Tests\Fixtures\Validator\Document") */
+    /**
+     * @ODM\ReferenceOne(targetDocument="Doctrine\Bundle\MongoDBBundle\Tests\Fixtures\Validator\Document")
+     *
+     * @var Document|null
+     */
     public $referenceOne;
 
-    /** @ODM\EmbedOne(targetDocument="Doctrine\Bundle\MongoDBBundle\Tests\Fixtures\Validator\EmbeddedDocument") */
+    /**
+     * @ODM\EmbedOne(targetDocument="Doctrine\Bundle\MongoDBBundle\Tests\Fixtures\Validator\EmbeddedDocument")
+     *
+     * @var EmbeddedDocument|null
+     */
     public $embedOne;
 
-    /** @ODM\EmbedMany(targetDocument="Doctrine\Bundle\MongoDBBundle\Tests\Fixtures\Validator\EmbeddedDocument") */
+    /**
+     * @ODM\EmbedMany(targetDocument="Doctrine\Bundle\MongoDBBundle\Tests\Fixtures\Validator\EmbeddedDocument")
+     *
+     * @var EmbeddedDocument[]
+     */
     public $embedMany = [];
 
-    /**
-     * @param ObjectId $id
-     */
-    public function __construct($id)
+    public function __construct(ObjectId $id)
     {
         $this->id = $id;
     }
@@ -43,6 +68,10 @@ class Document
 /** @ODM\EmbeddedDocument */
 class EmbeddedDocument
 {
-    /** @ODM\Field(type="string") */
+    /**
+     * @ODM\Field(type="string")
+     *
+     * @var string
+     */
     public $name;
 }

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -41,8 +41,4 @@
     <rule ref="Squiz.Classes.ClassFileName.NoMatch">
         <exclude-pattern>Tests/*</exclude-pattern>
     </rule>
-
-    <rule ref="SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingAnyTypeHint">
-        <exclude-pattern>Tests/*</exclude-pattern>
-    </rule>
 </ruleset>


### PR DESCRIPTION
This PR removes a phpcs excluded rule that makes mandatory to have type declarations in tests.

This would be nice to do it in the ODM library as well, but the amount of work is considerable so I guess it would be done by steps.