### PR TITLE
Update Documentation doctrine_mongodb.connections.default.options.connect is no longer a valid configuration option.

### DIFF
--- a/Resources/doc/config.rst
+++ b/Resources/doc/config.rst
@@ -577,7 +577,6 @@ Full Default Configuration
                     server:               ~
                     options:
                         authMechanism:                          ~
-                        connect:                                ~
                         connectTimeoutMS:                       ~
                         db:                                     ~
                         authSource:                             ~
@@ -669,7 +668,6 @@ Full Default Configuration
                 <doctrine:connection id="conn1" server="mongodb://localhost">
                     <doctrine:options
                             authMechanism=""
-                            connect=""
                             connectTimeoutMS=""
                             db=""
                             authSource=""


### PR DESCRIPTION
While attempting to perform an upgrade from an older version we started getting errors for `doctrine_mongodb.connections.default.options.connect` not being valid. After consulting the docs it looks like it should be possible but after looking at the configuration here https://github.com/doctrine/DoctrineMongoDBBundle/blob/4.4.x/DependencyInjection/Configuration.php#L257 it looks like it was removed in this PR https://github.com/doctrine/DoctrineMongoDBBundle/pull/475/files.
