### PR TITLE
Add missing mapping

### DIFF
--- a/Tests/DependencyInjection/Fixtures/Bundles/AnnotationsBundle/Document/Test.php
+++ b/Tests/DependencyInjection/Fixtures/Bundles/AnnotationsBundle/Document/Test.php
@@ -4,6 +4,11 @@ declare(strict_types=1);
 
 namespace DoctrineMongoDBBundle\Tests\DependencyInjection\Fixtures\Bundles\AnnotationsBundle\Document;
 
+use Doctrine\ODM\MongoDB\Mapping\Annotations as MongoDB;
+
+/**
+ * @MongoDB\Document
+ */
 class Test
 {
 }

--- a/Tests/DependencyInjection/Fixtures/Bundles/AttributesBundle/Document/Test.php
+++ b/Tests/DependencyInjection/Fixtures/Bundles/AttributesBundle/Document/Test.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace DoctrineMongoDBBundle\Tests\DependencyInjection\Fixtures\Bundles\AttributesBundle\Document;
 
+use Doctrine\ODM\MongoDB\Mapping\Annotations as MongoDB;
+
+#[MongoDB\Document]
 class Test
 {
 }


### PR DESCRIPTION
This will be needed after https://github.com/doctrine/DoctrineMongoDBBundle/pull/713 to auto detect mapping when using Symfony >= 5.4