### PR TITLE
Fix mkdir() race condition

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -89,7 +89,7 @@ jobs:
           ini-values: "zend.assertions=1"
 
       - name: "Globally install symfony/flex"
-        run: "composer global require --no-progress --no-scripts --no-plugins symfony/flex"
+        run: "composer global require --no-progress --no-scripts --no-plugins symfony/flex && composer global config --no-plugins allow-plugins.symfony/flex true"
 
       - name: "Set minimum-stability to stable in Composer"
         run: "composer config minimum-stability ${{ matrix.stability }}"

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -89,7 +89,7 @@ jobs:
           ini-values: "zend.assertions=1"
 
       - name: "Globally install symfony/flex"
-        run: "composer global require --no-progress --no-scripts --no-plugins symfony/flex && composer global config --no-plugins allow-plugins.symfony/flex true"
+        run: "composer global require --no-progress --no-scripts --no-plugins symfony/flex"
 
       - name: "Set minimum-stability to stable in Composer"
         run: "composer config minimum-stability ${{ matrix.stability }}"

--- a/CacheWarmer/HydratorCacheWarmer.php
+++ b/CacheWarmer/HydratorCacheWarmer.php
@@ -17,6 +17,7 @@ use function file_exists;
 use function is_writable;
 use function mkdir;
 use function sprintf;
