### PR TITLE
Deprecate tailable cursor command

### DIFF
--- a/Command/TailCursorDoctrineODMCommand.php
+++ b/Command/TailCursorDoctrineODMCommand.php
@@ -19,9 +19,12 @@ use Throwable;
 
 use function sleep;
 use function sprintf;
+use function trigger_deprecation;
 
 /**
  * Command helping to configure a daemon listening to a tailable cursor. Works only with capped collections.
+ *
+ * @deprecated since version 4.4
  */
 class TailCursorDoctrineODMCommand extends Command implements ContainerAwareInterface
 {
@@ -46,6 +49,13 @@ class TailCursorDoctrineODMCommand extends Command implements ContainerAwareInte
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
+        trigger_deprecation(
+            'doctrine/mongodb-odm-bundle',
+            '4.4',
+            'The "%s" command is deprecated and will be dropped in DoctrineMongoDBBundle 5.0. You should consider using https://docs.mongodb.com/manual/changeStreams/ instead.',
+            $this->getName()
+        );
+
         $dm                   = $this->getContainer()->get('doctrine_mongodb.odm.document_manager');
         $repository           = $dm->getRepository($input->getArgument('document'));
         $repositoryReflection = new ReflectionClass($repository);

--- a/Cursor/TailableCursorProcessorInterface.php
+++ b/Cursor/TailableCursorProcessorInterface.php
@@ -6,6 +6,8 @@ namespace Doctrine\Bundle\MongoDBBundle\Cursor;
 
 /**
  * Contract for tailable cursor processors.
+ *
+ * @deprecated since version 4.4
  */
 interface TailableCursorProcessorInterface
 {

--- a/UPGRADE-4.4.md
+++ b/UPGRADE-4.4.md
@@ -1,0 +1,7 @@
+UPGRADE FROM 4.x to 4.4
+=======================
+
+* The `doctrine:mongodb:tail-cursor` command and
+  `Doctrine\Bundle\MongoDBBundle\Cursor\TailableCursorProcessorInterface`
+  interface have been deprecated. You should use
+  [change streams](https://docs.mongodb.com/manual/changeStreams/) instead.

--- a/UPGRADE-5.0.md
+++ b/UPGRADE-5.0.md
@@ -1,0 +1,7 @@
+UPGRADE FROM 4.x to 5.0
+=======================
+
+* The `doctrine:mongodb:tail-cursor` command and
+  `Doctrine\Bundle\MongoDBBundle\Cursor\TailableCursorProcessorInterface`
+  interface have been dropped. You should use
+  [change streams](https://docs.mongodb.com/manual/changeStreams/) instead.


### PR DESCRIPTION
Apparently this command is not being used for a while since the code is not compatible with `ext-mongodb`.

As suggested by @jmikola, users can use https://docs.mongodb.com/manual/changeStreams/ instead in newer MongoDB versions.