### PR TITLE
add Stopwatch support

### DIFF
--- a/APM/StopwatchCommandLogger.php
+++ b/APM/StopwatchCommandLogger.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Bundle\MongoDBBundle\APM;
+
+use Doctrine\ODM\MongoDB\APM\CommandLoggerInterface;
+use MongoDB\Driver\Monitoring\CommandFailedEvent;
+use MongoDB\Driver\Monitoring\CommandStartedEvent;
+use MongoDB\Driver\Monitoring\CommandSucceededEvent;
+use Symfony\Component\Stopwatch\Stopwatch;
+
+use function MongoDB\Driver\Monitoring\addSubscriber;
+use function MongoDB\Driver\Monitoring\removeSubscriber;
+use function sprintf;
+
+final class StopwatchCommandLogger implements CommandLoggerInterface
+{
+    /** @var bool */
+    private $registered = false;
+
+    /** @var Stopwatch|null */
+    private $stopwatch;
+
+    public function __construct(?Stopwatch $stopwatch)
+    {
+        $this->stopwatch = $stopwatch;
+    }
+
+    public function register(): void
+    {
+        if ($this->stopwatch === null || $this->registered) {
+            return;
+        }
+
+        $this->registered = true;
+        addSubscriber($this);
+    }
+
+    public function unregister(): void
+    {
+        if (! $this->registered) {
+            return;
+        }
+
+        removeSubscriber($this);
+        $this->registered = false;
+    }
+
+    public function commandStarted(CommandStartedEvent $event)
+    {
+        if (! $this->stopwatch) {
+            return;
+        }
+
+        $this->stopwatch->start(sprintf('mongodb_%s', $event->getRequestId()), 'doctrine_mongodb');
+    }
+
+    public function commandSucceeded(CommandSucceededEvent $event)
+    {
+        if (! $this->stopwatch) {
+            return;
+        }
+
+        $this->stopwatch->stop(sprintf('mongodb_%s', $event->getRequestId()));
+    }
+
+    public function commandFailed(CommandFailedEvent $event)
+    {
+        if (! $this->stopwatch) {
+            return;
+        }
+
+        $this->stopwatch->stop(sprintf('mongodb_%s', $event->getRequestId()));
+    }
+}

