### PR TITLE
fix test namespaces

### DIFF
--- a/Tests/DependencyInjection/AbstractMongoDBExtensionTest.php
+++ b/Tests/DependencyInjection/AbstractMongoDBExtensionTest.php
@@ -294,7 +294,7 @@ abstract class AbstractMongoDBExtensionTest extends TestCase
         $definition = $container->getDefinition('doctrine_mongodb.odm.default_configuration');
         $calls      = $definition->getMethodCalls();
         $this->assertTrue(isset($calls[0][1][0]['XmlBundle']));
-        $this->assertEquals('DoctrineMongoDBBundle\Tests\DependencyInjection\Fixtures\Bundles\XmlBundle\Document', $calls[0][1][0]['XmlBundle']);
+        $this->assertEquals('Doctrine\Bundle\MongoDBBundle\Tests\DependencyInjection\Fixtures\Bundles\XmlBundle\Document', $calls[0][1][0]['XmlBundle']);
     }
 
     public function testXmlBundleMappingDetection(): void
@@ -308,7 +308,7 @@ abstract class AbstractMongoDBExtensionTest extends TestCase
 
         $calls = $container->getDefinition('doctrine_mongodb.odm.default_metadata_driver')->getMethodCalls();
         $this->assertEquals('doctrine_mongodb.odm.default_xml_metadata_driver', (string) $calls[0][1][0]);
-        $this->assertEquals('DoctrineMongoDBBundle\Tests\DependencyInjection\Fixtures\Bundles\XmlBundle\Document', $calls[0][1][1]);
+        $this->assertEquals('Doctrine\Bundle\MongoDBBundle\Tests\DependencyInjection\Fixtures\Bundles\XmlBundle\Document', $calls[0][1][1]);
     }
 
     public function testNewBundleStructureXmlBundleMappingDetection(): void
@@ -326,7 +326,7 @@ abstract class AbstractMongoDBExtensionTest extends TestCase
 
         $calls = $container->getDefinition('doctrine_mongodb.odm.default_metadata_driver')->getMethodCalls();
         $this->assertEquals('doctrine_mongodb.odm.default_xml_metadata_driver', (string) $calls[0][1][0]);
-        $this->assertEquals('DoctrineMongoDBBundle\Tests\DependencyInjection\Fixtures\Bundles\NewXmlBundle\Document', $calls[0][1][1]);
+        $this->assertEquals('Doctrine\Bundle\MongoDBBundle\Tests\DependencyInjection\Fixtures\Bundles\NewXmlBundle\Document', $calls[0][1][1]);
     }
 
     public function testAnnotationsBundleMappingDetection(): void
@@ -340,7 +340,7 @@ abstract class AbstractMongoDBExtensionTest extends TestCase
 
         $calls = $container->getDefinition('doctrine_mongodb.odm.default_metadata_driver')->getMethodCalls();
         $this->assertEquals('doctrine_mongodb.odm.default_annotation_metadata_driver', (string) $calls[0][1][0]);
