### PR TITLE
support Unique constraint as attribute

### DIFF
--- a/Validator/Constraints/Unique.php
+++ b/Validator/Constraints/Unique.php
@@ -4,13 +4,16 @@ declare(strict_types=1);
 
 namespace Doctrine\Bundle\MongoDBBundle\Validator\Constraints;
 
+use Attribute;
 use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
 
 /**
  * Constraint for the unique document validator
  *
  * @Annotation
+ * @Target({"CLASS", "ANNOTATION"})
  */
+#[Attribute(Attribute::TARGET_CLASS | Attribute::IS_REPEATABLE)]
 class Unique extends UniqueEntity
 {
     /** @var string */


### PR DESCRIPTION
This change allows using `Unique` constraint as attribute:

```php
#[Unique()]
```

see https://github.com/symfony/symfony/blob/5.4/src/Symfony/Bridge/Doctrine/Validator/Constraints/UniqueEntity.php