### PR TITLE
Remove deprecations using Symfony 5.4

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -26,9 +26,11 @@ jobs:
           - "7.3"
           - "7.4"
           - "8.0"
+        stability:
+          - "stable"
         symfony-version:
           - "4.4.x"
-          - "5.1.x"
+          - "5.3.x"
         driver-version:
           - "stable"
         dependencies:
@@ -38,7 +40,14 @@ jobs:
             os: "ubuntu-20.04"
             php-version: "7.2"
             driver-version: "1.5.0"
+            stability: "stable"
             symfony-version: "4.4.*"
+          - dependencies: "highest"
+            os: "ubuntu-20.04"
+            driver-version: "stable"
+            php-version: "8.0"
+            stability: "dev"
+            symfony-version: "5.4.*"
 
     services:
       mongodb:
@@ -80,7 +89,7 @@ jobs:
         run: "composer global require --no-progress --no-scripts --no-plugins symfony/flex"
 
       - name: "Set minimum-stability to stable in Composer"
-        run: "composer config minimum-stability stable"
+        run: "composer config minimum-stability ${{ matrix.stability }}"
 
       - name: "Install dependencies with Composer"
         uses: "ramsey/composer-install@v1"

--- a/CacheWarmer/HydratorCacheWarmer.php
+++ b/CacheWarmer/HydratorCacheWarmer.php
@@ -49,7 +49,9 @@ class HydratorCacheWarmer implements CacheWarmerInterface
     }
 
     /**
-     * {@inheritDoc}
+     * @param string $cacheDir
+     *
+     * @return string[]
      */
     public function warmUp($cacheDir)
     {

--- a/CacheWarmer/PersistentCollectionCacheWarmer.php
+++ b/CacheWarmer/PersistentCollectionCacheWarmer.php
@@ -51,7 +51,9 @@ class PersistentCollectionCacheWarmer implements CacheWarmerInterface
     }
 
     /**
-     * {@inheritDoc}
+     * @param string $cacheDir
+     *
+     * @return string[]
      */
     public function warmUp($cacheDir)
     {

--- a/CacheWarmer/ProxyCacheWarmer.php
+++ b/CacheWarmer/ProxyCacheWarmer.php
@@ -51,7 +51,9 @@ class ProxyCacheWarmer implements CacheWarmerInterface
     }
 
     /**
-     * {@inheritDoc}
+     * @param string $cacheDir
+     *
+     * @return string[]
      */
     public function warmUp($cacheDir)
     {

--- a/DependencyInjection/DoctrineMongoDBExtension.php
+++ b/DependencyInjection/DoctrineMongoDBExtension.php
@@ -457,7 +457,9 @@ class DoctrineMongoDBExtension extends AbstractDoctrineExtension
     }
 
     /**
-     * {@inheritDoc}
+     * @param string $name
+     *
+     * @return string
      */
     protected function getObjectManagerElementName($name)
     {
@@ -465,7 +467,7 @@ class DoctrineMongoDBExtension extends AbstractDoctrineExtension
     }
 
     /**
-     * {@inheritDoc}
+     * @return string
      */
     protected function getMappingObjectDefaultName()
     {
@@ -473,7 +475,7 @@ class DoctrineMongoDBExtension extends AbstractDoctrineExtension
     }
 
     /**
-     * {@inheritDoc}
+     * @return string
      */
     protected function getMappingResourceConfigDirectory()
     {
@@ -481,7 +483,7 @@ class DoctrineMongoDBExtension extends AbstractDoctrineExtension
     }
 
     /**
-     * {@inheritDoc}
+     * @return string
      */
     protected function getMappingResourceExtension()
     {
@@ -494,7 +496,7 @@ class DoctrineMongoDBExtension extends AbstractDoctrineExtension
     }
 
     /**
-     * {@inheritDoc}
+     * @return string
      */
     public function getAlias()
     {

--- a/DoctrineMongoDBBundle.php
+++ b/DoctrineMongoDBBundle.php
@@ -18,6 +18,7 @@ use Symfony\Bridge\Doctrine\DependencyInjection\Security\UserProvider\EntityFact
 use Symfony\Bundle\SecurityBundle\DependencyInjection\SecurityExtension;
 use Symfony\Component\DependencyInjection\Compiler\PassConfig;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 use function assert;
@@ -56,7 +57,7 @@ class DoctrineMongoDBBundle extends Bundle
     }
 
     /**
-     * {@inheritDoc}
+     * @return ExtensionInterface|null
      */
     public function getContainerExtension()
     {

--- a/Form/ChoiceList/MongoDBQueryBuilderLoader.php
+++ b/Form/ChoiceList/MongoDBQueryBuilderLoader.php
@@ -53,7 +53,7 @@ class MongoDBQueryBuilderLoader implements EntityLoaderInterface
     }
 
     /**
-     * {@inheritDoc}
+     * @return object[]
      */
     public function getEntities()
     {
@@ -61,7 +61,9 @@ class MongoDBQueryBuilderLoader implements EntityLoaderInterface
     }
 
     /**
-     * {@inheritDoc}
+     * @param string $identifier
+     *
+     * @return object[]
      */
     public function getEntitiesByIds($identifier, array $values)
     {

--- a/Form/DoctrineMongoDBExtension.php
+++ b/Form/DoctrineMongoDBExtension.php
@@ -6,6 +6,8 @@ namespace Doctrine\Bundle\MongoDBBundle\Form;
 
 use Doctrine\Persistence\ManagerRegistry;
 use Symfony\Component\Form\AbstractExtension;
+use Symfony\Component\Form\FormTypeGuesserInterface;
+use Symfony\Component\Form\FormTypeInterface;
 
 /**
  * Form extension.
@@ -21,7 +23,7 @@ class DoctrineMongoDBExtension extends AbstractExtension
     }
 
     /**
-     * {@inheritDoc}
+     * @return FormTypeInterface[]
      */
     protected function loadTypes()
     {
@@ -31,7 +33,7 @@ class DoctrineMongoDBExtension extends AbstractExtension
     }
 
     /**
-     * {@inheritDoc}
+     * @return FormTypeGuesserInterface|null
      */
     protected function loadTypeGuesser()
     {

--- a/Form/DoctrineMongoDBTypeGuesser.php
+++ b/Form/DoctrineMongoDBTypeGuesser.php
@@ -38,7 +38,10 @@ class DoctrineMongoDBTypeGuesser implements FormTypeGuesserInterface
     }
 
     /**
-     * @inheritDoc
+     * @param string $class
+     * @param string $property
+     *
+     * @return TypeGuess|null
      */
     public function guessType($class, $property)
     {
@@ -118,7 +121,10 @@ class DoctrineMongoDBTypeGuesser implements FormTypeGuesserInterface
     }
 
     /**
-     * @inheritDoc
+     * @param string $class
+     * @param string $property
+     *
+     * @return ValueGuess|null
      */
     public function guessRequired($class, $property)
     {
@@ -139,7 +145,10 @@ class DoctrineMongoDBTypeGuesser implements FormTypeGuesserInterface
     }
 
     /**
-     * @inheritDoc
+     * @param string $class
+     * @param string $property
+     *
+     * @return ValueGuess|null
      */
     public function guessMaxLength($class, $property)
     {
@@ -167,7 +176,10 @@ class DoctrineMongoDBTypeGuesser implements FormTypeGuesserInterface
     }
 
     /**
-     * @inheritDoc
+     * @param string $class
+     * @param string $property
+     *
+     * @return ValueGuess|null
      */
     public function guessPattern($class, $property)
     {

--- a/Form/Type/DocumentType.php
+++ b/Form/Type/DocumentType.php
@@ -8,6 +8,7 @@ use Doctrine\Bundle\MongoDBBundle\Form\ChoiceList\MongoDBQueryBuilderLoader;
 use Doctrine\ODM\MongoDB\DocumentManager;
 use Doctrine\Persistence\ObjectManager;
 use InvalidArgumentException;
+use Symfony\Bridge\Doctrine\Form\ChoiceList\EntityLoaderInterface;
 use Symfony\Bridge\Doctrine\Form\Type\DoctrineType;
 use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -20,7 +21,10 @@ use function interface_exists;
 class DocumentType extends DoctrineType
 {
     /**
-     * {@inheritDoc}
+     * @param object $queryBuilder
+     * @param string $class
+     *
+     * @return EntityLoaderInterface
      */
     public function getLoader(ObjectManager $manager, $queryBuilder, $class)
     {

--- a/Tests/APM/StopwatchCommandLoggerTest.php
+++ b/Tests/APM/StopwatchCommandLoggerTest.php
@@ -10,6 +10,8 @@ use Doctrine\Bundle\MongoDBBundle\Tests\TestCase;
 use Doctrine\ODM\MongoDB\DocumentManager;
 use Symfony\Component\Stopwatch\Stopwatch;
 
+use function method_exists;
+
 class StopwatchCommandLoggerTest extends TestCase
 {
     /** @var StopwatchCommandLogger */
@@ -56,7 +58,12 @@ class StopwatchCommandLoggerTest extends TestCase
 
         foreach ($events as $eventName => $stopwatchEvent) {
             // @todo replace with assertMatchesRegularExpression() when PHP 7.2 is dropped
-            self::assertRegExp('/mongodb_\d+/', $eventName);
+            if (method_exists($this, 'assertMatchesRegularExpression')) {
+                self::assertMatchesRegularExpression('/mongodb_\d+/', $eventName);
+            } else {
+                self::assertRegExp('/mongodb_\d+/', $eventName);
+            }
+
             self::assertGreaterThan(0, $stopwatchEvent->getDuration());
             self::assertSame('doctrine_mongodb', $stopwatchEvent->getCategory());
         }

--- a/Tests/FixtureIntegrationTest.php
+++ b/Tests/FixtureIntegrationTest.php
@@ -25,9 +25,9 @@ use Symfony\Component\Routing\RouteCollectionBuilder;
 use function array_map;
 use function assert;
 use function get_class;
-use function rand;
 use function sprintf;
 use function sys_get_temp_dir;
+use function uniqid;
 
 class FixtureIntegrationTest extends TestCase
 {
@@ -283,13 +283,12 @@ class IntegrationTestKernel extends Kernel
     /** @var callable */
     private $servicesCallback;
 
-    /** @var int */
+    /** @var string */
     private $randomKey;
 
     public function __construct(string $environment, bool $debug)
     {
-        $this->randomKey = rand(100, 999);
-
+        $this->randomKey = uniqid('');
         parent::__construct($environment, $debug);
     }
 

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -35,4 +35,8 @@
             </exclude>
         </whitelist>
     </filter>
+
+    <listeners>
+        <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener"/>
+    </listeners>
 </phpunit>


### PR DESCRIPTION
This PR adds a CI job testing Symfony 5.4.

[Symfony 5.4 adds deprecations](https://symfony.com/blog/preparing-your-apps-and-bundles-for-symfony-6#introducing-php-types-everywhere) where there is no return type explicitly set (native or phpdoc) in overriding or implementing methods from Symfony or core.