### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "php": "^7.2 || ^8.0",
         "ext-mongodb": "^1.5",
         "doctrine/annotations": "^1.13",
-        "doctrine/mongodb-odm": "^2.3",
+        "doctrine/mongodb-odm": "^2.4",
         "doctrine/persistence": "^2.2|^3.0",
         "psr/log": "^1.0|^2.0|^3.0",
         "symfony/config": "^4.4|^5.3|^6.0",


### PR DESCRIPTION
Update `doctrine/mongodb-odm` to 2.4.x in order to match function signatures.

This MR aims to fix this issue
```
Doctrine\ODM\MongoDB\APM\CommandLogger::commandStarted(MongoDB\Driver\Monitoring\CommandStartedEvent $event) should either be compatible with MongoDB\Driver\Monitoring\CommandSubscriber::commandStarted(MongoDB\Driver\Monitoring\CommandStartedEvent $event): void, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /var/www/vendor/doctrine/mongodb-odm/lib/Doctrine/ODM/MongoDB/APM/CommandLogger.php on line 47
```