### PR TITLE
Allow doctrine/annotations 2

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -31,7 +31,7 @@ jobs:
         symfony-version:
           - "4.4.x"
           - "5.4.x"
-          - "6.0.x"
+          - "6.2.x"
         driver-version:
           - "stable"
         dependencies:
@@ -43,9 +43,16 @@ jobs:
             driver-version: "1.5.0"
             stability: "stable"
             symfony-version: "4.4.*"
+          # Remove this job when releasing mongodb-odm 2.5
+          - dependencies: "highest"
+            os: "ubuntu-20.04"
+            php-version: "8.2"
+            driver-version: "stable"
+            stability: "dev"
+            symfony-version: "6.2.*"
         exclude:
           - php-version: "7.4"
-            symfony-version: "6.0.x"
+            symfony-version: "6.2.x"
 
     services:
       mongodb:

--- a/Command/ClearMetadataCacheDoctrineODMCommand.php
+++ b/Command/ClearMetadataCacheDoctrineODMCommand.php
@@ -14,6 +14,7 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class ClearMetadataCacheDoctrineODMCommand extends MetadataCommand
 {
+    /** @return void */
     protected function configure()
     {
         parent::configure();

--- a/Command/CreateSchemaDoctrineODMCommand.php
+++ b/Command/CreateSchemaDoctrineODMCommand.php
@@ -15,6 +15,7 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class CreateSchemaDoctrineODMCommand extends CreateCommand
 {
+    /** @return void */
     protected function configure()
     {
         parent::configure();

--- a/Command/DropSchemaDoctrineODMCommand.php
+++ b/Command/DropSchemaDoctrineODMCommand.php
@@ -15,6 +15,7 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class DropSchemaDoctrineODMCommand extends DropCommand
 {
+    /** @return void */
     protected function configure()
     {
         parent::configure();

--- a/Command/GenerateHydratorsDoctrineODMCommand.php
+++ b/Command/GenerateHydratorsDoctrineODMCommand.php
@@ -14,6 +14,7 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class GenerateHydratorsDoctrineODMCommand extends GenerateHydratorsCommand
 {
+    /** @return void */
     protected function configure()
     {
         parent::configure();

--- a/Command/GenerateProxiesDoctrineODMCommand.php
+++ b/Command/GenerateProxiesDoctrineODMCommand.php
@@ -14,6 +14,7 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class GenerateProxiesDoctrineODMCommand extends GenerateProxiesCommand
 {
+    /** @return void */
     protected function configure()
     {
         parent::configure();

--- a/Command/InfoDoctrineODMCommand.php
+++ b/Command/InfoDoctrineODMCommand.php
@@ -20,6 +20,7 @@ use function sprintf;
  */
 class InfoDoctrineODMCommand extends DoctrineODMCommand
 {
+    /** @return void */
     protected function configure()
     {
         $this

--- a/Command/LoadDataFixturesDoctrineODMCommand.php
+++ b/Command/LoadDataFixturesDoctrineODMCommand.php
@@ -43,6 +43,7 @@ class LoadDataFixturesDoctrineODMCommand extends DoctrineODMCommand
         return parent::isEnabled() && class_exists(Loader::class);
     }
 
+    /** @return void */
     protected function configure()
     {
         $this

--- a/Command/QueryDoctrineODMCommand.php
+++ b/Command/QueryDoctrineODMCommand.php
@@ -14,6 +14,7 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class QueryDoctrineODMCommand extends QueryCommand
 {
+    /** @return void */
     protected function configure()
     {
         parent::configure();

--- a/Command/ShardDoctrineODMCommand.php
+++ b/Command/ShardDoctrineODMCommand.php
@@ -15,6 +15,7 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class ShardDoctrineODMCommand extends ShardCommand
 {
+    /** @return void */
     protected function configure()
     {
         parent::configure();

--- a/Command/TailCursorDoctrineODMCommand.php
+++ b/Command/TailCursorDoctrineODMCommand.php
@@ -30,6 +30,7 @@ class TailCursorDoctrineODMCommand extends Command implements ContainerAwareInte
 {
     use ContainerAwareTrait;
 
+    /** @return void */
     protected function configure()
     {
         $this

--- a/Command/UpdateSchemaDoctrineODMCommand.php
+++ b/Command/UpdateSchemaDoctrineODMCommand.php
@@ -15,6 +15,7 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class UpdateSchemaDoctrineODMCommand extends UpdateCommand
 {
+    /** @return void */
     protected function configure()
     {
         parent::configure();

--- a/DependencyInjection/Compiler/CreateHydratorDirectoryPass.php
+++ b/DependencyInjection/Compiler/CreateHydratorDirectoryPass.php
@@ -16,6 +16,7 @@ use function sprintf;
 
 class CreateHydratorDirectoryPass implements CompilerPassInterface
 {
+    /** @return void */
     public function process(ContainerBuilder $container)
     {
         if (! $container->hasParameter('doctrine_mongodb.odm.hydrator_dir')) {

--- a/DependencyInjection/Compiler/CreateProxyDirectoryPass.php
+++ b/DependencyInjection/Compiler/CreateProxyDirectoryPass.php
@@ -16,6 +16,7 @@ use function sprintf;
 
 class CreateProxyDirectoryPass implements CompilerPassInterface
 {
+    /** @return void */
     public function process(ContainerBuilder $container)
     {
         if (! $container->hasParameter('doctrine_mongodb.odm.proxy_dir')) {

--- a/DependencyInjection/Compiler/FixturesCompilerPass.php
+++ b/DependencyInjection/Compiler/FixturesCompilerPass.php
@@ -12,6 +12,7 @@ final class FixturesCompilerPass implements CompilerPassInterface
 {
     public const FIXTURE_TAG = 'doctrine.fixture.odm.mongodb';
 
+    /** @return void */
     public function process(ContainerBuilder $container)
     {
         if (! $container->hasDefinition('doctrine_mongodb.odm.symfony.fixtures.loader')) {

--- a/DependencyInjection/Compiler/ServiceRepositoryCompilerPass.php
+++ b/DependencyInjection/Compiler/ServiceRepositoryCompilerPass.php
@@ -17,6 +17,7 @@ final class ServiceRepositoryCompilerPass implements CompilerPassInterface
 {
     public const REPOSITORY_SERVICE_TAG = 'doctrine_mongodb.odm.repository_service';
 
+    /** @return void */
     public function process(ContainerBuilder $container)
     {
         // when ODM is not enabled

--- a/DependencyInjection/DoctrineMongoDBExtension.php
+++ b/DependencyInjection/DoctrineMongoDBExtension.php
@@ -53,6 +53,8 @@ class DoctrineMongoDBExtension extends AbstractDoctrineExtension
 
     /**
      * Responds to the doctrine_mongodb configuration parameter.
+     *
+     * @return void
      */
     public function load(array $configs, ContainerBuilder $container)
     {

--- a/DoctrineMongoDBBundle.php
+++ b/DoctrineMongoDBBundle.php
@@ -33,6 +33,7 @@ class DoctrineMongoDBBundle extends Bundle
     /** @var callable|null */
     private $autoloader;
 
+    /** @return void */
     public function build(ContainerBuilder $container)
     {
         $container->addCompilerPass(new CacheCompatibilityPass());
@@ -61,6 +62,7 @@ class DoctrineMongoDBBundle extends Bundle
         return new DoctrineMongoDBExtension();
     }
 
+    /** @return void */
     public function boot()
     {
         $registry = $this->container->get('doctrine_mongodb');
@@ -104,6 +106,7 @@ class DoctrineMongoDBBundle extends Bundle
         $commandLoggerRegistry->unregister();
     }
 
+    /** @return void */
     public function shutdown()
     {
         $this->unregisterAutoloader();

--- a/Form/Type/DocumentType.php
+++ b/Form/Type/DocumentType.php
@@ -34,6 +34,7 @@ class DocumentType extends DoctrineType
         );
     }
 
+    /** @return void */
     public function configureOptions(OptionsResolver $resolver)
     {
         parent::configureOptions($resolver);

--- a/Tests/bootstrap.php
+++ b/Tests/bootstrap.php
@@ -8,7 +8,3 @@ if (! file_exists($file)) {
 }
 
 require_once $file;
-
-use Doctrine\Common\Annotations\AnnotationRegistry;
-
-AnnotationRegistry::registerLoader('class_exists');

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-mongodb": "^1.5",
-        "doctrine/annotations": "^1.13",
+        "doctrine/annotations": "^1.13 || ^2.0",
         "doctrine/mongodb-odm": "^2.3",
         "doctrine/persistence": "^2.2|^3.0",
         "psr/log": "^1.0|^2.0|^3.0",


### PR DESCRIPTION
The second commit is because Symfony is adding `void` return types and the build fails using the dev version of Symfony.