### PR TITLE
Drop support of PHP < 7.4

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -22,8 +22,6 @@ jobs:
         os:
           - "ubuntu-20.04"
         php-version:
-          - "7.2"
-          - "7.3"
           - "7.4"
           - "8.0"
           - "8.1"
@@ -41,15 +39,11 @@ jobs:
         include:
           - dependencies: "lowest"
             os: "ubuntu-20.04"
-            php-version: "7.2"
+            php-version: "7.4"
             driver-version: "1.5.0"
             stability: "stable"
             symfony-version: "4.4.*"
         exclude:
-          - php-version: "7.2"
-            symfony-version: "6.0.x"
-          - php-version: "7.3"
-            symfony-version: "6.0.x"
           - php-version: "7.4"
             symfony-version: "6.0.x"
 

--- a/README.markdown
+++ b/README.markdown
@@ -13,7 +13,7 @@ Compatibility
 =============
 
 The current version of this bundle has the following requirements:
- * PHP 7.2 or newer is required
+ * PHP 7.4 or newer is required
  * `ext-mongodb` 1.5 or newer
  * Symfony 4.3 or newer is required
 

--- a/UPGRADE-4.4.md
+++ b/UPGRADE-4.4.md
@@ -1,4 +1,4 @@
-UPGRADE FROM 4.x to 4.4
+UPGRADE FROM 4.0 to 4.4
 =======================
 
 * The `doctrine:mongodb:tail-cursor` command and

--- a/UPGRADE-4.6.md
+++ b/UPGRADE-4.6.md
@@ -1,0 +1,7 @@
+UPGRADE FROM 4.4 to 4.6
+=======================
+
+## PHP requirements
+
+* The bundle now requires PHP 7.4 or newer. If you're not running PHP 7.4 yet,
+  it's recommended that you upgrade to PHP 7.4 before upgrading the bundle.

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         {"name": "Jonathan H. Wage", "email": "jonwage@gmail.com"}
     ],
     "require": {
-        "php": "^7.2 || ^8.0",
+        "php": "^7.4 || ^8.0",
         "ext-mongodb": "^1.5",
         "doctrine/annotations": "^1.13",
         "doctrine/mongodb-odm": "^2.3",
@@ -33,7 +33,7 @@
     "require-dev": {
         "doctrine/coding-standard": "^11.0",
         "doctrine/data-fixtures": "^1.3",
-        "phpunit/phpunit": "^8.5.16 || ^9.3",
+        "phpunit/phpunit": "^9.5.5",
         "psalm/plugin-symfony": "^3.0",
         "squizlabs/php_codesniffer": "^3.5",
         "symfony/form": "^4.3.3|^5.0|^6.0",


### PR DESCRIPTION
As we did it [in the ODM](https://github.com/doctrine/mongodb-odm/pull/2466) I think we can do the same for the `4.6.0` release.