### PR TITLE
Fix some issues in `DoctrineMongoDBTypeGuesser`

### DIFF
--- a/Form/DoctrineMongoDBTypeGuesser.php
+++ b/Form/DoctrineMongoDBTypeGuesser.php
@@ -48,13 +48,13 @@ class DoctrineMongoDBTypeGuesser implements FormTypeGuesserInterface
     {
         $ret = $this->getMetadata($class);
         if (! $ret) {
-            return;
+            return null;
         }
 
         [$metadata, $name] = $ret;
 
         if (! $metadata->hasField($property)) {
-            return;
+            return null;
         }
 
         if ($metadata->hasAssociation($property)) {
@@ -143,6 +143,8 @@ class DoctrineMongoDBTypeGuesser implements FormTypeGuesserInterface
                 Guess::MEDIUM_CONFIDENCE
             );
         }
+
+        return null;
     }
 
     /**
@@ -155,7 +157,7 @@ class DoctrineMongoDBTypeGuesser implements FormTypeGuesserInterface
     {
         $ret = $this->getMetadata($class);
         if (! $ret || ! $ret[0]->hasField($property) || $ret[0]->hasAssociation($property)) {
-            return;
+            return null;
         }
 
         $mapping = $ret[0]->getFieldMapping($property);
@@ -167,6 +169,8 @@ class DoctrineMongoDBTypeGuesser implements FormTypeGuesserInterface
         if ($mapping['type'] === Type::FLOAT) {
             return new ValueGuess(null, Guess::MEDIUM_CONFIDENCE);
         }
+
+        return null;
     }
 
     /**
@@ -186,7 +190,7 @@ class DoctrineMongoDBTypeGuesser implements FormTypeGuesserInterface
     {
         $ret = $this->getMetadata($class);
         if (! $ret || ! $ret[0]->hasField($property) || $ret[0]->hasAssociation($property)) {
-            return;
+            return null;
         }
 
         $mapping = $ret[0]->getFieldMapping($property);
@@ -194,6 +198,8 @@ class DoctrineMongoDBTypeGuesser implements FormTypeGuesserInterface
         if ($mapping['type'] === Type::FLOAT) {
             return new ValueGuess(null, Guess::MEDIUM_CONFIDENCE);
         }
+
+        return null;
     }
 
     /**
@@ -215,5 +221,7 @@ class DoctrineMongoDBTypeGuesser implements FormTypeGuesserInterface
                 // not an entity or mapped super class
             }
         }
+
+        return null;
     }
 }

--- a/Form/DoctrineMongoDBTypeGuesser.php
+++ b/Form/DoctrineMongoDBTypeGuesser.php
@@ -155,21 +155,6 @@ class DoctrineMongoDBTypeGuesser implements FormTypeGuesserInterface
      */
     public function guessMaxLength($class, $property)
     {
-        $ret = $this->getMetadata($class);
-        if (! $ret || ! $ret[0]->hasField($property) || $ret[0]->hasAssociation($property)) {
-            return null;
-        }
-
-        $mapping = $ret[0]->getFieldMapping($property);
-
-        if (isset($mapping['length'])) {
-            return new ValueGuess($mapping['length'], Guess::HIGH_CONFIDENCE);
-        }
-
-        if ($mapping['type'] === Type::FLOAT) {
-            return new ValueGuess(null, Guess::MEDIUM_CONFIDENCE);
-        }
-
         return null;
     }
 

--- a/Form/DoctrineMongoDBTypeGuesser.php
+++ b/Form/DoctrineMongoDBTypeGuesser.php
@@ -6,6 +6,7 @@ namespace Doctrine\Bundle\MongoDBBundle\Form;
 
 use Doctrine\Bundle\MongoDBBundle\Form\Type\DocumentType;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
+use Doctrine\ODM\MongoDB\Types\Type;
 use Doctrine\Persistence\ManagerRegistry;
 use Doctrine\Persistence\Mapping\MappingException;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
@@ -73,45 +74,45 @@ class DoctrineMongoDBTypeGuesser implements FormTypeGuesserInterface
 
         $fieldMapping = $metadata->getFieldMapping($property);
         switch ($fieldMapping['type']) {
-            case 'collection':
+            case Type::COLLECTION:
                 return new TypeGuess(
                     CollectionType::class,
                     [],
                     Guess::MEDIUM_CONFIDENCE
                 );
 
-            case 'bool':
-            case 'boolean':
+            case Type::BOOL:
+            case Type::BOOLEAN:
                 return new TypeGuess(
                     CheckboxType::class,
                     [],
                     Guess::HIGH_CONFIDENCE
                 );
 
-            case 'date':
-            case 'timestamp':
+            case Type::DATE:
+            case Type::TIMESTAMP:
                 return new TypeGuess(
                     DateTimeType::class,
                     [],
                     Guess::HIGH_CONFIDENCE
                 );
 
-            case 'float':
+            case Type::FLOAT:
                 return new TypeGuess(
                     NumberType::class,
                     [],
                     Guess::MEDIUM_CONFIDENCE
                 );
 
-            case 'int':
-            case 'integer':
+            case Type::INT:
+            case Type::INTEGER:
                 return new TypeGuess(
                     IntegerType::class,
                     [],
                     Guess::MEDIUM_CONFIDENCE
                 );
 
-            case 'string':
+            case Type::STRING:
                 return new TypeGuess(
                     TextType::class,
                     [],
@@ -163,7 +164,7 @@ class DoctrineMongoDBTypeGuesser implements FormTypeGuesserInterface
             return new ValueGuess($mapping['length'], Guess::HIGH_CONFIDENCE);
         }
 
-        if ($mapping['type'] === 'float') {
+        if ($mapping['type'] === Type::FLOAT) {
             return new ValueGuess(null, Guess::MEDIUM_CONFIDENCE);
         }
     }
@@ -190,7 +191,7 @@ class DoctrineMongoDBTypeGuesser implements FormTypeGuesserInterface
 
         $mapping = $ret[0]->getFieldMapping($property);
 
-        if ($mapping['type'] === 'float') {
+        if ($mapping['type'] === Type::FLOAT) {
             return new ValueGuess(null, Guess::MEDIUM_CONFIDENCE);
         }
     }


### PR DESCRIPTION
When trying psalm 5, it complains about an invalid array offset in `mapping['length']`, so I was going to remove it and found some other things to do in the class.