### PR TITLE
Bump coding standard to v11

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -11,4 +11,4 @@ on:
 jobs:
   coding-standards:
     name: "Coding Standards"
-    uses: "doctrine/.github/.github/workflows/coding-standards.yml@1.2.0"
+    uses: "doctrine/.github/.github/workflows/coding-standards.yml@3.0.0"

--- a/CacheWarmer/ProxyCacheWarmer.php
+++ b/CacheWarmer/ProxyCacheWarmer.php
@@ -83,9 +83,7 @@ class ProxyCacheWarmer implements CacheWarmerInterface
         return [];
     }
 
-    /**
-     * @return ClassMetadata[]
-     */
+    /** @return ClassMetadata[] */
     private function getClassesForProxyGeneration(DocumentManager $dm)
     {
         return array_filter($dm->getMetadataFactory()->getAllMetadata(), static function (ClassMetadata $metadata) {

--- a/Command/ClearMetadataCacheDoctrineODMCommand.php
+++ b/Command/ClearMetadataCacheDoctrineODMCommand.php
@@ -22,7 +22,7 @@ class ClearMetadataCacheDoctrineODMCommand extends MetadataCommand
             ->setName('doctrine:mongodb:cache:clear-metadata')
             ->setDescription('Clear all metadata cache for a document manager.')
             ->addOption('dm', null, InputOption::VALUE_OPTIONAL, 'The document manager to use for this command.')
-            ->setHelp(<<<EOT
+            ->setHelp(<<<'EOT'
 The <info>doctrine:mongodb:cache:clear-metadata</info> command clears all metadata cache for the default document manager:
 
   <info>./app/console doctrine:mongodb:cache:clear-metadata</info>
@@ -34,9 +34,7 @@ EOT
         );
     }
 
-    /**
-     * @return int
-     */
+    /** @return int */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         DoctrineODMCommand::setApplicationDocumentManager($this->getApplication(), $input->getOption('dm'));

--- a/Command/CreateSchemaDoctrineODMCommand.php
+++ b/Command/CreateSchemaDoctrineODMCommand.php
@@ -22,7 +22,7 @@ class CreateSchemaDoctrineODMCommand extends CreateCommand
         $this
             ->setName('doctrine:mongodb:schema:create')
             ->addOption('dm', null, InputOption::VALUE_REQUIRED, 'The document manager to use for this command.')
-            ->setHelp(<<<EOT
+            ->setHelp(<<<'EOT'
 The <info>doctrine:mongodb:schema:create</info> command creates the default document manager's schema:
 
   <info>./app/console doctrine:mongodb:schema:create</info>
@@ -34,9 +34,7 @@ EOT
         );
     }
 
-    /**
-     * @return int
-     */
+    /** @return int */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         DoctrineODMCommand::setApplicationDocumentManager($this->getApplication(), $input->getOption('dm'));

--- a/Command/DoctrineODMCommand.php
+++ b/Command/DoctrineODMCommand.php
@@ -43,9 +43,7 @@ abstract class DoctrineODMCommand extends Command
         $this->managerRegistry = $registry;
     }
 
-    /**
-     * @deprecated since version 4.4
-     */
+    /** @deprecated since version 4.4 */
     public function setContainer(?ContainerInterface $container = null)
     {
         trigger_deprecation(
@@ -88,9 +86,7 @@ abstract class DoctrineODMCommand extends Command
         return $this->container;
     }
 
-    /**
-     * @param string $dmName
-     */
+    /** @param string $dmName */
     public static function setApplicationDocumentManager(Application $application, $dmName)
     {
         $dm        = $application->getKernel()->getContainer()->get('doctrine_mongodb')->getManager($dmName);

--- a/Command/DropSchemaDoctrineODMCommand.php
+++ b/Command/DropSchemaDoctrineODMCommand.php
@@ -22,7 +22,7 @@ class DropSchemaDoctrineODMCommand extends DropCommand
         $this
             ->setName('doctrine:mongodb:schema:drop')
             ->addOption('dm', null, InputOption::VALUE_REQUIRED, 'The document manager to use for this command.')
-            ->setHelp(<<<EOT
+            ->setHelp(<<<'EOT'
 The <info>doctrine:mongodb:schema:drop</info> command drops the default document manager's schema:
 
   <info>./app/console doctrine:mongodb:schema:drop</info>
@@ -34,9 +34,7 @@ EOT
         );
     }
 
-    /**
-     * @return int
-     */
+    /** @return int */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         DoctrineODMCommand::setApplicationDocumentManager($this->getApplication(), $input->getOption('dm'));

--- a/Command/GenerateHydratorsDoctrineODMCommand.php
+++ b/Command/GenerateHydratorsDoctrineODMCommand.php
@@ -21,7 +21,7 @@ class GenerateHydratorsDoctrineODMCommand extends GenerateHydratorsCommand
         $this
             ->setName('doctrine:mongodb:generate:hydrators')
             ->addOption('dm', null, InputOption::VALUE_OPTIONAL, 'The document manager to use for this command.')
-            ->setHelp(<<<EOT
+            ->setHelp(<<<'EOT'
 The <info>doctrine:mongodb:generate:hydrators</info> command generates hydrator classes for your documents:
 
   <info>./app/console doctrine:mongodb:generate:hydrators</info>
@@ -33,9 +33,7 @@ EOT
         );
     }
 
-    /**
-     * @return int
-     */
+    /** @return int */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         DoctrineODMCommand::setApplicationDocumentManager($this->getApplication(), $input->getOption('dm'));

--- a/Command/GenerateProxiesDoctrineODMCommand.php
+++ b/Command/GenerateProxiesDoctrineODMCommand.php
@@ -21,7 +21,7 @@ class GenerateProxiesDoctrineODMCommand extends GenerateProxiesCommand
         $this
             ->setName('doctrine:mongodb:generate:proxies')
             ->addOption('dm', null, InputOption::VALUE_OPTIONAL, 'The document manager to use for this command.')
-            ->setHelp(<<<EOT
+            ->setHelp(<<<'EOT'
 The <info>doctrine:mongodb:generate:proxies</info> command generates proxy classes for your default document manager:
 
   <info>./app/console doctrine:mongodb:generate:proxies</info>
@@ -33,9 +33,7 @@ EOT
         );
     }
 
-    /**
-     * @return int
-     */
+    /** @return int */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         DoctrineODMCommand::setApplicationDocumentManager($this->getApplication(), $input->getOption('dm'));

--- a/Command/InfoDoctrineODMCommand.php
+++ b/Command/InfoDoctrineODMCommand.php
@@ -26,7 +26,7 @@ class InfoDoctrineODMCommand extends DoctrineODMCommand
             ->setName('doctrine:mongodb:mapping:info')
             ->addOption('dm', null, InputOption::VALUE_OPTIONAL, 'The document manager to use for this command.')
             ->setDescription('Show basic information about all mapped documents.')
-            ->setHelp(<<<EOT
+            ->setHelp(<<<'EOT'
 The <info>doctrine:mongodb:mapping:info</info> shows basic information about which
 documents exist and possibly if their mapping information contains errors or not.
 
@@ -39,9 +39,7 @@ EOT
         );
     }
 
-    /**
-     * @return int
-     */
+    /** @return int */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $documentManagerName = $input->getOption('dm') ?

--- a/Command/LoadDataFixturesDoctrineODMCommand.php
+++ b/Command/LoadDataFixturesDoctrineODMCommand.php
@@ -37,9 +37,7 @@ class LoadDataFixturesDoctrineODMCommand extends DoctrineODMCommand
         $this->fixturesLoader = $fixturesLoader;
     }
 
-    /**
-     * @return bool
-     */
+    /** @return bool */
     public function isEnabled()
     {
         return parent::isEnabled() && class_exists(Loader::class);
@@ -54,7 +52,7 @@ class LoadDataFixturesDoctrineODMCommand extends DoctrineODMCommand
             ->addOption('group', null, InputOption::VALUE_IS_ARRAY | InputOption::VALUE_REQUIRED, 'Only load fixtures that belong to this group (use with --services)')
             ->addOption('append', null, InputOption::VALUE_NONE, 'Append the data fixtures instead of flushing the database first.')
             ->addOption('dm', null, InputOption::VALUE_REQUIRED, 'The document manager to use for this command.')
-            ->setHelp(<<<EOT
+            ->setHelp(<<<'EOT'
 The <info>doctrine:mongodb:fixtures:load</info> command loads data fixtures from your application:
 
   <info>php %command.full_name%</info>
@@ -75,9 +73,7 @@ EOT
         );
     }
 
-    /**
-     * @return int
-     */
+    /** @return int */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $dm = $this->getManagerRegistry()->getManager($input->getOption('dm'));

--- a/Command/QueryDoctrineODMCommand.php
+++ b/Command/QueryDoctrineODMCommand.php
@@ -23,9 +23,7 @@ class QueryDoctrineODMCommand extends QueryCommand
             ->addOption('dm', null, InputOption::VALUE_OPTIONAL, 'The document manager to use for this command.');
     }
 
-    /**
-     * @return int
-     */
+    /** @return int */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         DoctrineODMCommand::setApplicationDocumentManager($this->getApplication(), $input->getOption('dm'));

--- a/Command/ShardDoctrineODMCommand.php
+++ b/Command/ShardDoctrineODMCommand.php
@@ -22,7 +22,7 @@ class ShardDoctrineODMCommand extends ShardCommand
         $this
             ->setName('doctrine:mongodb:schema:shard')
             ->addOption('dm', null, InputOption::VALUE_REQUIRED, 'The document manager to use for this command.')
-            ->setHelp(<<<EOT
+            ->setHelp(<<<'EOT'
 The <info>doctrine:mongodb:schema:shard</info> command shards collections based on their metadata:
 
   <info>./app/console doctrine:mongodb:schema:shard</info>
@@ -34,9 +34,7 @@ EOT
         );
     }
 
-    /**
-     * @return int
-     */
+    /** @return int */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         DoctrineODMCommand::setApplicationDocumentManager($this->getApplication(), $input->getOption('dm'));

--- a/Command/TailCursorDoctrineODMCommand.php
+++ b/Command/TailCursorDoctrineODMCommand.php
@@ -42,9 +42,7 @@ class TailCursorDoctrineODMCommand extends Command implements ContainerAwareInte
             ->addOption('sleep-time', null, InputOption::VALUE_REQUIRED, 'The number of seconds to wait between two checks.', '10');
     }
 
-    /**
-     * @return int
-     */
+    /** @return int */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         trigger_deprecation(
@@ -109,9 +107,7 @@ class TailCursorDoctrineODMCommand extends Command implements ContainerAwareInte
         return 0;
     }
 
-    /**
-     * @return ContainerInterface
-     */
+    /** @return ContainerInterface */
     protected function getContainer()
     {
         return $this->container;

--- a/Command/UpdateSchemaDoctrineODMCommand.php
+++ b/Command/UpdateSchemaDoctrineODMCommand.php
@@ -22,7 +22,7 @@ class UpdateSchemaDoctrineODMCommand extends UpdateCommand
         $this
             ->setName('doctrine:mongodb:schema:update')
             ->addOption('dm', null, InputOption::VALUE_REQUIRED, 'The document manager to use for this command.')
-            ->setHelp(<<<EOT
+            ->setHelp(<<<'EOT'
 The <info>doctrine:mongodb:schema:update</info> command updates the default document manager's schema:
 
   <info>./app/console doctrine:mongodb:schema:update</info>
@@ -34,9 +34,7 @@ EOT
         );
     }
 
-    /**
-     * @return int
-     */
+    /** @return int */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         DoctrineODMCommand::setApplicationDocumentManager($this->getApplication(), $input->getOption('dm'));

--- a/Cursor/TailableCursorProcessorInterface.php
+++ b/Cursor/TailableCursorProcessorInterface.php
@@ -11,8 +11,6 @@ namespace Doctrine\Bundle\MongoDBBundle\Cursor;
  */
 interface TailableCursorProcessorInterface
 {
-    /**
-     * @param mixed $document
-     */
+    /** @param mixed $document */
     public function process($document);
 }

--- a/DataCollector/CommandDataCollector.php
+++ b/DataCollector/CommandDataCollector.php
@@ -74,9 +74,7 @@ class CommandDataCollector extends DataCollector
         return $this->data['time'];
     }
 
-    /**
-     * @return array<array{database: string, command: stdClass, durationMicros: int}>
-     */
+    /** @return array<array{database: string, command: stdClass, durationMicros: int}> */
     public function getCommands(): array
     {
         return $this->data['commands'];

--- a/DependencyInjection/Compiler/DoctrineMongoDBMappingsPass.php
+++ b/DependencyInjection/Compiler/DoctrineMongoDBMappingsPass.php
@@ -36,6 +36,7 @@ class DoctrineMongoDBMappingsPass extends RegisterMappingsPass
     public function __construct($driver, array $namespaces, array $managerParameters, $enabledParameter = false, array $aliasMap = [])
     {
         $managerParameters[] = 'doctrine_mongodb.odm.default_document_manager';
+
         parent::__construct(
             $driver,
             $namespaces,

--- a/DependencyInjection/DoctrineMongoDBExtension.php
+++ b/DependencyInjection/DoctrineMongoDBExtension.php
@@ -469,9 +469,7 @@ class DoctrineMongoDBExtension extends AbstractDoctrineExtension
         $odmConfigDef->addMethodCall('setDocumentNamespaces', [$this->aliasMap]);
     }
 
-    /**
-     * @param string $name
-     */
+    /** @param string $name */
     protected function getObjectManagerElementName($name): string
     {
         return 'doctrine_mongodb.odm.' . $name;
@@ -516,9 +514,7 @@ class DoctrineMongoDBExtension extends AbstractDoctrineExtension
         return 'http://symfony.com/schema/dic/doctrine/odm/mongodb';
     }
 
-    /**
-     * @return string
-     */
+    /** @return string */
     public function getXsdValidationBasePath()
     {
         return __DIR__ . '/../Resources/config/schema';

--- a/Form/ChoiceList/MongoDBQueryBuilderLoader.php
+++ b/Form/ChoiceList/MongoDBQueryBuilderLoader.php
@@ -52,9 +52,7 @@ class MongoDBQueryBuilderLoader implements EntityLoaderInterface
         $this->queryBuilder = $queryBuilder;
     }
 
-    /**
-     * @return object[]
-     */
+    /** @return object[] */
     public function getEntities(): array
     {
         return array_values($this->queryBuilder->getQuery()->execute()->toArray());

--- a/Form/DoctrineMongoDBExtension.php
+++ b/Form/DoctrineMongoDBExtension.php
@@ -22,9 +22,7 @@ class DoctrineMongoDBExtension extends AbstractExtension
         $this->registry = $registry;
     }
 
-    /**
-     * @return FormTypeInterface[]
-     */
+    /** @return FormTypeInterface[] */
     protected function loadTypes()
     {
         return [
@@ -32,9 +30,7 @@ class DoctrineMongoDBExtension extends AbstractExtension
         ];
     }
 
-    /**
-     * @return FormTypeGuesserInterface|null
-     */
+    /** @return FormTypeGuesserInterface|null */
     protected function loadTypeGuesser()
     {
         return new DoctrineMongoDBTypeGuesser($this->registry);

--- a/Loader/SymfonyFixturesLoader.php
+++ b/Loader/SymfonyFixturesLoader.php
@@ -134,9 +134,7 @@ final class SymfonyFixturesLoader extends ContainerAwareLoader implements Symfon
         }
     }
 
-    /**
-     * @param array<class-string<FixtureInterface>, FixtureInterface> $fixtures An array of fixtures with class names as keys
-     */
+    /** @param array<class-string<FixtureInterface>, FixtureInterface> $fixtures An array of fixtures with class names as keys */
     private function validateDependencies(array $fixtures, FixtureInterface $fixture)
     {
         if (! $fixture instanceof DependentFixtureInterface) {

--- a/Repository/ContainerRepositoryFactory.php
+++ b/Repository/ContainerRepositoryFactory.php
@@ -30,9 +30,7 @@ final class ContainerRepositoryFactory implements RepositoryFactory
     /** @var ContainerInterface|null */
     private $container;
 
-    /**
-     * @param ContainerInterface $container A service locator containing the repositories
-     */
+    /** @param ContainerInterface $container A service locator containing the repositories */
     public function __construct(ContainerInterface $container)
     {
         $this->container = $container;

--- a/Repository/ServiceRepositoryTrait.php
+++ b/Repository/ServiceRepositoryTrait.php
@@ -11,9 +11,7 @@ use LogicException;
 use function assert;
 use function sprintf;
 
-/**
- * @template T of object
- */
+/** @template T of object */
 trait ServiceRepositoryTrait
 {
     /**

--- a/Tests/CacheWarmer/HydratorCacheWarmerTest.php
+++ b/Tests/CacheWarmer/HydratorCacheWarmerTest.php
@@ -57,9 +57,7 @@ class HydratorCacheWarmerTest extends TestCase
         }
     }
 
-    /**
-     * @dataProvider provideWarmerNotExecuted
-     */
+    /** @dataProvider provideWarmerNotExecuted */
     public function testWarmerNotExecuted(int $autoGenerate): void
     {
         $this->container->setParameter('doctrine_mongodb.odm.auto_generate_hydrator_classes', $autoGenerate);
@@ -85,9 +83,7 @@ class HydratorCacheWarmerTest extends TestCase
         $this->assertFileDoesNotExist($filename);
     }
 
-    /**
-     * @return array<array{int}>
-     */
+    /** @return array<array{int}> */
     public function provideWarmerNotExecuted(): array
     {
         return [

--- a/Tests/CacheWarmer/PersistentCollectionCacheWarmerTest.php
+++ b/Tests/CacheWarmer/PersistentCollectionCacheWarmerTest.php
@@ -55,9 +55,7 @@ class PersistentCollectionCacheWarmerTest extends TestCase
         $this->warmer->warmUp('meh');
     }
 
-    /**
-     * @dataProvider provideWarmerNotExecuted
-     */
+    /** @dataProvider provideWarmerNotExecuted */
     public function testWarmerNotExecuted(int $autoGenerate): void
     {
         $this->container->setParameter('doctrine_mongodb.odm.auto_generate_persistent_collection_classes', $autoGenerate);

--- a/Tests/Command/CommandTestKernel.php
+++ b/Tests/Command/CommandTestKernel.php
@@ -32,9 +32,7 @@ final class CommandTestKernel extends Kernel
         ];
     }
 
-    /**
-     * @param RouteConfigurator|RouteCollectionBuilder $routes
-     */
+    /** @param RouteConfigurator|RouteCollectionBuilder $routes */
     public function configureRoutes($routes): void
     {
     }

--- a/Tests/ContainerTest.php
+++ b/Tests/ContainerTest.php
@@ -38,9 +38,7 @@ class ContainerTest extends TestCase
         $this->extension = new DoctrineMongoDBExtension();
     }
 
-    /**
-     * @dataProvider provideLoggerConfigs
-     */
+    /** @dataProvider provideLoggerConfigs */
     public function testLoggerConfig(bool $expected, array $config, bool $debug): void
     {
         $this->container->setParameter('kernel.debug', $debug);
@@ -55,9 +53,7 @@ class ContainerTest extends TestCase
         $this->container->get('doctrine_mongodb.odm.command_logger_registry');
     }
 
-    /**
-     * @return array<string, array{expected: bool, config: array, debug: bool}>
-     */
+    /** @return array<string, array{expected: bool, config: array, debug: bool}> */
     public function provideLoggerConfigs(): array
     {
         $config = ['connections' => ['default' => []]];
@@ -90,9 +86,7 @@ class ContainerTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider provideDataCollectorConfigs
-     */
+    /** @dataProvider provideDataCollectorConfigs */
     public function testDataCollectorConfig(bool $expected, array $config, bool $debug): void
     {
         $this->container->setParameter('kernel.debug', $debug);
@@ -116,9 +110,7 @@ class ContainerTest extends TestCase
         $this->container->get('doctrine_mongodb.odm.command_logger_registry');
     }
 
-    /**
-     * @return array<string, array{expected: bool, config: array, debug: bool}>
-     */
+    /** @return array<string, array{expected: bool, config: array, debug: bool}> */
     public function provideDataCollectorConfigs(): array
     {
         $config = ['connections' => ['default' => []]];

--- a/Tests/DependencyInjection/AbstractMongoDBExtensionTest.php
+++ b/Tests/DependencyInjection/AbstractMongoDBExtensionTest.php
@@ -44,9 +44,7 @@ abstract class AbstractMongoDBExtensionTest extends TestCase
 {
     abstract protected function loadFromFile(ContainerBuilder $container, string $file): void;
 
-    /**
-     * @psalm-suppress UndefinedClass this won't be necessary when removing metadata cache configuration
-     */
+    /** @psalm-suppress UndefinedClass this won't be necessary when removing metadata cache configuration */
     public function testDependencyInjectionConfigurationDefaults(): void
     {
         $container = $this->getContainer();
@@ -343,9 +341,7 @@ abstract class AbstractMongoDBExtensionTest extends TestCase
         $this->assertEquals('Doctrine\Bundle\MongoDBBundle\Tests\DependencyInjection\Fixtures\Bundles\AnnotationsBundle\Document', $calls[0][1][1]);
     }
 
-    /**
-     * @requires PHP 8.0
-     */
+    /** @requires PHP 8.0 */
     public function testAttributesBundleMappingDetection(): void
     {
         if (! class_exists(AttributeDriver::class)) {
@@ -383,9 +379,7 @@ abstract class AbstractMongoDBExtensionTest extends TestCase
         $this->assertEquals('%doctrine_mongodb.odm.cache.apc.class%', $definition->getClass());
     }
 
-    /**
-     * @psalm-suppress UndefinedClass this won't be necessary when removing metadata cache configuration
-     */
+    /** @psalm-suppress UndefinedClass this won't be necessary when removing metadata cache configuration */
     public function testDocumentManagerMemcachedMetadataCacheDriverConfiguration(): void
     {
         $container = $this->getContainer();

--- a/Tests/DependencyInjection/Compiler/CacheCompatibilityPassTest.php
+++ b/Tests/DependencyInjection/Compiler/CacheCompatibilityPassTest.php
@@ -17,9 +17,7 @@ class CacheCompatibilityPassTest extends TestCase
 {
     use ExpectDeprecationTrait;
 
-    /**
-     * @group legacy
-     */
+    /** @group legacy */
     public function testMetadataCacheConfigUsingPsr6ServiceDefinedByApplication(): void
     {
         $kernel = (new class (false) extends TestKernel {
@@ -48,9 +46,7 @@ class CacheCompatibilityPassTest extends TestCase
         self::assertTrue($kernel->isBooted());
     }
 
-    /**
-     * @group legacy
-     */
+    /** @group legacy */
     public function testMetadataCacheConfigUsingNonPsr6ServiceDefinedByApplication(): void
     {
         $this->expectDeprecation('Since doctrine/mongodb-odm-bundle 4.4: Configuring doctrine/cache is deprecated. Please update the cache service "custom_cache_service" to use a PSR-6 cache.');

--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -54,9 +54,7 @@ class ConfigurationTest extends TestCase
         $this->assertEquals($defaults, $options);
     }
 
-    /**
-     * @dataProvider provideFullConfiguration
-     */
+    /** @dataProvider provideFullConfiguration */
     public function testFullConfiguration(array $config): void
     {
         $processor     = new Processor();
@@ -210,9 +208,7 @@ class ConfigurationTest extends TestCase
         $this->assertEquals($expected, $options);
     }
 
-    /**
-     * @return array<mixed[]>
-     */
+    /** @return array<mixed[]> */
     public function provideFullConfiguration(): array
     {
         $yaml = Yaml::parse(file_get_contents(__DIR__ . '/Fixtures/config/yml/full.yml'));
@@ -244,9 +240,7 @@ class ConfigurationTest extends TestCase
         }
     }
 
-    /**
-     * @return array<mixed[]>
-     */
+    /** @return array<mixed[]> */
     public function provideMergeOptions(): array
     {
         $cases = [];
@@ -368,9 +362,7 @@ class ConfigurationTest extends TestCase
         }
     }
 
-    /**
-     * @return array<mixed[]>
-     */
+    /** @return array<mixed[]> */
     public function provideNormalizeOptions(): array
     {
         $cases = [];
@@ -517,9 +509,7 @@ class ConfigurationTest extends TestCase
         $this->assertFalse(array_key_exists('replicaSet', $processedConfig['connections']['conn1']['options']));
     }
 
-    /**
-     * @dataProvider provideExceptionConfiguration
-     */
+    /** @dataProvider provideExceptionConfiguration */
     public function testFixtureLoaderValidation(array $config): void
     {
         $processor     = new Processor();
@@ -528,9 +518,7 @@ class ConfigurationTest extends TestCase
         $processor->processConfiguration($configuration, [$config]);
     }
 
-    /**
-     * @return array<mixed[]>
-     */
+    /** @return array<mixed[]> */
     public function provideExceptionConfiguration(): array
     {
         $yaml = Yaml::parse(file_get_contents(__DIR__ . '/Fixtures/config/yml/exception.yml'));

--- a/Tests/DependencyInjection/Fixtures/Bundles/RepositoryServiceBundle/Document/TestCustomServiceRepoFile.php
+++ b/Tests/DependencyInjection/Fixtures/Bundles/RepositoryServiceBundle/Document/TestCustomServiceRepoFile.php
@@ -7,9 +7,7 @@ namespace Doctrine\Bundle\MongoDBBundle\Tests\DependencyInjection\Fixtures\Bundl
 use Doctrine\Bundle\MongoDBBundle\Tests\DependencyInjection\Fixtures\Bundles\RepositoryServiceBundle\Repository\TestCustomServiceRepoGridFSRepository;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
-/**
- * @ODM\File(repositoryClass=TestCustomServiceRepoGridFSRepository::class)
- */
+/** @ODM\File(repositoryClass=TestCustomServiceRepoGridFSRepository::class) */
 class TestCustomServiceRepoFile
 {
     /**

--- a/Tests/DependencyInjection/Fixtures/Bundles/RepositoryServiceBundle/Document/TestDefaultRepoFile.php
+++ b/Tests/DependencyInjection/Fixtures/Bundles/RepositoryServiceBundle/Document/TestDefaultRepoFile.php
@@ -6,9 +6,7 @@ namespace Doctrine\Bundle\MongoDBBundle\Tests\DependencyInjection\Fixtures\Bundl
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
-/**
- * @ODM\File
- */
+/** @ODM\File */
 class TestDefaultRepoFile
 {
     /**

--- a/Tests/FixtureIntegrationTest.php
+++ b/Tests/FixtureIntegrationTest.php
@@ -290,6 +290,7 @@ class IntegrationTestKernel extends Kernel
     public function __construct(string $environment, bool $debug)
     {
         $this->randomKey = uniqid('');
+
         parent::__construct($environment, $debug);
     }
 
@@ -307,9 +308,7 @@ class IntegrationTestKernel extends Kernel
         ];
     }
 
-    /**
-     * @return void
-     */
+    /** @return void */
     protected function build(ContainerBuilder $container)
     {
         $container->prependExtensionConfig('doctrine_mongodb', [
@@ -323,9 +322,7 @@ class IntegrationTestKernel extends Kernel
         $this->servicesCallback = $callback;
     }
 
-    /**
-     * @param RouteConfigurator|RouteCollectionBuilder $routes
-     */
+    /** @param RouteConfigurator|RouteCollectionBuilder $routes */
     protected function configureRoutes($routes): void
     {
     }

--- a/Tests/Fixtures/FooBundle/DataFixtures/RequiredConstructorArgsFixtures.php
+++ b/Tests/Fixtures/FooBundle/DataFixtures/RequiredConstructorArgsFixtures.php
@@ -9,9 +9,7 @@ use Doctrine\Persistence\ObjectManager;
 
 class RequiredConstructorArgsFixtures implements ODMFixtureInterface
 {
-    /**
-     * @param mixed $fooRequiredArg
-     */
+    /** @param mixed $fooRequiredArg */
     public function __construct($fooRequiredArg)
     {
     }

--- a/Tests/Fixtures/Form/Guesser.php
+++ b/Tests/Fixtures/Form/Guesser.php
@@ -9,9 +9,7 @@ use Doctrine\Common\Collections\Collection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use MongoDB\BSON\ObjectId;
 
-/**
- * @ODM\Document
- */
+/** @ODM\Document */
 class Guesser
 {
     /**

--- a/Tests/Form/Type/DocumentTypeTest.php
+++ b/Tests/Form/Type/DocumentTypeTest.php
@@ -116,9 +116,7 @@ class DocumentTypeTest extends TypeTestCase
         $this->assertFalse($form->get('categories')->get('1')->createView()->vars['checked']);
     }
 
-    /**
-     * @return MockObject&ManagerRegistry
-     */
+    /** @return MockObject&ManagerRegistry */
     protected function createRegistryMock(string $name, DocumentManager $dm): MockObject
     {
         $registry = $this->createMock(ManagerRegistry::class);
@@ -130,9 +128,7 @@ class DocumentTypeTest extends TypeTestCase
         return $registry;
     }
 
-    /**
-     * @return FormExtensionInterface[]
-     */
+    /** @return FormExtensionInterface[] */
     protected function getExtensions()
     {
         return array_merge(parent::getExtensions(), [

--- a/Tests/Form/Type/GuesserTestType.php
+++ b/Tests/Form/Type/GuesserTestType.php
@@ -11,9 +11,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class GuesserTestType extends AbstractType
 {
-    /**
-     * @return void
-     */
+    /** @return void */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
@@ -28,9 +26,7 @@ class GuesserTestType extends AbstractType
             ->add('nonMappedField');
     }
 
-    /**
-     * @return void
-     */
+    /** @return void */
     public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults([

--- a/Tests/Form/Type/TypeGuesserTest.php
+++ b/Tests/Form/Type/TypeGuesserTest.php
@@ -51,9 +51,7 @@ class TypeGuesserTest extends TypeTestCase
         parent::tearDown();
     }
 
-    /**
-     * @group legacy
-     */
+    /** @group legacy */
     public function testTypesShouldBeGuessedCorrectly(): void
     {
         $form = $this->factory->create(GuesserTestType::class, null, ['dm' => $this->dm]);
@@ -73,9 +71,7 @@ class TypeGuesserTest extends TypeTestCase
         $this->assertEquals($type, $form->getConfig()->getType()->getBlockPrefix());
     }
 
-    /**
-     * @return MockObject&ManagerRegistry
-     */
+    /** @return MockObject&ManagerRegistry */
     protected function createRegistryMock(string $name, DocumentManager $dm): MockObject
     {
         $registry = $this->createMock(ManagerRegistry::class);
@@ -90,9 +86,7 @@ class TypeGuesserTest extends TypeTestCase
         return $registry;
     }
 
-    /**
-     * @return FormExtensionInterface[]
-     */
+    /** @return FormExtensionInterface[] */
     protected function getExtensions()
     {
         return array_merge(parent::getExtensions(), [

--- a/Tests/Mapping/Driver/XmlDriverTest.php
+++ b/Tests/Mapping/Driver/XmlDriverTest.php
@@ -8,25 +8,19 @@ use Doctrine\Bundle\MongoDBBundle\Mapping\Driver\XmlDriver;
 
 class XmlDriverTest extends AbstractDriverTest
 {
-    /**
-     * @return string
-     */
+    /** @return string */
     protected function getFileExtension()
     {
         return '.mongodb.xml';
     }
 
-    /**
-     * @return string
-     */
+    /** @return string */
     protected function getFixtureDir()
     {
         return __DIR__ . '/Fixtures/xml';
     }
 
-    /**
-     * @return XmlDriver
-     */
+    /** @return XmlDriver */
     protected function getDriver(array $paths = [])
     {
         return new XmlDriver($paths, $this->getFileExtension());

--- a/Tests/Repository/ContainerRepositoryFactoryTest.php
+++ b/Tests/Repository/ContainerRepositoryFactoryTest.php
@@ -116,9 +116,7 @@ class ContainerRepositoryFactoryTest extends TestCase
         $factory->getRepository($dm, CoolDocument::class);
     }
 
-    /**
-     * @return MockObject|ContainerInterface
-     */
+    /** @return MockObject|ContainerInterface */
     private function createContainer(array $services)
     {
         $container = $this->getMockBuilder(ContainerInterface::class)->getMock();
@@ -136,9 +134,7 @@ class ContainerRepositoryFactoryTest extends TestCase
         return $container;
     }
 
-    /**
-     * @return MockObject|DocumentManager
-     */
+    /** @return MockObject|DocumentManager */
     private function createDocumentManager(array $documentRepositoryClasses)
     {
         $classMetadatas = [];

--- a/Tests/TestCase.php
+++ b/Tests/TestCase.php
@@ -15,9 +15,7 @@ use function sys_get_temp_dir;
 
 class TestCase extends BaseTestCase
 {
-    /**
-     * @param string[] $paths
-     */
+    /** @param string[] $paths */
     public static function createTestDocumentManager(array $paths = []): DocumentManager
     {
         $config = new Configuration();

--- a/composer.json
+++ b/composer.json
@@ -31,9 +31,9 @@
         "doctrine/data-fixtures": "<1.3"
     },
     "require-dev": {
-        "doctrine/coding-standard": "^9.0",
+        "doctrine/coding-standard": "^11.0",
         "doctrine/data-fixtures": "^1.3",
-        "phpunit/phpunit": "^8.5 || ^9.3",
+        "phpunit/phpunit": "^8.5.16 || ^9.3",
         "psalm/plugin-symfony": "^3.0",
         "squizlabs/php_codesniffer": "^3.5",
         "symfony/form": "^4.3.3|^5.0|^6.0",

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -9,6 +9,8 @@
     <!-- Ignore warnings and show progress of the run -->
     <arg value="np"/>
 
+    <config name="php_version" value="70200"/>
+
     <file>.</file>
 
     <exclude-pattern>vendor/*</exclude-pattern>
@@ -40,5 +42,12 @@
 
     <rule ref="Squiz.Classes.ClassFileName.NoMatch">
         <exclude-pattern>Tests/*</exclude-pattern>
+    </rule>
+
+    <!-- Disabled to allow Symfony to detect mapping, see https://github.com/symfony/symfony/pull/48896 -->
+    <rule ref="SlevomatCodingStandard.Commenting.RequireOneLineDocComment">
+        <exclude-pattern>Tests/Fixtures/CommandBundle/Document/*</exclude-pattern>
+        <exclude-pattern>Tests/DependencyInjection/Fixtures/Bundles/RepositoryServiceBundle/Document/*</exclude-pattern>
+        <exclude-pattern>Tests/DependencyInjection/Fixtures/Bundles/AnnotationsBundle/Document/*</exclude-pattern>
     </rule>
 </ruleset>


### PR DESCRIPTION
Use the latest `doctrine/coding-standard` version ([it supports `"php": "^7.2 || ^8.0"`](https://github.com/doctrine/coding-standard/blob/eec72ad87d3d5d2e8f2aefb58b3880f019b88a7e/composer.json#L25))