### PR TITLE
[doc] Remove Unrecognized option metadata_cache_driver under doctrine_mongodb

### DIFF
--- a/Resources/doc/config.rst
+++ b/Resources/doc/config.rst
@@ -324,7 +324,6 @@ following syntax:
             default_database: hello_%kernel.environment%
             default_connection: conn2
             default_document_manager: dm2
-            metadata_cache_driver: apc
             connections:
                 conn1:
                     server: mongodb://localhost:27017


### PR DESCRIPTION
Version: 4.4.1

https://github.com/doctrine/DoctrineMongoDBBundle/blob/4.4.x/Resources/doc/config.rst

In "Multiple Connections" uses option metadata_cache_driver under doctrine_mongodb but it is not supported,