### PR TITLE
Use typed properties

### DIFF
--- a/APM/CommandLoggerRegistry.php
+++ b/APM/CommandLoggerRegistry.php
@@ -11,7 +11,7 @@ use function array_map;
 final class CommandLoggerRegistry
 {
     /** @var CommandLoggerInterface[] */
-    private $commandLoggers = [];
+    private array $commandLoggers = [];
 
     public function __construct(iterable $commandLoggers)
     {

--- a/APM/PSRCommandLogger.php
+++ b/APM/PSRCommandLogger.php
@@ -16,14 +16,11 @@ use function MongoDB\Driver\Monitoring\removeSubscriber;
 
 final class PSRCommandLogger implements CommandLoggerInterface
 {
-    /** @var bool */
-    private $registered = false;
+    private bool $registered = false;
 
-    /** @var LoggerInterface|null */
-    private $logger;
+    private ?LoggerInterface $logger;
 
-    /** @var string */
-    private $prefix;
+    private string $prefix;
 
     public function __construct(?LoggerInterface $logger, string $prefix = 'MongoDB command: ')
     {

--- a/APM/StopwatchCommandLogger.php
+++ b/APM/StopwatchCommandLogger.php
@@ -16,11 +16,9 @@ use function sprintf;
 
 final class StopwatchCommandLogger implements CommandLoggerInterface
 {
-    /** @var bool */
-    private $registered = false;
+    private bool $registered = false;
 
-    /** @var Stopwatch|null */
-    private $stopwatch;
+    private ?Stopwatch $stopwatch;
 
     public function __construct(?Stopwatch $stopwatch)
     {

--- a/CacheWarmer/HydratorCacheWarmer.php
+++ b/CacheWarmer/HydratorCacheWarmer.php
@@ -31,8 +31,7 @@ use function sprintf;
  */
 class HydratorCacheWarmer implements CacheWarmerInterface
 {
-    /** @var ContainerInterface */
-    private $container;
+    private ContainerInterface $container;
 
     public function __construct(ContainerInterface $container)
     {

--- a/CacheWarmer/PersistentCollectionCacheWarmer.php
+++ b/CacheWarmer/PersistentCollectionCacheWarmer.php
@@ -32,8 +32,7 @@ use function sprintf;
  */
 class PersistentCollectionCacheWarmer implements CacheWarmerInterface
 {
-    /** @var ContainerInterface */
-    private $container;
+    private ContainerInterface $container;
 
     public function __construct(ContainerInterface $container)
     {

--- a/CacheWarmer/ProxyCacheWarmer.php
+++ b/CacheWarmer/ProxyCacheWarmer.php
@@ -33,8 +33,7 @@ use function sprintf;
  */
 class ProxyCacheWarmer implements CacheWarmerInterface
 {
-    /** @var ContainerInterface */
-    private $container;
+    private ContainerInterface $container;
 
     public function __construct(ContainerInterface $container)
     {

--- a/Command/DoctrineODMCommand.php
+++ b/Command/DoctrineODMCommand.php
@@ -33,8 +33,7 @@ abstract class DoctrineODMCommand extends Command
     /** @var ContainerInterface|null */
     protected $container;
 
-    /** @var ManagerRegistry|null */
-    private $managerRegistry;
+    private ?ManagerRegistry $managerRegistry;
 
     public function __construct(?ManagerRegistry $registry = null)
     {

--- a/Command/LoadDataFixturesDoctrineODMCommand.php
+++ b/Command/LoadDataFixturesDoctrineODMCommand.php
@@ -27,8 +27,7 @@ use function trigger_deprecation;
  */
 class LoadDataFixturesDoctrineODMCommand extends DoctrineODMCommand
 {
-    /** @var SymfonyFixturesLoaderInterface  */
-    private $fixturesLoader;
+    private ?SymfonyFixturesLoaderInterface $fixturesLoader;
 
     public function __construct(?ManagerRegistry $registry = null, ?KernelInterface $kernel = null, ?SymfonyFixturesLoaderInterface $fixturesLoader = null)
     {

--- a/DataCollector/CommandDataCollector.php
+++ b/DataCollector/CommandDataCollector.php
@@ -21,8 +21,7 @@ use function MongoDB\BSON\toCanonicalExtendedJSON;
 
 class CommandDataCollector extends DataCollector
 {
-    /** @var CommandLogger */
-    private $commandLogger;
+    private CommandLogger $commandLogger;
 
     public function __construct(CommandLogger $commandLogger)
     {

--- a/Form/ChoiceList/MongoDBQueryBuilderLoader.php
+++ b/Form/ChoiceList/MongoDBQueryBuilderLoader.php
@@ -22,10 +22,8 @@ class MongoDBQueryBuilderLoader implements EntityLoaderInterface
      * entities
      *
      * This property should only be accessed through queryBuilder.
-     *
-     * @var Builder
      */
-    private $queryBuilder;
+    private Builder $queryBuilder;
 
     /**
      * Construct an ORM Query Builder Loader

--- a/Form/DoctrineMongoDBTypeGuesser.php
+++ b/Form/DoctrineMongoDBTypeGuesser.php
@@ -30,8 +30,8 @@ class DoctrineMongoDBTypeGuesser implements FormTypeGuesserInterface
     /** @var ManagerRegistry */
     protected $registry;
 
-    /** @var array */
-    private $cache = [];
+    /** @var array<class-string, array{ClassMetadata, string}|null> */
+    private array $cache = [];
 
     public function __construct(ManagerRegistry $registry)
     {

--- a/Loader/SymfonyFixturesLoader.php
+++ b/Loader/SymfonyFixturesLoader.php
@@ -21,10 +21,10 @@ use function sprintf;
 final class SymfonyFixturesLoader extends ContainerAwareLoader implements SymfonyFixturesLoaderInterface
 {
     /** @var FixtureInterface[] */
-    private $loadedFixtures = [];
+    private array $loadedFixtures = [];
 
     /** @var array<string, array<string, bool>> */
-    private $groupsFixtureMapping = [];
+    private array $groupsFixtureMapping = [];
 
     /**
      * @internal

--- a/ManagerConfigurator.php
+++ b/ManagerConfigurator.php
@@ -14,7 +14,7 @@ use Doctrine\ODM\MongoDB\Types\Type;
 class ManagerConfigurator
 {
     /** @var array */
-    private $enabledFilters = [];
+    private array $enabledFilters = [];
 
     /**
      * Construct.

--- a/Repository/ContainerRepositoryFactory.php
+++ b/Repository/ContainerRepositoryFactory.php
@@ -25,10 +25,9 @@ use function sprintf;
 final class ContainerRepositoryFactory implements RepositoryFactory
 {
     /** @var array<string, ObjectRepository> */
-    private $managedRepositories = [];
+    private array $managedRepositories = [];
 
-    /** @var ContainerInterface|null */
-    private $container;
+    private ContainerInterface $container;
 
     /** @param ContainerInterface $container A service locator containing the repositories */
     public function __construct(ContainerInterface $container)
@@ -50,7 +49,7 @@ final class ContainerRepositoryFactory implements RepositoryFactory
 
         if ($customRepositoryName !== null) {
             // fetch from the container
-            if ($this->container && $this->container->has($customRepositoryName)) {
+            if ($this->container->has($customRepositoryName)) {
                 /** @var ObjectRepository<T> $repository */
                 $repository = $this->container->get($customRepositoryName);
 

--- a/Tests/APM/StopwatchCommandLoggerTest.php
+++ b/Tests/APM/StopwatchCommandLoggerTest.php
@@ -14,12 +14,9 @@ use function method_exists;
 
 class StopwatchCommandLoggerTest extends TestCase
 {
-    /** @var StopwatchCommandLogger */
-    private $commandLogger;
-    /** @var Stopwatch */
-    private $stopwatch;
-    /** @var DocumentManager */
-    private $dm;
+    private StopwatchCommandLogger $commandLogger;
+    private Stopwatch $stopwatch;
+    private DocumentManager $dm;
 
     protected function setUp(): void
     {

--- a/Tests/APM/StopwatchCommandLoggerTest.php
+++ b/Tests/APM/StopwatchCommandLoggerTest.php
@@ -10,8 +10,6 @@ use Doctrine\Bundle\MongoDBBundle\Tests\TestCase;
 use Doctrine\ODM\MongoDB\DocumentManager;
 use Symfony\Component\Stopwatch\Stopwatch;
 
-use function method_exists;
-
 class StopwatchCommandLoggerTest extends TestCase
 {
     private StopwatchCommandLogger $commandLogger;
@@ -54,13 +52,7 @@ class StopwatchCommandLoggerTest extends TestCase
         self::assertCount(3, $events);
 
         foreach ($events as $eventName => $stopwatchEvent) {
-            // @todo replace with assertMatchesRegularExpression() when PHP 7.2 is dropped
-            if (method_exists($this, 'assertMatchesRegularExpression')) {
-                self::assertMatchesRegularExpression('/mongodb_\d+/', $eventName);
-            } else {
-                self::assertRegExp('/mongodb_\d+/', $eventName);
-            }
-
+            self::assertMatchesRegularExpression('/mongodb_\d+/', $eventName);
             self::assertGreaterThan(0, $stopwatchEvent->getDuration());
             self::assertSame('doctrine_mongodb', $stopwatchEvent->getCategory());
         }

--- a/Tests/CacheWarmer/HydratorCacheWarmerTest.php
+++ b/Tests/CacheWarmer/HydratorCacheWarmerTest.php
@@ -19,11 +19,9 @@ use const DIRECTORY_SEPARATOR;
 
 class HydratorCacheWarmerTest extends TestCase
 {
-    /** @var ContainerInterface */
-    private $container;
+    private ContainerInterface $container;
 
-    /** @var HydratorCacheWarmer */
-    private $warmer;
+    private HydratorCacheWarmer $warmer;
 
     protected function setUp(): void
     {

--- a/Tests/CacheWarmer/HydratorCacheWarmerTest.php
+++ b/Tests/CacheWarmer/HydratorCacheWarmerTest.php
@@ -11,7 +11,6 @@ use Doctrine\ODM\MongoDB\Configuration;
 use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
-use function method_exists;
 use function sys_get_temp_dir;
 use function unlink;
 
@@ -63,22 +62,10 @@ class HydratorCacheWarmerTest extends TestCase
 
         try {
             $this->warmer->warmUp('meh');
-            // Replace by "assertFileDoesNotExist" when PHPUnit 9 is minimum
-            $this->assertFileDoesNotExistWithBC($hydratorFilename);
+            $this->assertFileDoesNotExist($hydratorFilename);
         } finally {
             @unlink($hydratorFilename);
         }
-    }
-
-    private function assertFileDoesNotExistWithBC(string $filename): void
-    {
-        if (! method_exists($this, 'assertFileDoesNotExist')) {
-            $this->assertFileNotExists($filename);
-
-            return;
-        }
-
-        $this->assertFileDoesNotExist($filename);
     }
 
     /** @return array<array{int}> */

--- a/Tests/CacheWarmer/PersistentCollectionCacheWarmerTest.php
+++ b/Tests/CacheWarmer/PersistentCollectionCacheWarmerTest.php
@@ -17,14 +17,12 @@ use function sys_get_temp_dir;
 
 class PersistentCollectionCacheWarmerTest extends TestCase
 {
-    /** @var ContainerInterface */
-    private $container;
+    private ContainerInterface $container;
 
     /** @var PersistentCollectionGenerator&MockObject  */
-    private $generatorMock;
+    private PersistentCollectionGenerator $generatorMock;
 
-    /** @var PersistentCollectionCacheWarmer */
-    private $warmer;
+    private PersistentCollectionCacheWarmer $warmer;
 
     protected function setUp(): void
     {

--- a/Tests/CacheWarmer/ProxyCacheWarmerTest.php
+++ b/Tests/CacheWarmer/ProxyCacheWarmerTest.php
@@ -18,14 +18,12 @@ use function sys_get_temp_dir;
 
 class ProxyCacheWarmerTest extends TestCase
 {
-    /** @var ContainerInterface */
-    private $container;
+    private ContainerInterface $container;
 
-    /** @var ProxyFactory|MockObject */
-    private $proxyMock;
+    /** @var ProxyFactory&MockObject */
+    private ProxyFactory $proxyMock;
 
-    /** @var ProxyCacheWarmer */
-    private $warmer;
+    private ProxyCacheWarmer $warmer;
 
     protected function setUp(): void
     {

--- a/Tests/Command/LoadDataFixturesDoctrineODMCommandTest.php
+++ b/Tests/Command/LoadDataFixturesDoctrineODMCommandTest.php
@@ -11,8 +11,7 @@ use Symfony\Component\Console\Tester\CommandTester;
 
 class LoadDataFixturesDoctrineODMCommandTest extends KernelTestCase
 {
-    /** @var LoadDataFixturesDoctrineODMCommand */
-    private $command;
+    private LoadDataFixturesDoctrineODMCommand $command;
 
     protected function setUp(): void
     {

--- a/Tests/ContainerTest.php
+++ b/Tests/ContainerTest.php
@@ -15,11 +15,9 @@ use function sys_get_temp_dir;
 
 class ContainerTest extends TestCase
 {
-    /** @var ContainerBuilder */
-    private $container;
+    private ContainerBuilder $container;
 
-    /** @var DoctrineMongoDBExtension */
-    private $extension;
+    private DoctrineMongoDBExtension $extension;
 
     protected function setUp(): void
     {

--- a/Tests/DataCollector/CommandDataCollectorTest.php
+++ b/Tests/DataCollector/CommandDataCollectorTest.php
@@ -14,10 +14,8 @@ use Symfony\Component\HttpFoundation\Response;
 
 class CommandDataCollectorTest extends TestCase
 {
-    /** @var CommandLogger */
-    private $commandLogger;
-    /** @var DocumentManager */
-    private $dm;
+    private CommandLogger $commandLogger;
+    private DocumentManager $dm;
 
     protected function setUp(): void
     {

--- a/Tests/DependencyInjection/Fixtures/Bundles/RepositoryServiceBundle/Document/TestCustomClassRepoDocument.php
+++ b/Tests/DependencyInjection/Fixtures/Bundles/RepositoryServiceBundle/Document/TestCustomClassRepoDocument.php
@@ -14,8 +14,6 @@ class TestCustomClassRepoDocument
 {
     /**
      * @ODM\Id
-     *
-     * @var string
      */
-    private $id;
+    private string $id;
 }

--- a/Tests/DependencyInjection/Fixtures/Bundles/RepositoryServiceBundle/Document/TestCustomServiceRepoDocument.php
+++ b/Tests/DependencyInjection/Fixtures/Bundles/RepositoryServiceBundle/Document/TestCustomServiceRepoDocument.php
@@ -14,8 +14,6 @@ class TestCustomServiceRepoDocument
 {
     /**
      * @ODM\Id
-     *
-     * @var string
      */
-    private $id;
+    private string $id;
 }

--- a/Tests/DependencyInjection/Fixtures/Bundles/RepositoryServiceBundle/Document/TestCustomServiceRepoFile.php
+++ b/Tests/DependencyInjection/Fixtures/Bundles/RepositoryServiceBundle/Document/TestCustomServiceRepoFile.php
@@ -12,8 +12,6 @@ class TestCustomServiceRepoFile
 {
     /**
      * @ODM\Id
-     *
-     * @var string
      */
-    private $id;
+    private string $id;
 }

--- a/Tests/DependencyInjection/Fixtures/Bundles/RepositoryServiceBundle/Document/TestDefaultRepoDocument.php
+++ b/Tests/DependencyInjection/Fixtures/Bundles/RepositoryServiceBundle/Document/TestDefaultRepoDocument.php
@@ -13,8 +13,6 @@ class TestDefaultRepoDocument
 {
     /**
      * @ODM\Id
-     *
-     * @var string
      */
-    private $id;
+    private string $id;
 }

--- a/Tests/DependencyInjection/Fixtures/Bundles/RepositoryServiceBundle/Document/TestDefaultRepoFile.php
+++ b/Tests/DependencyInjection/Fixtures/Bundles/RepositoryServiceBundle/Document/TestDefaultRepoFile.php
@@ -11,8 +11,6 @@ class TestDefaultRepoFile
 {
     /**
      * @ODM\Id
-     *
-     * @var string
      */
-    private $id;
+    private string $id;
 }

--- a/Tests/DependencyInjection/Fixtures/TestKernel.php
+++ b/Tests/DependencyInjection/Fixtures/TestKernel.php
@@ -18,8 +18,7 @@ use function sys_get_temp_dir;
 
 class TestKernel extends Kernel
 {
-    /** @var string|null */
-    private $projectDir;
+    private ?string $projectDir = null;
 
     public function __construct(bool $debug = true)
     {

--- a/Tests/FixtureIntegrationTest.php
+++ b/Tests/FixtureIntegrationTest.php
@@ -284,8 +284,7 @@ class IntegrationTestKernel extends Kernel
     /** @var callable */
     private $servicesCallback;
 
-    /** @var string */
-    private $randomKey;
+    private string $randomKey;
 
     public function __construct(string $environment, bool $debug)
     {

--- a/Tests/Fixtures/Cache/Collections.php
+++ b/Tests/Fixtures/Cache/Collections.php
@@ -11,33 +11,17 @@ use MongoDB\BSON\ObjectId;
 /** @ODM\Document */
 class Collections
 {
-    /**
-     * @ODM\Id
-     *
-     * @var ObjectId|null
-     */
-    public $id;
+    /** @ODM\Id */
+    public ?ObjectId $id = null;
 
-    /**
-     * @ODM\EmbedMany(collectionClass=SomeCollection::class)
-     *
-     * @var SomeCollection
-     */
-    public $coll;
+    /** @ODM\EmbedMany(collectionClass=SomeCollection::class) */
+    public SomeCollection $coll;
 
-    /**
-     * @ODM\ReferenceMany(collectionClass=SomeCollection::class)
-     *
-     * @var SomeCollection
-     */
-    public $refs;
+    /** @ODM\ReferenceMany(collectionClass=SomeCollection::class) */
+    public SomeCollection $refs;
 
-    /**
-     * @ODM\EmbedMany(collectionClass=AnotherCollection::class)
-     *
-     * @var AnotherCollection
-     */
-    public $another;
+    /** @ODM\EmbedMany(collectionClass=AnotherCollection::class) */
+    public AnotherCollection $another;
 }
 
 /** @template-extends ArrayCollection<array-key, mixed> */

--- a/Tests/Fixtures/CommandBundle/Document/User.php
+++ b/Tests/Fixtures/CommandBundle/Document/User.php
@@ -13,8 +13,6 @@ class User
 {
     /**
      * @ODM\Id
-     *
-     * @var string|null
      */
-    private $id;
+    private ?string $id = null;
 }

--- a/Tests/Fixtures/DataCollector/Category.php
+++ b/Tests/Fixtures/DataCollector/Category.php
@@ -10,19 +10,11 @@ use MongoDB\BSON\ObjectId;
 /** @ODM\Document */
 class Category
 {
-    /**
-     * @ODM\Id
-     *
-     * @var ObjectId|null
-     */
-    protected $id;
+    /** @ODM\Id */
+    protected ?ObjectId $id = null;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string
-     */
-    public $name;
+    /** @ODM\Field(type="string") */
+    public string $name;
 
     public function __construct(string $name)
     {

--- a/Tests/Fixtures/Form/Category.php
+++ b/Tests/Fixtures/Form/Category.php
@@ -15,16 +15,12 @@ class Category
     /**
      * @ODM\Id
      *
-     * @var ObjectId|null
+     * @var ObjectId|string|null
      */
     protected $id;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string
-     */
-    public $name;
+    /** @ODM\Field(type="string") */
+    public string $name;
 
     /**
      * @ODM\ReferenceMany(
@@ -34,7 +30,7 @@ class Category
      *
      * @var Collection<int, Document>
      */
-    public $documents;
+    public Collection $documents;
 
     public function __construct(string $name)
     {

--- a/Tests/Fixtures/Form/Document.php
+++ b/Tests/Fixtures/Form/Document.php
@@ -12,19 +12,11 @@ use MongoDB\BSON\ObjectId;
 /** @ODM\Document */
 class Document
 {
-    /**
-     * @ODM\Id(strategy="none")
-     *
-     * @var ObjectId
-     */
-    protected $id;
+    /** @ODM\Id(strategy="none") */
+    protected ObjectId $id;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string
-     */
-    public $name;
+    /** @ODM\Field(type="string") */
+    public string $name;
 
     /**
      * @ODM\ReferenceMany(
@@ -35,7 +27,7 @@ class Document
      *
      * @var Collection<int, Category>
      */
-    public $categories;
+    public Collection $categories;
 
     public function __construct(ObjectId $id, string $name)
     {

--- a/Tests/Fixtures/Form/Guesser.php
+++ b/Tests/Fixtures/Form/Guesser.php
@@ -12,33 +12,17 @@ use MongoDB\BSON\ObjectId;
 /** @ODM\Document */
 class Guesser
 {
-    /**
-     * @ODM\Id(strategy="none")
-     *
-     * @var ObjectId|null
-     */
-    protected $id;
+    /** @ODM\Id(strategy="none") */
+    protected ?ObjectId $id = null;
 
-    /**
-     * @ODM\Field()
-     *
-     * @var string|null
-     */
-    public $name;
+    /** @ODM\Field() */
+    public ?string $name = null;
 
-    /**
-     * @ODM\Field(type="date")
-     *
-     * @var DateTime|null
-     */
-    public $date;
+    /** @ODM\Field(type="date") */
+    public ?DateTime $date = null;
 
-    /**
-     * @ODM\Field(type="timestamp")
-     *
-     * @var DateTime
-     */
-    public $ts;
+    /** @ODM\Field(type="timestamp") */
+    public DateTime $ts;
 
     /**
      * @ODM\ReferenceMany(
@@ -49,35 +33,23 @@ class Guesser
      *
      * @var Collection<int, Category>
      */
-    public $categories;
+    public Collection $categories;
 
-    /**
-     * @ODM\Field(type="bool")
-     *
-     * @var bool|null
-     */
-    public $boolField;
+    /** @ODM\Field(type="bool") */
+    public ?bool $boolField = null;
 
-    /**
-     * @ODM\Field(type="float")
-     *
-     * @var float|null
-     */
-    public $floatField;
+    /** @ODM\Field(type="float") */
+    public ?float $floatField = null;
 
-    /**
-     * @ODM\Field(type="int")
-     *
-     * @var int|null
-     */
-    public $intField;
+    /** @ODM\Field(type="int") */
+    public ?int $intField = null;
 
     /**
      * @ODM\Field(type="collection")
      *
      * @var array
      */
-    public $collectionField;
+    public array $collectionField;
 
     /** @var mixed */
     public $nonMappedField;

--- a/Tests/Fixtures/Security/User.php
+++ b/Tests/Fixtures/Security/User.php
@@ -11,19 +11,11 @@ use Symfony\Component\Security\Core\User\UserInterface;
 /** @ODM\Document */
 class User implements UserInterface
 {
-    /**
-     * @ODM\Id(strategy="none")
-     *
-     * @var ObjectId
-     */
-    protected $id;
+    /** @ODM\Id(strategy="none") */
+    protected ObjectId $id;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string
-     */
-    public $name;
+    /** @ODM\Field(type="string") */
+    public string $name;
 
     public function __construct(ObjectId $id, string $name)
     {

--- a/Tests/Fixtures/Validator/Document.php
+++ b/Tests/Fixtures/Validator/Document.php
@@ -10,54 +10,38 @@ use MongoDB\BSON\ObjectId;
 /** @ODM\Document(collection="DoctrineMongoDBBundle_Tests_Validator_Document") */
 class Document
 {
-    /**
-     * @ODM\Id(strategy="none")
-     *
-     * @var ObjectId
-     */
-    protected $id;
+    /** @ODM\Id(strategy="none") */
+    protected ObjectId $id;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string
-     */
-    public $name;
+    /** @ODM\Field(type="string") */
+    public string $name;
 
     /**
      * @ODM\Field(type="hash")
      *
      * @var array
      */
-    public $hash;
+    public array $hash;
 
     /**
      * @ODM\Field(type="collection")
      *
      * @var array
      */
-    public $collection;
+    public array $collection;
 
-    /**
-     * @ODM\ReferenceOne(targetDocument="Doctrine\Bundle\MongoDBBundle\Tests\Fixtures\Validator\Document")
-     *
-     * @var Document|null
-     */
-    public $referenceOne;
+    /** @ODM\ReferenceOne(targetDocument="Doctrine\Bundle\MongoDBBundle\Tests\Fixtures\Validator\Document") */
+    public ?Document $referenceOne = null;
 
-    /**
-     * @ODM\EmbedOne(targetDocument="Doctrine\Bundle\MongoDBBundle\Tests\Fixtures\Validator\EmbeddedDocument")
-     *
-     * @var EmbeddedDocument|null
-     */
-    public $embedOne;
+    /** @ODM\EmbedOne(targetDocument="Doctrine\Bundle\MongoDBBundle\Tests\Fixtures\Validator\EmbeddedDocument") */
+    public ?EmbeddedDocument $embedOne = null;
 
     /**
      * @ODM\EmbedMany(targetDocument="Doctrine\Bundle\MongoDBBundle\Tests\Fixtures\Validator\EmbeddedDocument")
      *
      * @var EmbeddedDocument[]
      */
-    public $embedMany = [];
+    public array $embedMany = [];
 
     public function __construct(ObjectId $id)
     {
@@ -68,10 +52,6 @@ class Document
 /** @ODM\EmbeddedDocument */
 class EmbeddedDocument
 {
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string
-     */
-    public $name;
+    /** @ODM\Field(type="string") */
+    public string $name;
 }

--- a/Tests/Form/Type/DocumentTypeTest.php
+++ b/Tests/Form/Type/DocumentTypeTest.php
@@ -23,11 +23,10 @@ use function array_merge;
 
 class DocumentTypeTest extends TypeTestCase
 {
-    /** @var DocumentManager */
-    private $dm;
+    private DocumentManager $dm;
 
     /** @var MockObject&ManagerRegistry */
-    private $dmRegistry;
+    private ManagerRegistry $dmRegistry;
 
     protected function setUp(): void
     {

--- a/Tests/Form/Type/TypeGuesserTest.php
+++ b/Tests/Form/Type/TypeGuesserTest.php
@@ -20,11 +20,10 @@ use function array_merge;
 
 class TypeGuesserTest extends TypeTestCase
 {
-    /** @var DocumentManager */
-    private $dm;
+    private DocumentManager $dm;
 
     /** @var MockObject&ManagerRegistry */
-    private $dmRegistry;
+    private ManagerRegistry $dmRegistry;
 
     protected function setUp(): void
     {

--- a/Tests/ServiceRepositoryTest.php
+++ b/Tests/ServiceRepositoryTest.php
@@ -33,8 +33,7 @@ use function sys_get_temp_dir;
 
 class ServiceRepositoryTest extends TestCase
 {
-    /** @var ContainerBuilder */
-    private $container;
+    private ContainerBuilder $container;
 
     protected function setUp(): void
     {


### PR DESCRIPTION
Since the minimum version of PHP that we support is `7.4`, we can add typed properties.