### PR TITLE
Add compatibility with Symfony 6

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -48,6 +48,12 @@ jobs:
             php-version: "8.0"
             stability: "dev"
             symfony-version: "5.4.*"
+          - dependencies: "highest"
+            os: "ubuntu-20.04"
+            driver-version: "stable"
+            php-version: "8.0"
+            stability: "dev"
+            symfony-version: "6.0.*"
 
     services:
       mongodb:

--- a/DependencyInjection/DoctrineMongoDBExtension.php
+++ b/DependencyInjection/DoctrineMongoDBExtension.php
@@ -459,26 +459,18 @@ class DoctrineMongoDBExtension extends AbstractDoctrineExtension
 
     /**
      * @param string $name
-     *
-     * @return string
      */
-    protected function getObjectManagerElementName($name)
+    protected function getObjectManagerElementName($name): string
     {
         return 'doctrine_mongodb.odm.' . $name;
     }
 
-    /**
-     * @return string
-     */
-    protected function getMappingObjectDefaultName()
+    protected function getMappingObjectDefaultName(): string
     {
         return 'Document';
     }
 
-    /**
-     * @return string
-     */
-    protected function getMappingResourceConfigDirectory(?string $bundleDir = null)
+    protected function getMappingResourceConfigDirectory(?string $bundleDir = null): string
     {
         if ($bundleDir !== null && is_dir($bundleDir . '/config/doctrine')) {
             return 'config/doctrine';
@@ -487,10 +479,7 @@ class DoctrineMongoDBExtension extends AbstractDoctrineExtension
         return 'Resources/config/doctrine';
     }
 
-    /**
-     * @return string
-     */
-    protected function getMappingResourceExtension()
+    protected function getMappingResourceExtension(): string
     {
         return 'mongodb';
     }
@@ -500,10 +489,7 @@ class DoctrineMongoDBExtension extends AbstractDoctrineExtension
         return '%' . $this->getObjectManagerElementName('metadata.' . $driverType . '.class') . '%';
     }
 
-    /**
-     * @return string
-     */
-    public function getAlias()
+    public function getAlias(): string
     {
         return 'doctrine_mongodb';
     }
@@ -533,13 +519,11 @@ class DoctrineMongoDBExtension extends AbstractDoctrineExtension
      * @param string $objectManagerName The object manager name
      * @param array  $cacheDriver       The cache driver mapping
      *
-     * @return string
-     *
      * @throws InvalidArgumentException
      *
      * @psalm-suppress UndefinedClass this won't be necessary when removing metadata cache configuration
      */
