### PR TITLE
Fix type deprecations in command loggers

### DIFF
--- a/APM/PSRCommandLogger.php
+++ b/APM/PSRCommandLogger.php
@@ -51,7 +51,7 @@ final class PSRCommandLogger implements CommandLoggerInterface
         $this->registered = false;
     }
 
-    public function commandStarted(CommandStartedEvent $event)
+    public function commandStarted(CommandStartedEvent $event): void
     {
         if (! $this->logger) {
             return;
@@ -60,11 +60,11 @@ final class PSRCommandLogger implements CommandLoggerInterface
         $this->logger->debug($this->prefix . json_encode($event->getCommand()));
     }
 
-    public function commandSucceeded(CommandSucceededEvent $event)
+    public function commandSucceeded(CommandSucceededEvent $event): void
     {
     }
 
-    public function commandFailed(CommandFailedEvent $event)
+    public function commandFailed(CommandFailedEvent $event): void
     {
     }
 }

--- a/APM/StopwatchCommandLogger.php
+++ b/APM/StopwatchCommandLogger.php
@@ -47,7 +47,7 @@ final class StopwatchCommandLogger implements CommandLoggerInterface
         $this->registered = false;
     }
 
-    public function commandStarted(CommandStartedEvent $event)
+    public function commandStarted(CommandStartedEvent $event): void
     {
         if (! $this->stopwatch) {
             return;
@@ -56,7 +56,7 @@ final class StopwatchCommandLogger implements CommandLoggerInterface
         $this->stopwatch->start(sprintf('mongodb_%s', $event->getRequestId()), 'doctrine_mongodb');
     }
 
-    public function commandSucceeded(CommandSucceededEvent $event)
+    public function commandSucceeded(CommandSucceededEvent $event): void
     {
         if (! $this->stopwatch) {
             return;
@@ -65,7 +65,7 @@ final class StopwatchCommandLogger implements CommandLoggerInterface
         $this->stopwatch->stop(sprintf('mongodb_%s', $event->getRequestId()));
     }
 
-    public function commandFailed(CommandFailedEvent $event)
+    public function commandFailed(CommandFailedEvent $event): void
     {
         if (! $this->stopwatch) {
             return;


### PR DESCRIPTION
CommandLoggers are now fully typed (see https://github.com/mongodb/mongo-php-driver/releases/tag/1.15.0).

Fixes following issue:
>Return type of Doctrine\Bundle\MongoDBBundle\APM\StopwatchCommandLogger::commandStarted(MongoDB\Driver\Monitoring\CommandStartedEvent $event) should either be compatible with MongoDB\Driver\Monitoring\CommandSubscriber::commandStarted(MongoDB\Driver\Monitoring\CommandStartedEvent $event): void, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice

Ref: https://github.com/doctrine/mongodb-odm/pull/2485