### PR TITLE
Move command name to tag attribute

### DIFF
--- a/Command/ClearMetadataCacheDoctrineODMCommand.php
+++ b/Command/ClearMetadataCacheDoctrineODMCommand.php
@@ -14,14 +14,12 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class ClearMetadataCacheDoctrineODMCommand extends MetadataCommand
 {
-    /** @var string */
-    protected static $defaultName = 'doctrine:mongodb:cache:clear-metadata';
-
     protected function configure()
     {
         parent::configure();
 
         $this
+            ->setName('doctrine:mongodb:cache:clear-metadata')
             ->setDescription('Clear all metadata cache for a document manager.')
             ->addOption('dm', null, InputOption::VALUE_OPTIONAL, 'The document manager to use for this command.')
             ->setHelp(<<<EOT

--- a/Command/CreateSchemaDoctrineODMCommand.php
+++ b/Command/CreateSchemaDoctrineODMCommand.php
@@ -15,14 +15,12 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class CreateSchemaDoctrineODMCommand extends CreateCommand
 {
-    /** @var string */
-    protected static $defaultName = 'doctrine:mongodb:schema:create';
-
     protected function configure()
     {
         parent::configure();
 
         $this
+            ->setName('doctrine:mongodb:schema:create')
             ->addOption('dm', null, InputOption::VALUE_REQUIRED, 'The document manager to use for this command.')
             ->setHelp(<<<EOT
 The <info>doctrine:mongodb:schema:create</info> command creates the default document manager's schema:

--- a/Command/DropSchemaDoctrineODMCommand.php
+++ b/Command/DropSchemaDoctrineODMCommand.php
@@ -15,14 +15,12 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class DropSchemaDoctrineODMCommand extends DropCommand
 {
-    /** @var string */
-    protected static $defaultName = 'doctrine:mongodb:schema:drop';
-
     protected function configure()
     {
         parent::configure();
 
         $this
+            ->setName('doctrine:mongodb:schema:drop')
             ->addOption('dm', null, InputOption::VALUE_REQUIRED, 'The document manager to use for this command.')
             ->setHelp(<<<EOT
 The <info>doctrine:mongodb:schema:drop</info> command drops the default document manager's schema:

--- a/Command/GenerateHydratorsDoctrineODMCommand.php
+++ b/Command/GenerateHydratorsDoctrineODMCommand.php
@@ -14,14 +14,12 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class GenerateHydratorsDoctrineODMCommand extends GenerateHydratorsCommand
 {
-    /** @var string */
-    protected static $defaultName = 'doctrine:mongodb:generate:hydrators';
-
     protected function configure()
     {
         parent::configure();
 
         $this
+            ->setName('doctrine:mongodb:generate:hydrators')
             ->addOption('dm', null, InputOption::VALUE_OPTIONAL, 'The document manager to use for this command.')
             ->setHelp(<<<EOT
 The <info>doctrine:mongodb:generate:hydrators</info> command generates hydrator classes for your documents:

--- a/Command/GenerateProxiesDoctrineODMCommand.php
+++ b/Command/GenerateProxiesDoctrineODMCommand.php
@@ -14,14 +14,12 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class GenerateProxiesDoctrineODMCommand extends GenerateProxiesCommand
 {
-    /** @var string */
-    protected static $defaultName = 'doctrine:mongodb:generate:proxies';
-
     protected function configure()
     {
         parent::configure();
 
         $this
+            ->setName('doctrine:mongodb:generate:proxies')
             ->addOption('dm', null, InputOption::VALUE_OPTIONAL, 'The document manager to use for this command.')
             ->setHelp(<<<EOT
 The <info>doctrine:mongodb:generate:proxies</info> command generates proxy classes for your default document manager:

--- a/Command/InfoDoctrineODMCommand.php
+++ b/Command/InfoDoctrineODMCommand.php
@@ -20,12 +20,10 @@ use function sprintf;
  */
 class InfoDoctrineODMCommand extends DoctrineODMCommand
 {
-    /** @var string */
-    protected static $defaultName = 'doctrine:mongodb:mapping:info';
-
     protected function configure()
     {
         $this
+            ->setName('doctrine:mongodb:mapping:info')
             ->addOption('dm', null, InputOption::VALUE_OPTIONAL, 'The document manager to use for this command.')
             ->setDescription('Show basic information about all mapped documents.')
             ->setHelp(<<<EOT

--- a/Command/LoadDataFixturesDoctrineODMCommand.php
+++ b/Command/LoadDataFixturesDoctrineODMCommand.php
@@ -27,9 +27,6 @@ use function trigger_deprecation;
  */
 class LoadDataFixturesDoctrineODMCommand extends DoctrineODMCommand
 {
-    /** @var string */
-    protected static $defaultName = 'doctrine:mongodb:fixtures:load';
-
     /** @var SymfonyFixturesLoaderInterface  */
     private $fixturesLoader;
 
@@ -51,6 +48,7 @@ class LoadDataFixturesDoctrineODMCommand extends DoctrineODMCommand
     protected function configure()
     {
         $this
+            ->setName('doctrine:mongodb:fixtures:load')
             ->setDescription('Load data fixtures to your database.')
             ->addOption('services', null, InputOption::VALUE_NONE, 'Use services as fixtures')
             ->addOption('group', null, InputOption::VALUE_IS_ARRAY | InputOption::VALUE_REQUIRED, 'Only load fixtures that belong to this group (use with --services)')

--- a/Command/QueryDoctrineODMCommand.php
+++ b/Command/QueryDoctrineODMCommand.php
@@ -14,14 +14,12 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class QueryDoctrineODMCommand extends QueryCommand
 {
-    /** @var string */
-    protected static $defaultName = 'doctrine:mongodb:query';
-
     protected function configure()
     {
         parent::configure();
 
         $this
+            ->setName('doctrine:mongodb:query')
             ->addOption('dm', null, InputOption::VALUE_OPTIONAL, 'The document manager to use for this command.');
     }
 

--- a/Command/ShardDoctrineODMCommand.php
+++ b/Command/ShardDoctrineODMCommand.php
@@ -15,14 +15,12 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class ShardDoctrineODMCommand extends ShardCommand
 {
-    /** @var string */
-    protected static $defaultName = 'doctrine:mongodb:schema:shard';
-
     protected function configure()
     {
         parent::configure();
 
         $this
+            ->setName('doctrine:mongodb:schema:shard')
             ->addOption('dm', null, InputOption::VALUE_REQUIRED, 'The document manager to use for this command.')
             ->setHelp(<<<EOT
 The <info>doctrine:mongodb:schema:shard</info> command shards collections based on their metadata:

--- a/Command/TailCursorDoctrineODMCommand.php
+++ b/Command/TailCursorDoctrineODMCommand.php
@@ -30,12 +30,10 @@ class TailCursorDoctrineODMCommand extends Command implements ContainerAwareInte
 {
     use ContainerAwareTrait;
 
-    /** @var string */
-    protected static $defaultName = 'doctrine:mongodb:tail-cursor';
-
     protected function configure()
     {
         $this
+            ->setName('doctrine:mongodb:tail-cursor')
             ->setDescription('Tails a mongodb cursor and processes the documents that come through')
             ->addArgument('document', InputArgument::REQUIRED, 'The document we are going to tail the cursor for.')
             ->addArgument('finder', InputArgument::REQUIRED, 'The repository finder method which returns the cursor to tail.')

--- a/Command/UpdateSchemaDoctrineODMCommand.php
+++ b/Command/UpdateSchemaDoctrineODMCommand.php
@@ -15,14 +15,12 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class UpdateSchemaDoctrineODMCommand extends UpdateCommand
 {
-    /** @var string */
-    protected static $defaultName = 'doctrine:mongodb:schema:update';
-
     protected function configure()
     {
         parent::configure();
 
         $this
+            ->setName('doctrine:mongodb:schema:update')
             ->addOption('dm', null, InputOption::VALUE_REQUIRED, 'The document manager to use for this command.')
             ->setHelp(<<<EOT
 The <info>doctrine:mongodb:schema:update</info> command updates the default document manager's schema:

--- a/Resources/config/mongodb.xml
+++ b/Resources/config/mongodb.xml
@@ -56,43 +56,43 @@
         <service id="%doctrine_mongodb.odm.class%" alias="doctrine_mongodb" public="false" />
 
         <service id="Doctrine\Bundle\MongoDBBundle\Command\ClearMetadataCacheDoctrineODMCommand" class="Doctrine\Bundle\MongoDBBundle\Command\ClearMetadataCacheDoctrineODMCommand">
-            <tag name="console.command"/>
+            <tag name="console.command" command="doctrine:mongodb:cache:clear-metadata"/>
         </service>
         <service id="Doctrine\Bundle\MongoDBBundle\Command\CreateSchemaDoctrineODMCommand" class="Doctrine\Bundle\MongoDBBundle\Command\CreateSchemaDoctrineODMCommand">
-            <tag name="console.command"/>
+            <tag name="console.command" command="doctrine:mongodb:schema:create"/>
         </service>
         <service id="Doctrine\Bundle\MongoDBBundle\Command\DropSchemaDoctrineODMCommand" class="Doctrine\Bundle\MongoDBBundle\Command\DropSchemaDoctrineODMCommand">
-            <tag name="console.command"/>
+            <tag name="console.command" command="doctrine:mongodb:schema:drop"/>
         </service>
         <service id="Doctrine\Bundle\MongoDBBundle\Command\GenerateHydratorsDoctrineODMCommand" class="Doctrine\Bundle\MongoDBBundle\Command\GenerateHydratorsDoctrineODMCommand">
-            <tag name="console.command"/>
+            <tag name="console.command" command="doctrine:mongodb:generate:hydrators"/>
         </service>
         <service id="Doctrine\Bundle\MongoDBBundle\Command\GenerateProxiesDoctrineODMCommand" class="Doctrine\Bundle\MongoDBBundle\Command\GenerateProxiesDoctrineODMCommand">
-            <tag name="console.command"/>
+            <tag name="console.command" command="doctrine:mongodb:generate:proxies"/>
         </service>
         <service id="Doctrine\Bundle\MongoDBBundle\Command\InfoDoctrineODMCommand" class="Doctrine\Bundle\MongoDBBundle\Command\InfoDoctrineODMCommand">
             <argument type="service" id="doctrine_mongodb"/>
 
-            <tag name="console.command"/>
+            <tag name="console.command" command="doctrine:mongodb:mapping:info"/>
         </service>
         <service id="Doctrine\Bundle\MongoDBBundle\Command\LoadDataFixturesDoctrineODMCommand" class="Doctrine\Bundle\MongoDBBundle\Command\LoadDataFixturesDoctrineODMCommand">
             <argument type="service" id="doctrine_mongodb"/>
             <argument type="service" id="kernel" on-invalid="null"/>
             <argument type="service" id="doctrine_mongodb.odm.symfony.fixtures.loader" on-invalid="null" />
 
-            <tag name="console.command"/>
+            <tag name="console.command" command="doctrine:mongodb:fixtures:load"/>
         </service>
         <service id="Doctrine\Bundle\MongoDBBundle\Command\QueryDoctrineODMCommand" class="Doctrine\Bundle\MongoDBBundle\Command\QueryDoctrineODMCommand">
-            <tag name="console.command"/>
+            <tag name="console.command" command="doctrine:mongodb:query"/>
         </service>
         <service id="Doctrine\Bundle\MongoDBBundle\Command\ShardDoctrineODMCommand" class="Doctrine\Bundle\MongoDBBundle\Command\ShardDoctrineODMCommand">
-            <tag name="console.command"/>
+            <tag name="console.command" command="doctrine:mongodb:schema:shard"/>
         </service>
         <service id="Doctrine\Bundle\MongoDBBundle\Command\TailCursorDoctrineODMCommand" class="Doctrine\Bundle\MongoDBBundle\Command\TailCursorDoctrineODMCommand">
-            <tag name="console.command"/>
+            <tag name="console.command" command="doctrine:mongodb:tail-cursor"/>
         </service>
         <service id="Doctrine\Bundle\MongoDBBundle\Command\UpdateSchemaDoctrineODMCommand" class="Doctrine\Bundle\MongoDBBundle\Command\UpdateSchemaDoctrineODMCommand">
-            <tag name="console.command"/>
+            <tag name="console.command" command="doctrine:mongodb:schema:update"/>
         </service>
 
         <!-- events -->


### PR DESCRIPTION
Closes https://github.com/doctrine/DoctrineMongoDBBundle/issues/737

This will keep [commands lazy loaded](https://symfony.com/doc/4.4/console/commands_as_services.html#lazy-loading) and prevents triggering deprecations when using Symfony 6.1