### PR TITLE
Wire the EntityArgumentResolver

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -109,6 +109,15 @@ class Configuration implements ConfigurationInterface
                         ->scalarNode('safe')->info('Deprecated. Please use the "w" option instead.')->end()
                     ->end()
                 ->end()
+                ->arrayNode('controller_resolver')
+                    ->canBeDisabled()
+                    ->children()
+                        ->booleanNode('auto_mapping')
+                            ->defaultTrue()
+                            ->info('Set to false to disable using route placeholders as lookup criteria when the object id doesn\'t match the argument name')
+                        ->end()
+                    ->end()
+                ->end()
             ->end();
 
         return $treeBuilder;

--- a/DependencyInjection/DoctrineMongoDBExtension.php
+++ b/DependencyInjection/DoctrineMongoDBExtension.php
@@ -16,6 +16,8 @@ use Doctrine\Common\DataFixtures\Loader as DataFixturesLoader;
 use Doctrine\Common\EventSubscriber;
 use Doctrine\ODM\MongoDB\DocumentManager;
 use InvalidArgumentException;
+use Symfony\Bridge\Doctrine\ArgumentResolver\EntityValueResolver;
+use Symfony\Bridge\Doctrine\Attribute\MapEntity;
 use Symfony\Bridge\Doctrine\DependencyInjection\AbstractDoctrineExtension;
 use Symfony\Bridge\Doctrine\Messenger\DoctrineClearEntityManagerWorkerSubscriber;
 use Symfony\Component\Cache\Adapter\ApcuAdapter;
@@ -30,6 +32,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
 use Symfony\Component\Messenger\MessageBusInterface;
 
 use function array_keys;
@@ -142,6 +145,40 @@ class DoctrineMongoDBExtension extends AbstractDoctrineExtension
         }
 
         $this->loadMessengerServices($container);
+
+        // available in Symfony 6.2 and higher
+        if (! class_exists(EntityValueResolver::class)) {
+            $container->removeDefinition('doctrine_mongodb.odm.entity_value_resolver');
+            $container->removeDefinition('doctrine_mongodb.odm.entity_value_resolver.expression_language');
+        } else {
+            if (! class_exists(ExpressionLanguage::class)) {
+                $container->removeDefinition('doctrine_mongodb.odm.entity_value_resolver.expression_language');
+            }
+
+            $controllerResolverDefaults = [];
+
+            if (! $config['controller_resolver']['enabled']) {
+                $controllerResolverDefaults['disabled'] = true;
+            }
+
+            if (! $config['controller_resolver']['auto_mapping']) {
+                $controllerResolverDefaults['mapping'] = [];
+            }
+
+            if ($controllerResolverDefaults) {
+                $container->getDefinition('doctrine_mongodb.odm.entity_value_resolver')->setArgument(2, (new Definition(MapEntity::class))->setArguments([
+                    null,
+                    null,
+                    null,
+                    $controllerResolverDefaults['mapping'] ?? null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    $controllerResolverDefaults['disabled'] ?? false,
+                ]));
+            }
+        }
     }
 
     /**

--- a/Resources/config/mongodb.xml
+++ b/Resources/config/mongodb.xml
@@ -208,5 +208,13 @@
         <service id="doctrine_mongodb.odm.symfony.fixtures.loader" class="Doctrine\Bundle\MongoDBBundle\Loader\SymfonyFixturesLoader" public="false">
             <argument type="service" id="service_container" />
         </service>
+
+        <service id="doctrine_mongodb.odm.entity_value_resolver" class="Symfony\Bridge\Doctrine\ArgumentResolver\EntityValueResolver">
+            <argument type="service" id="doctrine_mongodb" />
+            <argument type="service" id="doctrine_mongodb.odm.entity_value_resolver.expression_language" on-invalid="ignore" />
+            <tag name="controller.argument_value_resolver" priority="110" />
+        </service>
+
+        <service id="doctrine_mongodb.odm.entity_value_resolver.expression_language" class="Symfony\Component\ExpressionLanguage\ExpressionLanguage" />
     </services>
 </container>

--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -49,6 +49,10 @@ class ConfigurationTest extends TestCase
             'persistent_collection_dir'      => '%kernel.cache_dir%/doctrine/odm/mongodb/PersistentCollections',
             'persistent_collection_namespace' => 'PersistentCollections',
             'types'                          => [],
+            'controller_resolver'            => [
+                'enabled'      => true,
+                'auto_mapping' => true,
+            ],
         ];
 
         $this->assertEquals($defaults, $options);
@@ -203,6 +207,10 @@ class ConfigurationTest extends TestCase
             ],
             'resolve_target_documents' => ['Foo\BarInterface' => 'Bar\FooClass'],
             'types' => [],
+            'controller_resolver' => [
+                'enabled'      => true,
+                'auto_mapping' => true,
+            ],
         ];
 
         $this->assertEquals($expected, $options);


### PR DESCRIPTION
Resolves #753

Despite "Entity" being in it's name, the `EntityValueResolver` & `#[MapEntity]` attribute work with MongoDB documents as well, it's just missing the wiring.
This PR is basically a copy of https://github.com/doctrine/DoctrineBundle/pull/1554 with some minor adjustments.