### PR TITLE
improve collector view

### DIFF
--- a/Resources/views/Collector/mongodb.html.twig
+++ b/Resources/views/Collector/mongodb.html.twig
@@ -2,21 +2,23 @@
 
 {% block toolbar %}
     {% if collector.commandCount > 0 %}
-        {% set profiler_markup_version = profiler_markup_version|default(1) %}
-
         {% set icon %}
-            {% if profiler_markup_version == 1 %}
-                <img width="20" height="28" alt="Mongo" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABQAAAAcCAYAAABh2p9gAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAAQRJREFUeNpi/P//PwM1ARMDlcGogZQDlpMnT7pxc3NbA9nhQKxOpL5rQLwJiPeBsI6Ozl+YBOOOHTv+AOllQNwtLS39F2owKYZ/gRq8G4i3ggxEToggWzvc3d2Pk+1lNL4fFAs6ODi8JzdS7mMRVyDVoAMHDsANdAPiOCC+jCQvQKqBQB/BDbwBxK5AHA3E/kB8nKJkA8TMQBwLxaBIKQbi70AvTADSBiSadwFXpCikpKQU8PDwkGTaly9fHFigkaKIJid4584dkiMFFI6jkTJII0WVmpHCAixZQEXWYhDeuXMnyLsVlEQKI45qFBQZ8eRECi4DBaAlDqle/8A48ip6gAADANdQY88Uc0oGAAAAAElFTkSuQmCC"/>
-                <span class="sf-toolbar-status">{{ collector.commandCount }}</span>
-            {% else %}
-                {{ include('@DoctrineMongoDB/Collector/icon.svg') }}
-                <span class="sf-toolbar-value">{{ collector.commandCount }}</span>
-            {% endif %}
+            {{ include('@DoctrineMongoDB/Collector/icon.svg') }}
+            <span class="sf-toolbar-value">{{ collector.commandCount }}</span>
+            <span class="sf-toolbar-info-piece-additional-detail">
+                <span class="sf-toolbar-label">in</span>
+                <span class="sf-toolbar-value">{{ '%0.2f'|format(collector.time / 1000) }}</span>
+                <span class="sf-toolbar-label">ms</span>
+            </span>
         {% endset %}
         {% set text %}
             <div class="sf-toolbar-info-piece">
-                <b>Database Commands</b>
+                <b>Database commands</b>
                 <span class="sf-toolbar-status">{{ collector.commandCount }}</span>
+            </div>
+            <div class="sf-toolbar-info-piece">
+                <b>Command time</b>
+                <span>{{ '%0.2f'|format(collector.time / 1000) }} ms</span>
             </div>
         {% endset %}
         {% include '@WebProfiler/Profiler/toolbar_item.html.twig' with { 'link': profiler_url } %}
@@ -38,12 +40,12 @@
     <div class="metrics">
         <div class="metric">
             <span class="value">{{ collector.commandCount }}</span>
-            <span class="label">Database Queries</span>
+            <span class="label">Database commands</span>
         </div>
 
         <div class="metric">
-            <span class="value">{{ '%0.3f'|format(collector.time / 1000) }} ms</span>
-            <span class="label">Query time</span>
+            <span class="value">{{ '%0.3f'|format(collector.time / 1000) }} <span class="unit">ms</span></span>
+            <span class="label">Command time</span>
         </div>
     </div>
 


### PR DESCRIPTION
This PR adds command time to the toolbar just like in ORM bundle:

![image](https://user-images.githubusercontent.com/1985514/139419693-3c78dc45-318a-41b5-ac73-c02041a9fc97.png)

The `ms` unit has been grayed out in the profiler to match other tabs:
![image](https://user-images.githubusercontent.com/1985514/139420502-e1616585-b439-4401-ace8-a51e0148e030.png)

I've also skipped check for `profiler_markup_version` as `1` means it's Symfony <2.8 which is no longer supported by the bundle.

I rephrased the "Query count" to "command count" but I'm not really sure how to name the "Query time".