--- a/DependencyInjection/DoctrineMongoDBExtension.php
+++ b/DependencyInjection/DoctrineMongoDBExtension.php
@@ -510,6 +510,7 @@ class DoctrineMongoDBExtension extends AbstractDoctrineExtension
 
     private function buildDeprecationArgs(string $version, string $message): array
     {
+        // @todo Remove when support for Symfony 5.1 and older is dropped
         return method_exists(BaseNode::class, 'getDeprecation')
             ? ['doctrine/mongodb-odm-bundle', $version, $message]
             : [$message];

--- a/Resources/config/mongodb.xml
+++ b/Resources/config/mongodb.xml
@@ -136,7 +136,13 @@
             <argument type="tagged" tag="doctrine_mongodb.odm.command_logger" />
         </service>
 
-        <service id="doctrine_mongodb.odm.command_logger" class="Doctrine\Bundle\MongoDBBundle\APM\PSRCommandLogger" public="false">
+        <service id="doctrine_mongodb.odm.stopwatch_command_logger" class="Doctrine\Bundle\MongoDBBundle\APM\StopwatchCommandLogger" public="false">
+            <argument type="service" id="debug.stopwatch" on-invalid="null" />
+        </service>
+
+        <service id="doctrine_mongodb.odm.command_logger" alias="doctrine_mongodb.odm.psr_command_logger" />
+
+        <service id="doctrine_mongodb.odm.psr_command_logger" class="Doctrine\Bundle\MongoDBBundle\APM\PSRCommandLogger" public="false">
             <argument type="service" id="logger" on-invalid="null" />
 
             <tag name="monolog.logger" channel="doctrine" />

--- a/Tests/APM/StopwatchCommandLoggerTest.php
+++ b/Tests/APM/StopwatchCommandLoggerTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Bundle\MongoDBBundle\Tests\APM;
+
+use Doctrine\Bundle\MongoDBBundle\APM\StopwatchCommandLogger;
+use Doctrine\Bundle\MongoDBBundle\Tests\Fixtures\Form\Category;
+use Doctrine\Bundle\MongoDBBundle\Tests\TestCase;
+use Doctrine\ODM\MongoDB\DocumentManager;
+use Symfony\Component\Stopwatch\Stopwatch;
+
+class StopwatchCommandLoggerTest extends TestCase
+{
+    /** @var StopwatchCommandLogger */
+    private $commandLogger;
+    /** @var Stopwatch */
+    private $stopwatch;
+    /** @var DocumentManager */
+    private $dm;
+
+    protected function setUp(): void
+    {
+        $this->dm = TestCase::createTestDocumentManager();
+
+        $this->stopwatch     = new Stopwatch(true);
+        $this->commandLogger = new StopwatchCommandLogger($this->stopwatch);
+        $this->commandLogger->register();
+
+        parent::setUp();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->commandLogger->unregister();
+
+        $this->dm->getDocumentCollection(Category::class)->drop();
+
+        parent::tearDown();
+    }
+
+    public function testItLogsStopwatchEvents(): void
+    {
+        $category = new Category('one');
+
+        $this->dm->persist($category);
+        $this->dm->flush();
+
+        $this->dm->remove($category);
+        $this->dm->flush();
+
+        $this->dm->getRepository(Category::class)->findAll();
+        $events = $this->stopwatch->getSectionEvents('__root__');
+
+        self::assertCount(3, $events);
+
+        foreach ($events as $eventName => $stopwatchEvent) {
+            // @todo replace with assertMatchesRegularExpression() when PHP 7.2 is dropped
+            self::assertRegExp('/mongodb_\d+/', $eventName);
+            self::assertGreaterThan(0, $stopwatchEvent->getDuration());
+            self::assertSame('doctrine_mongodb', $stopwatchEvent->getCategory());
+        }
+    }
+}

--- a/Tests/ContainerTest.php
+++ b/Tests/ContainerTest.php
@@ -46,7 +46,7 @@ class ContainerTest extends TestCase
         $this->container->setParameter('kernel.debug', $debug);
         $this->extension->load([$config], $this->container);
 
-        $definition = $this->container->getDefinition('doctrine_mongodb.odm.command_logger');
+        $definition = $this->container->getDefinition('doctrine_mongodb.odm.psr_command_logger');
         $this->assertSame($expected, $definition->hasTag('doctrine_mongodb.odm.command_logger'));
 
         $this->container->compile();
@@ -98,8 +98,14 @@ class ContainerTest extends TestCase
         $this->container->setParameter('kernel.debug', $debug);
         $this->extension->load([$config], $this->container);
 
+        $deprecatedLoggerDefinition = $this->container->getAlias('doctrine_mongodb.odm.command_logger');
+        $this->assertTrue($deprecatedLoggerDefinition->isDeprecated());
+
         $loggerDefinition = $this->container->getDefinition('doctrine_mongodb.odm.data_collector.command_logger');
         $this->assertSame($expected, $loggerDefinition->hasTag('doctrine_mongodb.odm.command_logger'));
+
+        $stopwatchLoggerDefinition = $this->container->getDefinition('doctrine_mongodb.odm.stopwatch_command_logger');
+        $this->assertSame($expected, $stopwatchLoggerDefinition->hasTag('doctrine_mongodb.odm.command_logger'));
 
         $dataCollectorDefinition = $this->container->getDefinition('doctrine_mongodb.odm.data_collector');
         $this->assertSame($expected, $dataCollectorDefinition->hasTag('data_collector'));

--- a/UPGRADE-4.4.md
+++ b/UPGRADE-4.4.md
@@ -11,3 +11,5 @@ UPGRADE FROM 4.x to 4.4
   deprecated without replacement.
 * The `Doctrine\Bundle\MongoDBBundle\Command\DoctrineODMCommand` class has
   been marked as `@internal`, you should not extend from this class.
+* The `doctrine_mongodb.odm.command_logger` service has been deprecated. You should use
+  `doctrine_mongodb.odm.psr_command_logger` instead.

--- a/composer.json
+++ b/composer.json
@@ -39,6 +39,7 @@
         "symfony/form": "^4.3.3|^5.0",
         "symfony/phpunit-bridge": "^5.1",
         "symfony/security-bundle": "^4.4|^5.0",
+        "symfony/stopwatch": "^4.4|^5.0",
         "symfony/validator": "^4.4|^5.0",
         "symfony/yaml": "^4.3.3|^5.0",
         "vimeo/psalm": "^4.8"


### PR DESCRIPTION
This feature adds Symfony Stopwatch support. Events tracked are grouped into `doctrine_mongodb` category and use `requestId` as unique event name identifier.

![image](https://user-images.githubusercontent.com/1985514/133759292-be936cc6-feb4-434b-ab9a-e9b5fbe6b35c.png)

Fixes #701, based on #594 but extracted this logger into a separate class (SRP).

Breaking changes:
 - `doctrine_mongodb.odm.command_logger` service ID is now `doctrine_mongodb.odm.psr_command_logger`