-    protected function loadCacheDriver($cacheName, $objectManagerName, array $cacheDriver, ContainerBuilder $container)
+    protected function loadCacheDriver($cacheName, $objectManagerName, array $cacheDriver, ContainerBuilder $container): string
     {
         if (isset($cacheDriver['namespace'])) {
             return parent::loadCacheDriver($cacheName, $objectManagerName, $cacheDriver, $container);

--- a/DoctrineMongoDBBundle.php
+++ b/DoctrineMongoDBBundle.php
@@ -56,10 +56,7 @@ class DoctrineMongoDBBundle extends Bundle
         $security->addUserProviderFactory(new EntityFactory('mongodb', 'doctrine_mongodb.odm.security.user.provider'));
     }
 
-    /**
-     * @return ExtensionInterface|null
-     */
-    public function getContainerExtension()
+    public function getContainerExtension(): ?ExtensionInterface
     {
         return new DoctrineMongoDBExtension();
     }

--- a/Form/ChoiceList/MongoDBQueryBuilderLoader.php
+++ b/Form/ChoiceList/MongoDBQueryBuilderLoader.php
@@ -55,7 +55,7 @@ class MongoDBQueryBuilderLoader implements EntityLoaderInterface
     /**
      * @return object[]
      */
-    public function getEntities()
+    public function getEntities(): array
     {
         return array_values($this->queryBuilder->getQuery()->execute()->toArray());
     }
@@ -65,7 +65,7 @@ class MongoDBQueryBuilderLoader implements EntityLoaderInterface
      *
      * @return object[]
      */
-    public function getEntitiesByIds($identifier, array $values)
+    public function getEntitiesByIds($identifier, array $values): array
     {
         $qb = clone $this->queryBuilder;
 

--- a/Form/Type/DocumentType.php
+++ b/Form/Type/DocumentType.php
@@ -23,10 +23,8 @@ class DocumentType extends DoctrineType
     /**
      * @param object $queryBuilder
      * @param string $class
-     *
-     * @return EntityLoaderInterface
      */
-    public function getLoader(ObjectManager $manager, $queryBuilder, $class)
+    public function getLoader(ObjectManager $manager, $queryBuilder, $class): EntityLoaderInterface
     {
         return new MongoDBQueryBuilderLoader(
             $queryBuilder,

--- a/UPGRADE-4.4.md
+++ b/UPGRADE-4.4.md
@@ -13,3 +13,14 @@ UPGRADE FROM 4.x to 4.4
   been marked as `@internal`, you should not extend from this class.
 * The `doctrine_mongodb.odm.command_logger` service has been deprecated. You should use
   `doctrine_mongodb.odm.psr_command_logger` instead.
+* [BC Break] In order to have compatibility with Symfony 6, return types have
+  been added to the following methods:
+  * `Doctrine\Bundle\MongoDBBundle\DependencyInjection\DoctrineMongoDBExtension::getObjectManagerElementName()`
+  * `Doctrine\Bundle\MongoDBBundle\DependencyInjection\DoctrineMongoDBExtension::getMappingObjectDefaultName()`
+  * `Doctrine\Bundle\MongoDBBundle\DependencyInjection\DoctrineMongoDBExtension::getMappingResourceExtension()`
+  * `Doctrine\Bundle\MongoDBBundle\DependencyInjection\DoctrineMongoDBExtension::getAlias()`
+  * `Doctrine\Bundle\MongoDBBundle\DependencyInjection\DoctrineMongoDBExtension::loadCacheDriver()`
+  * `Doctrine\Bundle\MongoDBBundle\DoctrineMongoDBBundle::getContainerExtension()`
+  * `Doctrine\Bundle\MongoDBBundle\Form\ChoiceList\MongoDBQueryBuilderLoader::getEntities()`
+  * `Doctrine\Bundle\MongoDBBundle\Form\ChoiceList\MongoDBQueryBuilderLoader::getEntitiesByIds()`
+  * `Doctrine\Bundle\MongoDBBundle\Form\Type\DocumentType::getLoader()`

--- a/composer.json
+++ b/composer.json
@@ -17,15 +17,15 @@
         "doctrine/annotations": "^1.13",
         "doctrine/mongodb-odm": "2.3.x-dev",
         "doctrine/persistence": "^1.3.6|^2.0",
-        "symfony/config": "^4.3.3|^5.0",
         "psr/log": "^1.0|^2.0|^3.0",
-        "symfony/console": "^4.4.6|^5.0",
-        "symfony/dependency-injection": "^4.3.3|^5.0",
+        "symfony/config": "^4.4|^5.3|^6.0",
+        "symfony/console": "^4.4.6|^5.3|^6.0",
+        "symfony/dependency-injection": "^4.4|^5.3|^6.0",
         "symfony/deprecation-contracts": "^2.1",
-        "symfony/doctrine-bridge": "^4.3.3|^5.0",
-        "symfony/framework-bundle": "^4.3.3|^5.0",
-        "symfony/http-kernel": "^4.3.7|^5.0",
-        "symfony/options-resolver": "^4.3.3|^5.0"
+        "symfony/doctrine-bridge": "^4.4|^5.3|^6.0",
+        "symfony/framework-bundle": "^4.4|^5.3|^6.0",
+        "symfony/http-kernel": "^4.4|^5.0|^6.0",
+        "symfony/options-resolver": "^4.4|^5.3|^6.0"
     },
     "conflict": {
         "doctrine/data-fixtures": "<1.3"
@@ -36,12 +36,12 @@
         "phpunit/phpunit": "^8.5 || ^9.3",
         "psalm/plugin-symfony": "^3.0",
         "squizlabs/php_codesniffer": "^3.5",
-        "symfony/form": "^4.3.3|^5.0",
+        "symfony/form": "^4.3.3|^5.0|^6.0",
         "symfony/phpunit-bridge": "^5.3",
-        "symfony/security-bundle": "^4.4|^5.0",
-        "symfony/stopwatch": "^4.4|^5.0",
-        "symfony/validator": "^4.4|^5.0",
-        "symfony/yaml": "^4.3.3|^5.0",
+        "symfony/security-bundle": "^4.4|^5.3|^6.0",
+        "symfony/stopwatch": "^4.4|^5.3|^6.0",
+        "symfony/validator": "^4.4|^5.3|^6.0",
+        "symfony/yaml": "^4.3.3|^5.3|^6.0",
         "vimeo/psalm": "^4.8"
     },
     "suggest": {


### PR DESCRIPTION
There are many BC breaks here

- `DoctrineMongoDBExtension`: I think they could be acceptable since I think it's quite unusual that someone extends from it.
- `DoctrineMongoDBBundle`: The same thing, I think it is unlikely that someone extends it.
- `MongoDBQueryBuilderLoader` and `DocumentType`: I'm not sure about these ones, should we comment on https://github.com/symfony/symfony/issues/43021? or do you think it's safe to add the return types.

Tests will be probably fixed with https://github.com/symfony/symfony/pull/43917