### PR TITLE
Fix Psalm job

### DIFF
--- a/Loader/SymfonyFixturesLoader.php
+++ b/Loader/SymfonyFixturesLoader.php
@@ -135,7 +135,7 @@ final class SymfonyFixturesLoader extends ContainerAwareLoader implements Symfon
     }
 
     /**
-     * @param string[] $fixtures An array of fixtures with class names as keys
+     * @param array<class-string<FixtureInterface>, FixtureInterface> $fixtures An array of fixtures with class names as keys
      */
     private function validateDependencies(array $fixtures, FixtureInterface $fixture)
     {

--- a/Tests/DependencyInjection/Fixtures/Bundles/RepositoryServiceBundle/Repository/TestCustomClassRepoRepository.php
+++ b/Tests/DependencyInjection/Fixtures/Bundles/RepositoryServiceBundle/Repository/TestCustomClassRepoRepository.php
@@ -6,6 +6,7 @@ namespace Doctrine\Bundle\MongoDBBundle\Tests\DependencyInjection\Fixtures\Bundl
 
 use Doctrine\ODM\MongoDB\Repository\DocumentRepository;
 
+/** @template-extends DocumentRepository<object> */
 class TestCustomClassRepoRepository extends DocumentRepository
 {
 }

--- a/Tests/DependencyInjection/Fixtures/Bundles/RepositoryServiceBundle/Repository/TestCustomServiceRepoDocumentRepository.php
+++ b/Tests/DependencyInjection/Fixtures/Bundles/RepositoryServiceBundle/Repository/TestCustomServiceRepoDocumentRepository.php
@@ -8,6 +8,7 @@ use Doctrine\Bundle\MongoDBBundle\ManagerRegistry;
 use Doctrine\Bundle\MongoDBBundle\Repository\ServiceDocumentRepository;
 use Doctrine\Bundle\MongoDBBundle\Tests\DependencyInjection\Fixtures\Bundles\RepositoryServiceBundle\Document\TestCustomServiceRepoDocument;
 
+/** @template-extends ServiceDocumentRepository<TestCustomServiceRepoDocument> */
 class TestCustomServiceRepoDocumentRepository extends ServiceDocumentRepository
 {
     public function __construct(ManagerRegistry $registry)

--- a/Tests/DependencyInjection/Fixtures/Bundles/RepositoryServiceBundle/Repository/TestCustomServiceRepoGridFSRepository.php
+++ b/Tests/DependencyInjection/Fixtures/Bundles/RepositoryServiceBundle/Repository/TestCustomServiceRepoGridFSRepository.php
@@ -8,6 +8,7 @@ use Doctrine\Bundle\MongoDBBundle\ManagerRegistry;
 use Doctrine\Bundle\MongoDBBundle\Repository\ServiceDocumentRepository;
 use Doctrine\Bundle\MongoDBBundle\Tests\DependencyInjection\Fixtures\Bundles\RepositoryServiceBundle\Document\TestCustomServiceRepoFile;
 
+/** @template-extends ServiceDocumentRepository<TestCustomServiceRepoFile> */
 class TestCustomServiceRepoGridFSRepository extends ServiceDocumentRepository
 {
     public function __construct(ManagerRegistry $registry)

--- a/Tests/DependencyInjection/Fixtures/Bundles/RepositoryServiceBundle/Repository/TestUnmappedDocumentRepository.php
+++ b/Tests/DependencyInjection/Fixtures/Bundles/RepositoryServiceBundle/Repository/TestUnmappedDocumentRepository.php
@@ -8,6 +8,7 @@ use Doctrine\Bundle\MongoDBBundle\ManagerRegistry;
 use Doctrine\Bundle\MongoDBBundle\Repository\ServiceDocumentRepository;
 use Doctrine\Bundle\MongoDBBundle\Tests\DependencyInjection\Fixtures\Bundles\RepositoryServiceBundle\Document\TestUnmappedDocument;
 
+/** @template-extends ServiceDocumentRepository<TestUnmappedDocument> */
 class TestUnmappedDocumentRepository extends ServiceDocumentRepository
 {
     public function __construct(ManagerRegistry $registry)

--- a/Tests/Fixtures/Cache/Collections.php
+++ b/Tests/Fixtures/Cache/Collections.php
@@ -40,10 +40,12 @@ class Collections
     public $another;
 }
 
+/** @template-extends ArrayCollection<array-key, mixed> */
 class SomeCollection extends ArrayCollection
 {
 }
 
+/** @template-extends ArrayCollection<array-key, mixed> */
 class AnotherCollection extends ArrayCollection
 {
 }

--- a/Tests/Fixtures/Repository/CustomGridFSRepository.php
+++ b/Tests/Fixtures/Repository/CustomGridFSRepository.php
@@ -6,6 +6,7 @@ namespace Doctrine\Bundle\MongoDBBundle\Tests\Fixtures\Repository;
 
 use Doctrine\ODM\MongoDB\Repository\DocumentRepository;
 
+/** @template-extends DocumentRepository<object> */
 final class CustomGridFSRepository extends DocumentRepository
 {
 }

--- a/Tests/Fixtures/Repository/CustomRepository.php
+++ b/Tests/Fixtures/Repository/CustomRepository.php
@@ -6,6 +6,7 @@ namespace Doctrine\Bundle\MongoDBBundle\Tests\Fixtures\Repository;
 
 use Doctrine\ODM\MongoDB\Repository\DocumentRepository;
 
+/** @template-extends DocumentRepository<object> */
 final class CustomRepository extends DocumentRepository
 {
 }

--- a/Tests/Repository/ContainerRepositoryFactoryTest.php
+++ b/Tests/Repository/ContainerRepositoryFactoryTest.php
@@ -171,10 +171,12 @@ class ContainerRepositoryFactoryTest extends TestCase
     }
 }
 
+/** @template-extends DocumentRepository<object> */
 class StubRepository extends DocumentRepository
 {
 }
 
+/** @template-extends DocumentRepository<object> */
 class StubServiceRepository extends DocumentRepository implements ServiceDocumentRepositoryInterface
 {
 }

--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
         "symfony/stopwatch": "^4.4|^5.3|^6.0",
         "symfony/validator": "^4.4|^5.3|^6.0",
         "symfony/yaml": "^4.3.3|^5.3|^6.0",
-        "vimeo/psalm": "^4.8"
+        "vimeo/psalm": "^4.30"
     },
     "suggest": {
         "doctrine/data-fixtures": "Load data fixtures"

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<files psalm-version="4.30.0@d0bc6e25d89f649e4f36a534f330f8bb4643dd69">
+  <file src="Command/LoadDataFixturesDoctrineODMCommand.php">
+    <UndefinedInterfaceMethod occurrences="1">
+      <code>ask</code>
+    </UndefinedInterfaceMethod>
+  </file>
+</files>

--- a/psalm.xml
+++ b/psalm.xml
@@ -5,6 +5,7 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="https://getpsalm.org/schema/config"
     xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
+    errorBaseline="psalm-baseline.xml"
 >
     <plugins>
         <pluginClass class="Psalm\SymfonyPsalmPlugin\Plugin"/>


### PR DESCRIPTION
The ignored issue is because `Command::getHelper()` changed the return type like in https://github.com/doctrine/mongodb-odm/pull/2492.

I was also trying psalm 5 and those missing templates in tests appeared.