### PR TITLE
Allow PSR/Log v2 and v3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "doctrine/annotations": "^1.2",
         "doctrine/mongodb-odm": "^2.0.0",
         "doctrine/persistence": "^1.3.6|^2.0",
-        "psr/log": "^1.0",
+        "psr/log": "^1.0|^2.0|^3.0",
         "symfony/console": "^4.4.6|^5.0",
         "symfony/dependency-injection": "^4.3.3|^5.0",
         "symfony/deprecation-contracts": "^2.1",


### PR DESCRIPTION
PSR logger is only used in `PSRCommandLogger`: https://github.com/doctrine/DoctrineMongoDBBundle/blob/4.4.x/APM/PSRCommandLogger.php

Since we are only calling `debug()` method and not relying on any of return types, we can safely allow installing all versions of `psr/log` without any changes in code.