### PR TITLE
Update to psalm 5

### DIFF
--- a/CacheWarmer/PersistentCollectionCacheWarmer.php
+++ b/CacheWarmer/PersistentCollectionCacheWarmer.php
@@ -6,7 +6,6 @@ namespace Doctrine\Bundle\MongoDBBundle\CacheWarmer;
 
 use Doctrine\ODM\MongoDB\Configuration;
 use Doctrine\ODM\MongoDB\DocumentManager;
-use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
 use Doctrine\Persistence\ManagerRegistry;
 use RuntimeException;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -81,7 +80,6 @@ class PersistentCollectionCacheWarmer implements CacheWarmerInterface
             $collectionGenerator = $dm->getConfiguration()->getPersistentCollectionGenerator();
             $classes             = $dm->getMetadataFactory()->getAllMetadata();
             foreach ($classes as $metadata) {
-                assert($metadata instanceof ClassMetadata);
                 foreach ($metadata->getAssociationNames() as $fieldName) {
                     $mapping = $metadata->getFieldMapping($fieldName);
                     if (empty($mapping['collectionClass']) || in_array($mapping['collectionClass'], $generated)) {

--- a/Form/Type/DocumentType.php
+++ b/Form/Type/DocumentType.php
@@ -8,6 +8,7 @@ use Doctrine\Bundle\MongoDBBundle\Form\ChoiceList\MongoDBQueryBuilderLoader;
 use Doctrine\ODM\MongoDB\DocumentManager;
 use Doctrine\Persistence\ObjectManager;
 use InvalidArgumentException;
+use ReturnTypeWillChange;
 use Symfony\Bridge\Doctrine\Form\ChoiceList\EntityLoaderInterface;
 use Symfony\Bridge\Doctrine\Form\Type\DoctrineType;
 use Symfony\Component\OptionsResolver\Options;
@@ -67,9 +68,8 @@ class DocumentType extends DoctrineType
      * @internal Symfony 2.8 compatibility
      *
      * @return string
-     *
-     * @inheritdoc
      */
+    #[ReturnTypeWillChange]
     public function getBlockPrefix()
     {
         return 'document';
@@ -79,8 +79,6 @@ class DocumentType extends DoctrineType
      * @internal Symfony 2.7 compatibility
      *
      * @return string
-     *
-     * @inheritdoc
      */
     public function getName()
     {

--- a/Repository/ServiceGridFSRepository.php
+++ b/Repository/ServiceGridFSRepository.php
@@ -19,8 +19,12 @@ use Doctrine\ODM\MongoDB\Repository\DefaultGridFSRepository;
  *         parent::__construct($registry, YourDocument::class);
  *     }
  * }
+ *
+ * @template TDocument of object
+ * @template-extends DefaultGridFSRepository<TDocument>
  */
 class ServiceGridFSRepository extends DefaultGridFSRepository implements ServiceDocumentRepositoryInterface
 {
+    /** @use ServiceRepositoryTrait<TDocument> */
     use ServiceRepositoryTrait;
 }

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
         "doctrine/coding-standard": "^11.0",
         "doctrine/data-fixtures": "^1.3",
         "phpunit/phpunit": "^9.5.5",
-        "psalm/plugin-symfony": "^3.0",
+        "psalm/plugin-symfony": "^5.0",
         "squizlabs/php_codesniffer": "^3.5",
         "symfony/form": "^4.3.3|^5.0|^6.0",
         "symfony/phpunit-bridge": "^6.0",
@@ -42,7 +42,7 @@
         "symfony/stopwatch": "^4.4|^5.3|^6.0",
         "symfony/validator": "^4.4|^5.3|^6.0",
         "symfony/yaml": "^4.3.3|^5.3|^6.0",
-        "vimeo/psalm": "^4.30"
+        "vimeo/psalm": "^5.6"
     },
     "suggest": {
         "doctrine/data-fixtures": "Load data fixtures"

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,8 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="4.30.0@d0bc6e25d89f649e4f36a534f330f8bb4643dd69">
+<files psalm-version="5.6.0@e784128902dfe01d489c4123d69918a9f3c1eac5">
   <file src="Command/LoadDataFixturesDoctrineODMCommand.php">
-    <UndefinedInterfaceMethod occurrences="1">
+    <UndefinedInterfaceMethod>
       <code>ask</code>
     </UndefinedInterfaceMethod>
+  </file>
+  <file src="Command/TailCursorDoctrineODMCommand.php">
+    <InvalidReturnType>
+      <code>int</code>
+    </InvalidReturnType>
+  </file>
+  <file src="Tests/Form/Type/GuesserTestType.php">
+    <MissingTemplateParam>
+      <code>GuesserTestType</code>
+    </MissingTemplateParam>
   </file>
 </files>

--- a/psalm.xml
+++ b/psalm.xml
@@ -6,6 +6,8 @@
     xmlns="https://getpsalm.org/schema/config"
     xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
     errorBaseline="psalm-baseline.xml"
+    findUnusedBaselineEntry="true"
+    findUnusedCode="false"
 >
     <plugins>
         <pluginClass class="Psalm\SymfonyPsalmPlugin\Plugin"/>


### PR DESCRIPTION
I've targeted 4.6.x because the template added to `ServiceGridFSRepository`.

The ignored errors are because 
 - a `while(true)` in `Command/TailCursorDoctrineODMCommand.php` which psalm thinks that the return type must be `never`.
 ~- In `ContainerRepositoryFactory`, there is a `$customRepositoryName` variable that with type `class-string|null` and when doing `if (! class_exists($customRepositoryName))` after `if ($customRepositoryName !== null)`, psalm says `All possible types for this argument were invalidated`.~
 - psalm/symfony-plugin added generics to `AbstractType` [which seems not accurate](https://github.com/symfony/symfony/pull/40783#issuecomment-953098461), so we better don't use them.

psalm/symfony-plugin 5 requires php `7.4`, so we need https://github.com/doctrine/DoctrineMongoDBBundle/pull/763 or remove this dependency if it's not really useful (it will if we pass a path to the compiled container in XML).