+use function is_dir;
 
 /**
  * The hydrator generator cache warmer generates all document hydrators.

--- a/CacheWarmer/HydratorCacheWarmer.php
+++ b/CacheWarmer/HydratorCacheWarmer.php
@@ -58,7 +58,7 @@ class HydratorCacheWarmer implements CacheWarmerInterface
         // we need the directory no matter the hydrator cache generation strategy.
         $hydratorCacheDir = (string) $this->container->getParameter('doctrine_mongodb.odm.hydrator_dir');
         if (! file_exists($hydratorCacheDir)) {
-            if (@mkdir($hydratorCacheDir, 0775, true) === false) {
+            if (@mkdir($hydratorCacheDir, 0775, true) === false && ! is_dir($hydratorCacheDir)) {
                 throw new RuntimeException(sprintf('Unable to create the Doctrine Hydrator directory (%s)', dirname($hydratorCacheDir)));
             }
         } elseif (! is_writable($hydratorCacheDir)) {

--- a/CacheWarmer/PersistentCollectionCacheWarmer.php
+++ b/CacheWarmer/PersistentCollectionCacheWarmer.php
@@ -60,7 +60,7 @@ class PersistentCollectionCacheWarmer implements CacheWarmerInterface
         // we need the directory no matter the hydrator cache generation strategy.
         $collCacheDir = (string) $this->container->getParameter('doctrine_mongodb.odm.persistent_collection_dir');
         if (! file_exists($collCacheDir)) {
-            if (@mkdir($collCacheDir, 0775, true) === false) {
+            if (@mkdir($collCacheDir, 0775, true) === false && ! is_dir($collCacheDir)) {
                 throw new RuntimeException(sprintf('Unable to create the Doctrine persistent collection directory (%s)', dirname($collCacheDir)));
             }
         } elseif (! is_writable($collCacheDir)) {

--- a/CacheWarmer/PersistentCollectionCacheWarmer.php
+++ b/CacheWarmer/PersistentCollectionCacheWarmer.php
@@ -19,6 +19,7 @@ use function in_array;
 use function is_writable;
 use function mkdir;
 use function sprintf;
+use function is_dir;
 
 /**
  * The persistent collections generator cache warmer generates all custom persistent collections.

--- a/CacheWarmer/ProxyCacheWarmer.php
+++ b/CacheWarmer/ProxyCacheWarmer.php
@@ -60,7 +60,7 @@ class ProxyCacheWarmer implements CacheWarmerInterface
         // we need the directory no matter the proxy cache generation strategy.
         $proxyCacheDir = (string) $this->container->getParameter('doctrine_mongodb.odm.proxy_dir');
         if (! file_exists($proxyCacheDir)) {
-            if (@mkdir($proxyCacheDir, 0775, true) === false) {
+            if (@mkdir($proxyCacheDir, 0775, true) === false && ! is_dir($proxyCacheDir)) {
                 throw new RuntimeException(sprintf('Unable to create the Doctrine Proxy directory (%s)', dirname($proxyCacheDir)));
             }
         } elseif (! is_writable($proxyCacheDir)) {

--- a/CacheWarmer/ProxyCacheWarmer.php
+++ b/CacheWarmer/ProxyCacheWarmer.php
@@ -19,6 +19,7 @@ use function file_exists;
 use function is_writable;
 use function mkdir;
 use function sprintf;
+use function is_dir;
 
 /**
  * The proxy generator cache warmer generates all document proxies.

--- a/DependencyInjection/Compiler/CreateHydratorDirectoryPass.php
+++ b/DependencyInjection/Compiler/CreateHydratorDirectoryPass.php
@@ -30,7 +30,7 @@ class CreateHydratorDirectoryPass implements CompilerPassInterface
         // Create document proxy directory
         $hydratorCacheDir = (string) $container->getParameter('doctrine_mongodb.odm.hydrator_dir');
         if (! is_dir($hydratorCacheDir)) {
-            if (@mkdir($hydratorCacheDir, 0775, true) === false) {
+            if (@mkdir($hydratorCacheDir, 0775, true) === false && ! is_dir($hydratorCacheDir)) {
                 throw new RuntimeException(
                     sprintf('Unable to create the Doctrine Hydrator directory (%s)', dirname($hydratorCacheDir))
                 );

--- a/DependencyInjection/Compiler/CreateProxyDirectoryPass.php
+++ b/DependencyInjection/Compiler/CreateProxyDirectoryPass.php
@@ -30,7 +30,7 @@ class CreateProxyDirectoryPass implements CompilerPassInterface
         // Create document proxy directory
         $proxyCacheDir = (string) $container->getParameter('doctrine_mongodb.odm.proxy_dir');
         if (! is_dir($proxyCacheDir)) {
-            if (@mkdir($proxyCacheDir, 0775, true) === false  && ! is_dir($proxyCacheDir)) {
+            if (@mkdir($proxyCacheDir, 0775, true) === false && ! is_dir($proxyCacheDir)) {
                 throw new RuntimeException(
                     sprintf('Unable to create the Doctrine Proxy directory (%s)', dirname($proxyCacheDir))
                 );

--- a/DependencyInjection/Compiler/CreateProxyDirectoryPass.php
+++ b/DependencyInjection/Compiler/CreateProxyDirectoryPass.php
@@ -30,7 +30,7 @@ class CreateProxyDirectoryPass implements CompilerPassInterface
         // Create document proxy directory
         $proxyCacheDir = (string) $container->getParameter('doctrine_mongodb.odm.proxy_dir');
         if (! is_dir($proxyCacheDir)) {
-            if (@mkdir($proxyCacheDir, 0775, true) === false) {
+            if (@mkdir($proxyCacheDir, 0775, true) === false  && ! is_dir($proxyCacheDir)) {
                 throw new RuntimeException(
                     sprintf('Unable to create the Doctrine Proxy directory (%s)', dirname($proxyCacheDir))
                 );

--- a/Repository/ContainerRepositoryFactory.php
+++ b/Repository/ContainerRepositoryFactory.php
@@ -24,7 +24,7 @@ use function sprintf;
  */
 final class ContainerRepositoryFactory implements RepositoryFactory
 {
-    /** @var array<string, ObjectRepository> */
+    /** @var ObjectRepository[] */
     private $managedRepositories = [];
 
     /** @var ContainerInterface|null */
@@ -89,7 +89,6 @@ final class ContainerRepositoryFactory implements RepositoryFactory
     {
         $repositoryHash = $metadata->getName() . spl_object_hash($documentManager);
         if (isset($this->managedRepositories[$repositoryHash])) {
-            /** @psalm-var ObjectRepository<T> */
             return $this->managedRepositories[$repositoryHash];
         }
 

--- a/Repository/ContainerRepositoryFactory.php
+++ b/Repository/ContainerRepositoryFactory.php
@@ -24,7 +24,7 @@ use function sprintf;
  */
 final class ContainerRepositoryFactory implements RepositoryFactory
 {
-    /** @var ObjectRepository[] */
+    /** @var array<string, ObjectRepository> */
     private $managedRepositories = [];
 
     /** @var ContainerInterface|null */
@@ -89,6 +89,7 @@ final class ContainerRepositoryFactory implements RepositoryFactory
     {
         $repositoryHash = $metadata->getName() . spl_object_hash($documentManager);
         if (isset($this->managedRepositories[$repositoryHash])) {
+            /** @psalm-var ObjectRepository<T> */
             return $this->managedRepositories[$repositoryHash];
         }
 

--- a/composer.json
+++ b/composer.json
@@ -61,6 +61,9 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true
+        }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -61,9 +61,6 @@
         }
     },
     "config": {
-        "sort-packages": true,
-        "allow-plugins": {
-            "dealerdirect/phpcodesniffer-composer-installer": true
-        }
+        "sort-packages": true
     }
 }


### PR DESCRIPTION
### Description

mkdir() race condition in cache warmers.

| Q             | A
| ------------- | ---
| Branch?       | 4.5.x
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix [Issue #744](https://github.com/doctrine/DoctrineMongoDBBundle/issues/744)
| License       | MIT
| Doc PR        |  -

The race condition is appears when several processes are attempting to create a same Doctrine Proxy/Hydrator directory which does not yet exist and `\RuntimeException` is thrown.

This PR adds an extra check `!is_dir()`.
