### PR TITLE
Test stable versions

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -26,6 +26,7 @@ jobs:
           - "7.3"
           - "7.4"
           - "8.0"
+          - "8.1"
         stability:
           - "stable"
         symfony-version:
@@ -43,12 +44,13 @@ jobs:
             driver-version: "1.5.0"
             stability: "stable"
             symfony-version: "4.4.*"
-          - dependencies: "highest"
-            os: "ubuntu-20.04"
-            php-version: "8.1"
-            driver-version: "stable"
-            stability: "dev" # change to stable when laminas/laminas-code 4.5 is released
-            symfony-version: "6.0.*"
+        exclude:
+          - php-version: "7.2"
+            symfony-version: "6.0.x"
+          - php-version: "7.3"
+            symfony-version: "6.0.x"
+          - php-version: "7.4"
+            symfony-version: "6.0.x"
 
     services:
       mongodb:


### PR DESCRIPTION
`laminas/laminas-code` was released some days ago.

I've excluded some jobs to save some 🎄 since symfony 6 requires minimum php 8.