-        $this->assertEquals('DoctrineMongoDBBundle\Tests\DependencyInjection\Fixtures\Bundles\AnnotationsBundle\Document', $calls[0][1][1]);
+        $this->assertEquals('Doctrine\Bundle\MongoDBBundle\Tests\DependencyInjection\Fixtures\Bundles\AnnotationsBundle\Document', $calls[0][1][1]);
     }
 
     /**
@@ -361,7 +361,7 @@ abstract class AbstractMongoDBExtensionTest extends TestCase
 
         $calls = $container->getDefinition('doctrine_mongodb.odm.default_metadata_driver')->getMethodCalls();
         $this->assertEquals('doctrine_mongodb.odm.default_attribute_metadata_driver', (string) $calls[0][1][0]);
-        $this->assertEquals('DoctrineMongoDBBundle\Tests\DependencyInjection\Fixtures\Bundles\AttributesBundle\Document', $calls[0][1][1]);
+        $this->assertEquals('Doctrine\Bundle\MongoDBBundle\Tests\DependencyInjection\Fixtures\Bundles\AttributesBundle\Document', $calls[0][1][1]);
     }
 
     public function testDocumentManagerMetadataCacheDriverConfiguration(): void
@@ -586,8 +586,8 @@ abstract class AbstractMongoDBExtensionTest extends TestCase
         }
 
         return new ContainerBuilder(new ParameterBag([
-            'kernel.bundles'          => [$bundle => 'DoctrineMongoDBBundle\\Tests\\DependencyInjection\\Fixtures\\Bundles\\' . $bundle . '\\' . $bundle],
-            'kernel.bundles_metadata' => [$bundle => ['path' => $bundleDir, 'namespace' => 'DoctrineMongoDBBundle\\Tests\\DependencyInjection\\Fixtures\\Bundles\\' . $bundle]],
+            'kernel.bundles'          => [$bundle => 'Doctrine\Bundle\MongoDBBundle\Tests\DependencyInjection\Fixtures\Bundles\\' . $bundle . '\\' . $bundle],
+            'kernel.bundles_metadata' => [$bundle => ['path' => $bundleDir, 'namespace' => 'Doctrine\Bundle\MongoDBBundle\Tests\DependencyInjection\Fixtures\Bundles\\' . $bundle]],
             'kernel.cache_dir'        => __DIR__,
             'kernel.compiled_classes' => [],
             'kernel.debug'            => false,

--- a/Tests/DependencyInjection/DoctrineMongoDBExtensionTest.php
+++ b/Tests/DependencyInjection/DoctrineMongoDBExtensionTest.php
@@ -82,11 +82,11 @@ class DoctrineMongoDBExtensionTest extends TestCase
                 require_once $bundleDir . '/' . $bundle . '.php';
             }
 
-            $map[$bundle] = 'DoctrineMongoDBBundle\Tests\DependencyInjection\Fixtures\Bundles\\' . $bundle . '\\' . $bundle;
+            $map[$bundle] = 'Doctrine\Bundle\MongoDBBundle\Tests\DependencyInjection\Fixtures\Bundles\\' . $bundle . '\\' . $bundle;
 
             $metadataMap[$bundle] = [
                 'path' => $bundleDir,
-                'namespace' => 'DoctrineMongoDBBundle\Tests\DependencyInjection\Fixtures\Bundles\\' . $bundle,
+                'namespace' => 'Doctrine\Bundle\MongoDBBundle\Tests\DependencyInjection\Fixtures\Bundles\\' . $bundle,
             ];
         }
 
@@ -202,7 +202,7 @@ class DoctrineMongoDBExtensionTest extends TestCase
             [
                 'setDocumentNamespaces',
                 [
-                    ['OtherXmlBundle' => 'DoctrineMongoDBBundle\Tests\DependencyInjection\Fixtures\Bundles\OtherXmlBundle\Document'],
+                    ['OtherXmlBundle' => 'Doctrine\Bundle\MongoDBBundle\Tests\DependencyInjection\Fixtures\Bundles\OtherXmlBundle\Document'],
                 ],
             ],
             $configDm1->getMethodCalls()
@@ -212,7 +212,7 @@ class DoctrineMongoDBExtensionTest extends TestCase
             [
                 'setDocumentNamespaces',
                 [
-                    ['XmlBundle' => 'DoctrineMongoDBBundle\Tests\DependencyInjection\Fixtures\Bundles\XmlBundle\Document'],
+                    ['XmlBundle' => 'Doctrine\Bundle\MongoDBBundle\Tests\DependencyInjection\Fixtures\Bundles\XmlBundle\Document'],
                 ],
             ],
             $configDm2->getMethodCalls()
@@ -222,7 +222,7 @@ class DoctrineMongoDBExtensionTest extends TestCase
             [
                 'setDocumentNamespaces',
                 [
-                    ['NewXmlBundle' => 'DoctrineMongoDBBundle\Tests\DependencyInjection\Fixtures\Bundles\NewXmlBundle\Document'],
+                    ['NewXmlBundle' => 'Doctrine\Bundle\MongoDBBundle\Tests\DependencyInjection\Fixtures\Bundles\NewXmlBundle\Document'],
                 ],
             ],
             $configDm3->getMethodCalls()

--- a/Tests/DependencyInjection/Fixtures/Bundles/AnnotationsBundle/AnnotationsBundle.php
+++ b/Tests/DependencyInjection/Fixtures/Bundles/AnnotationsBundle/AnnotationsBundle.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace DoctrineMongoDBBundle\Tests\DependencyInjection\Fixtures\Bundles\AnnotationsBundle;
+namespace Doctrine\Bundle\MongoDBBundle\Tests\DependencyInjection\Fixtures\Bundles\AnnotationsBundle;
 
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 

--- a/Tests/DependencyInjection/Fixtures/Bundles/AnnotationsBundle/Document/Test.php
+++ b/Tests/DependencyInjection/Fixtures/Bundles/AnnotationsBundle/Document/Test.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace DoctrineMongoDBBundle\Tests\DependencyInjection\Fixtures\Bundles\AnnotationsBundle\Document;
+namespace Doctrine\Bundle\MongoDBBundle\Tests\DependencyInjection\Fixtures\Bundles\AnnotationsBundle\Document;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as MongoDB;
 

--- a/Tests/DependencyInjection/Fixtures/Bundles/AttributesBundle/AttributesBundle.php
+++ b/Tests/DependencyInjection/Fixtures/Bundles/AttributesBundle/AttributesBundle.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace DoctrineMongoDBBundle\Tests\DependencyInjection\Fixtures\Bundles\AttributesBundle;
+namespace Doctrine\Bundle\MongoDBBundle\Tests\DependencyInjection\Fixtures\Bundles\AttributesBundle;
 
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 

--- a/Tests/DependencyInjection/Fixtures/Bundles/AttributesBundle/Document/Test.php
+++ b/Tests/DependencyInjection/Fixtures/Bundles/AttributesBundle/Document/Test.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace DoctrineMongoDBBundle\Tests\DependencyInjection\Fixtures\Bundles\AttributesBundle\Document;
+namespace Doctrine\Bundle\MongoDBBundle\Tests\DependencyInjection\Fixtures\Bundles\AttributesBundle\Document;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as MongoDB;
 

--- a/Tests/DependencyInjection/Fixtures/Bundles/NewXmlBundle/src/Document/Test.php
+++ b/Tests/DependencyInjection/Fixtures/Bundles/NewXmlBundle/src/Document/Test.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace DoctrineMongoDBBundle\Tests\DependencyInjection\Fixtures\Bundles\NewXmlBundle\Document;
+namespace Doctrine\Bundle\MongoDBBundle\Tests\DependencyInjection\Fixtures\Bundles\NewXmlBundle\Document;
 
 class Test
 {

--- a/Tests/DependencyInjection/Fixtures/Bundles/NewXmlBundle/src/NewXmlBundle.php
+++ b/Tests/DependencyInjection/Fixtures/Bundles/NewXmlBundle/src/NewXmlBundle.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace DoctrineMongoDBBundle\Tests\DependencyInjection\Fixtures\Bundles\NewXmlBundle;
+namespace Doctrine\Bundle\MongoDBBundle\Tests\DependencyInjection\Fixtures\Bundles\NewXmlBundle;
 
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 

--- a/Tests/DependencyInjection/Fixtures/Bundles/OtherXmlBundle/Document/Test.php
+++ b/Tests/DependencyInjection/Fixtures/Bundles/OtherXmlBundle/Document/Test.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace DoctrineMongoDBBundle\Tests\DependencyInjection\Fixtures\Bundles\OtherXmlBundle\Document;
+namespace Doctrine\Bundle\MongoDBBundle\Tests\DependencyInjection\Fixtures\Bundles\OtherXmlBundle\Document;
 
 class Test
 {

--- a/Tests/DependencyInjection/Fixtures/Bundles/OtherXmlBundle/OtherXmlBundle.php
+++ b/Tests/DependencyInjection/Fixtures/Bundles/OtherXmlBundle/OtherXmlBundle.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace DoctrineMongoDBBundle\Tests\DependencyInjection\Fixtures\Bundles\OtherXmlBundle;
+namespace Doctrine\Bundle\MongoDBBundle\Tests\DependencyInjection\Fixtures\Bundles\OtherXmlBundle;
 
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 

--- a/Tests/DependencyInjection/Fixtures/Bundles/RepositoryServiceBundle/Document/TestCustomClassRepoDocument.php
+++ b/Tests/DependencyInjection/Fixtures/Bundles/RepositoryServiceBundle/Document/TestCustomClassRepoDocument.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace Fixtures\Bundles\RepositoryServiceBundle\Document;
+namespace Doctrine\Bundle\MongoDBBundle\Tests\DependencyInjection\Fixtures\Bundles\RepositoryServiceBundle\Document;
 
+use Doctrine\Bundle\MongoDBBundle\Tests\DependencyInjection\Fixtures\Bundles\RepositoryServiceBundle\Repository\TestCustomClassRepoRepository;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
-use Fixtures\Bundles\RepositoryServiceBundle\Repository\TestCustomClassRepoRepository;
 
 /**
  * @ODM\Document(repositoryClass=TestCustomClassRepoRepository::class)

--- a/Tests/DependencyInjection/Fixtures/Bundles/RepositoryServiceBundle/Document/TestCustomServiceRepoDocument.php
+++ b/Tests/DependencyInjection/Fixtures/Bundles/RepositoryServiceBundle/Document/TestCustomServiceRepoDocument.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace Fixtures\Bundles\RepositoryServiceBundle\Document;
+namespace Doctrine\Bundle\MongoDBBundle\Tests\DependencyInjection\Fixtures\Bundles\RepositoryServiceBundle\Document;
 
+use Doctrine\Bundle\MongoDBBundle\Tests\DependencyInjection\Fixtures\Bundles\RepositoryServiceBundle\Repository\TestCustomServiceRepoDocumentRepository;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
-use Fixtures\Bundles\RepositoryServiceBundle\Repository\TestCustomServiceRepoDocumentRepository;
 
 /**
  * @ODM\Document(repositoryClass=TestCustomServiceRepoDocumentRepository::class)

--- a/Tests/DependencyInjection/Fixtures/Bundles/RepositoryServiceBundle/Document/TestCustomServiceRepoFile.php
+++ b/Tests/DependencyInjection/Fixtures/Bundles/RepositoryServiceBundle/Document/TestCustomServiceRepoFile.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace Fixtures\Bundles\RepositoryServiceBundle\Document;
+namespace Doctrine\Bundle\MongoDBBundle\Tests\DependencyInjection\Fixtures\Bundles\RepositoryServiceBundle\Document;
 
+use Doctrine\Bundle\MongoDBBundle\Tests\DependencyInjection\Fixtures\Bundles\RepositoryServiceBundle\Repository\TestCustomServiceRepoGridFSRepository;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
-use Fixtures\Bundles\RepositoryServiceBundle\Repository\TestCustomServiceRepoGridFSRepository;
 
 /**
  * @ODM\File(repositoryClass=TestCustomServiceRepoGridFSRepository::class)

--- a/Tests/DependencyInjection/Fixtures/Bundles/RepositoryServiceBundle/Document/TestDefaultRepoDocument.php
+++ b/Tests/DependencyInjection/Fixtures/Bundles/RepositoryServiceBundle/Document/TestDefaultRepoDocument.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Fixtures\Bundles\RepositoryServiceBundle\Document;
+namespace Doctrine\Bundle\MongoDBBundle\Tests\DependencyInjection\Fixtures\Bundles\RepositoryServiceBundle\Document;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 

--- a/Tests/DependencyInjection/Fixtures/Bundles/RepositoryServiceBundle/Document/TestDefaultRepoFile.php
+++ b/Tests/DependencyInjection/Fixtures/Bundles/RepositoryServiceBundle/Document/TestDefaultRepoFile.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Fixtures\Bundles\RepositoryServiceBundle\Document;
+namespace Doctrine\Bundle\MongoDBBundle\Tests\DependencyInjection\Fixtures\Bundles\RepositoryServiceBundle\Document;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 

--- a/Tests/DependencyInjection/Fixtures/Bundles/RepositoryServiceBundle/Document/TestUnmappedDocument.php
+++ b/Tests/DependencyInjection/Fixtures/Bundles/RepositoryServiceBundle/Document/TestUnmappedDocument.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Fixtures\Bundles\RepositoryServiceBundle\Document;
+namespace Doctrine\Bundle\MongoDBBundle\Tests\DependencyInjection\Fixtures\Bundles\RepositoryServiceBundle\Document;
 
 class TestUnmappedDocument
 {

--- a/Tests/DependencyInjection/Fixtures/Bundles/RepositoryServiceBundle/Repository/TestCustomClassRepoRepository.php
+++ b/Tests/DependencyInjection/Fixtures/Bundles/RepositoryServiceBundle/Repository/TestCustomClassRepoRepository.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Fixtures\Bundles\RepositoryServiceBundle\Repository;
+namespace Doctrine\Bundle\MongoDBBundle\Tests\DependencyInjection\Fixtures\Bundles\RepositoryServiceBundle\Repository;
 
 use Doctrine\ODM\MongoDB\Repository\DocumentRepository;
 

--- a/Tests/DependencyInjection/Fixtures/Bundles/RepositoryServiceBundle/Repository/TestCustomServiceRepoDocumentRepository.php
+++ b/Tests/DependencyInjection/Fixtures/Bundles/RepositoryServiceBundle/Repository/TestCustomServiceRepoDocumentRepository.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace Fixtures\Bundles\RepositoryServiceBundle\Repository;
+namespace Doctrine\Bundle\MongoDBBundle\Tests\DependencyInjection\Fixtures\Bundles\RepositoryServiceBundle\Repository;
 
 use Doctrine\Bundle\MongoDBBundle\ManagerRegistry;
 use Doctrine\Bundle\MongoDBBundle\Repository\ServiceDocumentRepository;
-use Fixtures\Bundles\RepositoryServiceBundle\Document\TestCustomServiceRepoDocument;
+use Doctrine\Bundle\MongoDBBundle\Tests\DependencyInjection\Fixtures\Bundles\RepositoryServiceBundle\Document\TestCustomServiceRepoDocument;
 
 class TestCustomServiceRepoDocumentRepository extends ServiceDocumentRepository
 {

--- a/Tests/DependencyInjection/Fixtures/Bundles/RepositoryServiceBundle/Repository/TestCustomServiceRepoGridFSRepository.php
+++ b/Tests/DependencyInjection/Fixtures/Bundles/RepositoryServiceBundle/Repository/TestCustomServiceRepoGridFSRepository.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace Fixtures\Bundles\RepositoryServiceBundle\Repository;
+namespace Doctrine\Bundle\MongoDBBundle\Tests\DependencyInjection\Fixtures\Bundles\RepositoryServiceBundle\Repository;
 
 use Doctrine\Bundle\MongoDBBundle\ManagerRegistry;
 use Doctrine\Bundle\MongoDBBundle\Repository\ServiceDocumentRepository;
-use Fixtures\Bundles\RepositoryServiceBundle\Document\TestCustomServiceRepoFile;
+use Doctrine\Bundle\MongoDBBundle\Tests\DependencyInjection\Fixtures\Bundles\RepositoryServiceBundle\Document\TestCustomServiceRepoFile;
 
 class TestCustomServiceRepoGridFSRepository extends ServiceDocumentRepository
 {

--- a/Tests/DependencyInjection/Fixtures/Bundles/RepositoryServiceBundle/Repository/TestUnmappedDocumentRepository.php
+++ b/Tests/DependencyInjection/Fixtures/Bundles/RepositoryServiceBundle/Repository/TestUnmappedDocumentRepository.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace Fixtures\Bundles\RepositoryServiceBundle\Repository;
+namespace Doctrine\Bundle\MongoDBBundle\Tests\DependencyInjection\Fixtures\Bundles\RepositoryServiceBundle\Repository;
 
 use Doctrine\Bundle\MongoDBBundle\ManagerRegistry;
 use Doctrine\Bundle\MongoDBBundle\Repository\ServiceDocumentRepository;
-use Fixtures\Bundles\RepositoryServiceBundle\Document\TestUnmappedDocument;
+use Doctrine\Bundle\MongoDBBundle\Tests\DependencyInjection\Fixtures\Bundles\RepositoryServiceBundle\Document\TestUnmappedDocument;
 
 class TestUnmappedDocumentRepository extends ServiceDocumentRepository
 {

--- a/Tests/DependencyInjection/Fixtures/Bundles/RepositoryServiceBundle/RepositoryServiceBundle.php
+++ b/Tests/DependencyInjection/Fixtures/Bundles/RepositoryServiceBundle/RepositoryServiceBundle.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Fixtures\Bundles\RepositoryServiceBundle;
+namespace Doctrine\Bundle\MongoDBBundle\Tests\DependencyInjection\Fixtures\Bundles\RepositoryServiceBundle;
 
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 

--- a/Tests/DependencyInjection/Fixtures/Bundles/XmlBundle/Document/Test.php
+++ b/Tests/DependencyInjection/Fixtures/Bundles/XmlBundle/Document/Test.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace DoctrineMongoDBBundle\Tests\DependencyInjection\Fixtures\Bundles\XmlBundle\Document;
+namespace Doctrine\Bundle\MongoDBBundle\Tests\DependencyInjection\Fixtures\Bundles\XmlBundle\Document;
 
 class Test
 {

--- a/Tests/DependencyInjection/Fixtures/Bundles/XmlBundle/XmlBundle.php
+++ b/Tests/DependencyInjection/Fixtures/Bundles/XmlBundle/XmlBundle.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace DoctrineMongoDBBundle\Tests\DependencyInjection\Fixtures\Bundles\XmlBundle;
+namespace Doctrine\Bundle\MongoDBBundle\Tests\DependencyInjection\Fixtures\Bundles\XmlBundle;
 
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 

--- a/Tests/ServiceRepositoryTest.php
+++ b/Tests/ServiceRepositoryTest.php
@@ -6,21 +6,21 @@ namespace Doctrine\Bundle\MongoDBBundle\Tests;
 
 use Doctrine\Bundle\MongoDBBundle\DependencyInjection\Compiler\ServiceRepositoryCompilerPass;
 use Doctrine\Bundle\MongoDBBundle\DependencyInjection\DoctrineMongoDBExtension;
+use Doctrine\Bundle\MongoDBBundle\Tests\DependencyInjection\Fixtures\Bundles\RepositoryServiceBundle\Document\TestCustomClassRepoDocument;
+use Doctrine\Bundle\MongoDBBundle\Tests\DependencyInjection\Fixtures\Bundles\RepositoryServiceBundle\Document\TestCustomServiceRepoDocument;
+use Doctrine\Bundle\MongoDBBundle\Tests\DependencyInjection\Fixtures\Bundles\RepositoryServiceBundle\Document\TestCustomServiceRepoFile;
+use Doctrine\Bundle\MongoDBBundle\Tests\DependencyInjection\Fixtures\Bundles\RepositoryServiceBundle\Document\TestDefaultRepoDocument;
+use Doctrine\Bundle\MongoDBBundle\Tests\DependencyInjection\Fixtures\Bundles\RepositoryServiceBundle\Document\TestDefaultRepoFile;
+use Doctrine\Bundle\MongoDBBundle\Tests\DependencyInjection\Fixtures\Bundles\RepositoryServiceBundle\Document\TestUnmappedDocument;
+use Doctrine\Bundle\MongoDBBundle\Tests\DependencyInjection\Fixtures\Bundles\RepositoryServiceBundle\Repository\TestCustomClassRepoRepository;
+use Doctrine\Bundle\MongoDBBundle\Tests\DependencyInjection\Fixtures\Bundles\RepositoryServiceBundle\Repository\TestCustomServiceRepoDocumentRepository;
+use Doctrine\Bundle\MongoDBBundle\Tests\DependencyInjection\Fixtures\Bundles\RepositoryServiceBundle\Repository\TestCustomServiceRepoGridFSRepository;
+use Doctrine\Bundle\MongoDBBundle\Tests\DependencyInjection\Fixtures\Bundles\RepositoryServiceBundle\Repository\TestUnmappedDocumentRepository;
+use Doctrine\Bundle\MongoDBBundle\Tests\DependencyInjection\Fixtures\Bundles\RepositoryServiceBundle\RepositoryServiceBundle;
 use Doctrine\Common\Annotations\AnnotationReader;
 use Doctrine\ODM\MongoDB\Query\Builder;
 use Doctrine\ODM\MongoDB\Repository\DefaultGridFSRepository;
 use Doctrine\ODM\MongoDB\Repository\DocumentRepository;
-use Fixtures\Bundles\RepositoryServiceBundle\Document\TestCustomClassRepoDocument;
-use Fixtures\Bundles\RepositoryServiceBundle\Document\TestCustomServiceRepoDocument;
-use Fixtures\Bundles\RepositoryServiceBundle\Document\TestCustomServiceRepoFile;
-use Fixtures\Bundles\RepositoryServiceBundle\Document\TestDefaultRepoDocument;
-use Fixtures\Bundles\RepositoryServiceBundle\Document\TestDefaultRepoFile;
-use Fixtures\Bundles\RepositoryServiceBundle\Document\TestUnmappedDocument;
-use Fixtures\Bundles\RepositoryServiceBundle\Repository\TestCustomClassRepoRepository;
-use Fixtures\Bundles\RepositoryServiceBundle\Repository\TestCustomServiceRepoDocumentRepository;
-use Fixtures\Bundles\RepositoryServiceBundle\Repository\TestCustomServiceRepoGridFSRepository;
-use Fixtures\Bundles\RepositoryServiceBundle\Repository\TestUnmappedDocumentRepository;
-use Fixtures\Bundles\RepositoryServiceBundle\RepositoryServiceBundle;
 use LogicException;
 use Symfony\Component\DependencyInjection\Alias;
 use Symfony\Component\DependencyInjection\Container;
@@ -63,7 +63,7 @@ class ServiceRepositoryTest extends TestCase
                             'RepositoryServiceBundle' => [
                                 'type' => 'annotation',
                                 'dir' => __DIR__ . '/DependencyInjection/Fixtures/Bundles/RepositoryServiceBundle/Document',
-                                'prefix' => 'Fixtures\Bundles\RepositoryServiceBundle\Document',
+                                'prefix' => 'Doctrine\Bundle\MongoDBBundle\Tests\DependencyInjection\Fixtures\Bundles\RepositoryServiceBundle\Document',
                             ],
                         ],
                     ],

--- a/composer.json
+++ b/composer.json
@@ -57,7 +57,6 @@
     },
     "autoload-dev": {
         "psr-4": {
-            "": "Tests/DependencyInjection",
             "Doctrine\\Bundle\\MongoDBBundle\\Tests\\": "Tests"
         }
     },


### PR DESCRIPTION
This PR fixed invalid (non-PSR-4-compliant) namespaces in tests:

- `\DoctrineMongoDBBundle\Tests\` -> `\Doctrine\Bundle\MongoDBBundle\Tests\`
- `\Fixtures\Bundles\RepositoryServiceBundle` -> `\Doctrine\Bundle\MongoDBBundle\Tests\DependencyInjection\Fixtures\Bundles\RepositoryServiceBundle`

Root namespace autoload mapping has been removed (it was only used in `RepositoryServiceBundle` tests).