### PR TITLE
add AsDocumentListener attribute

### DIFF
--- a/Attribute/AsDocumentListener.php
+++ b/Attribute/AsDocumentListener.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Bundle\MongoDBBundle\Attribute;
+
+use Attribute;
+
+/**
+ * Service tag to autoconfigure document listeners.
+ */
+#[Attribute(Attribute::TARGET_CLASS | Attribute::IS_REPEATABLE)]
+class AsDocumentListener
+{
+    public function __construct(
+        public ?string $event = null,
+        public ?string $method = null,
+        public ?bool $lazy = null,
+        public ?string $connection = null,
+    ) {
+    }
+}

--- a/DependencyInjection/DoctrineMongoDBExtension.php
+++ b/DependencyInjection/DoctrineMongoDBExtension.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\Bundle\MongoDBBundle\DependencyInjection;
 
+use Doctrine\Bundle\MongoDBBundle\Attribute\AsDocumentListener;
 use Doctrine\Bundle\MongoDBBundle\DependencyInjection\Compiler\FixturesCompilerPass;
 use Doctrine\Bundle\MongoDBBundle\DependencyInjection\Compiler\ServiceRepositoryCompilerPass;
 use Doctrine\Bundle\MongoDBBundle\EventSubscriber\EventSubscriberInterface;
@@ -128,6 +129,17 @@ class DoctrineMongoDBExtension extends AbstractDoctrineExtension
 
         $container->registerForAutoconfiguration(EventSubscriberInterface::class)
             ->addTag('doctrine_mongodb.odm.event_subscriber');
+
+        if (method_exists($container, 'registerAttributeForAutoconfiguration')) {
+            $container->registerAttributeForAutoconfiguration(AsDocumentListener::class, static function (ChildDefinition $definition, AsDocumentListener $attribute) {
+                $definition->addTag('doctrine_mongodb.odm.event_listener', [
+                    'event'      => $attribute->event,
+                    'method'     => $attribute->method,
+                    'lazy'       => $attribute->lazy,
+                    'connection' => $attribute->connection,
+                ]);
+            });
+        }
 
         $this->loadMessengerServices($container);
     }

--- a/Tests/DependencyInjection/Fixtures/Bundles/DocumentListenerBundle/Document/Test.php
+++ b/Tests/DependencyInjection/Fixtures/Bundles/DocumentListenerBundle/Document/Test.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Bundle\MongoDBBundle\Tests\DependencyInjection\Fixtures\Bundles\DocumentListenerBundle\Document;
+
+use Doctrine\ODM\MongoDB\Mapping\Annotations as MongoDB;
+
+#[MongoDB\Document]
+class Test
+{
+}

--- a/Tests/DependencyInjection/Fixtures/Bundles/DocumentListenerBundle/DocumentListenerBundle.php
+++ b/Tests/DependencyInjection/Fixtures/Bundles/DocumentListenerBundle/DocumentListenerBundle.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Bundle\MongoDBBundle\Tests\DependencyInjection\Fixtures\Bundles\DocumentListenerBundle;
+
+use Symfony\Component\HttpKernel\Bundle\Bundle;
+
+class DocumentListenerBundle extends Bundle
+{
+}

--- a/Tests/DependencyInjection/Fixtures/Bundles/DocumentListenerBundle/EventListener/TestAttributeListener.php
+++ b/Tests/DependencyInjection/Fixtures/Bundles/DocumentListenerBundle/EventListener/TestAttributeListener.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Bundle\MongoDBBundle\Tests\DependencyInjection\Fixtures\Bundles\DocumentListenerBundle\EventListener;
+
+use Doctrine\Bundle\MongoDBBundle\Attribute\AsDocumentListener;
+
+#[AsDocumentListener(event: 'prePersist', method: 'onPrePersist', lazy: true, connection: 'test')]
+class TestAttributeListener
+{
+    public function onPrePersist(): void
+    {
+    }
+}


### PR DESCRIPTION
This PR adds `AsDocumentListener` attribute which adds `doctrine_mongodb.odm.event_listener` tag to the service.

Depends on #716 as using attributes in DI requires class to be found in order to use Reflection.