### PR TITLE
Avoid deprecations in tests using Symfony >= 6.1

### DIFF
--- a/Tests/Command/CommandTestKernel.php
+++ b/Tests/Command/CommandTestKernel.php
@@ -44,6 +44,7 @@ final class CommandTestKernel extends Kernel
         $container->loadFromExtension('framework', [
             'secret' => 'foo',
             'router' => ['utf8' => false],
+            'http_method_override' => false,
         ]);
 
         $container->loadFromExtension('doctrine_mongodb', [

--- a/Tests/FixtureIntegrationTest.php
+++ b/Tests/FixtureIntegrationTest.php
@@ -335,6 +335,7 @@ class IntegrationTestKernel extends Kernel
         $c->loadFromExtension('framework', [
             'secret' => 'foo',
             'router' => ['utf8' => false],
+            'http_method_override' => false,
         ]);
 
         $callback = $this->servicesCallback;

--- a/Tests/Fixtures/Form/Category.php
+++ b/Tests/Fixtures/Form/Category.php
@@ -42,12 +42,7 @@ class Category
         $this->documents = new ArrayCollection();
     }
 
-    /**
-     * Converts to string
-     *
-     * @return string
-     **/
-    public function __toString()
+    public function __toString(): string
     {
         return $this->name;
     }

--- a/Tests/Fixtures/Form/Document.php
+++ b/Tests/Fixtures/Form/Document.php
@@ -44,12 +44,7 @@ class Document
         $this->categories = new ArrayCollection();
     }
 
-    /**
-     * Converts to string
-     *
-     * @return string
-     **/
-    public function __toString()
+    public function __toString(): string
     {
         return $this->name;
     }

--- a/Tests/Form/Type/GuesserTestType.php
+++ b/Tests/Form/Type/GuesserTestType.php
@@ -11,10 +11,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class GuesserTestType extends AbstractType
 {
-    /**
-     * @return void
-     */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('name')
@@ -28,20 +25,14 @@ class GuesserTestType extends AbstractType
             ->add('nonMappedField');
     }
 
-    /**
-     * @return void
-     */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'data_class' => Guesser::class,
         ])->setRequired('dm');
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'guesser_test';
     }


### PR DESCRIPTION
Seen in https://github.com/doctrine/DoctrineMongoDBBundle/actions/runs/3854144822/jobs/6567819681#step:10:29

I can extract the second commit in another PR if necessary.