### PR TITLE
Drop support of unmaintained versions of Symfony

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -29,7 +29,6 @@ jobs:
         stability:
           - "stable"
         symfony-version:
-          - "4.4.x"
           - "5.4.x"
           - "6.2.x"
         driver-version:
@@ -42,7 +41,7 @@ jobs:
             php-version: "7.4"
             driver-version: "1.5.0"
             stability: "stable"
-            symfony-version: "4.4.*"
+            symfony-version: "5.4.*"
         exclude:
           - php-version: "7.4"
             symfony-version: "6.2.x"

--- a/CacheWarmer/HydratorCacheWarmer.php
+++ b/CacheWarmer/HydratorCacheWarmer.php
@@ -48,12 +48,8 @@ class HydratorCacheWarmer implements CacheWarmerInterface
         return false;
     }
 
-    /**
-     * @param string $cacheDir
-     *
-     * @return string[]
-     */
-    public function warmUp($cacheDir)
+    /** @return string[] */
+    public function warmUp(string $cacheDir)
     {
         // we need the directory no matter the hydrator cache generation strategy.
         $hydratorCacheDir = (string) $this->container->getParameter('doctrine_mongodb.odm.hydrator_dir');

--- a/CacheWarmer/PersistentCollectionCacheWarmer.php
+++ b/CacheWarmer/PersistentCollectionCacheWarmer.php
@@ -49,12 +49,8 @@ class PersistentCollectionCacheWarmer implements CacheWarmerInterface
         return false;
     }
 
-    /**
-     * @param string $cacheDir
-     *
-     * @return string[]
-     */
-    public function warmUp($cacheDir)
+    /** @return string[] */
+    public function warmUp(string $cacheDir)
     {
         // we need the directory no matter the hydrator cache generation strategy.
         $collCacheDir = (string) $this->container->getParameter('doctrine_mongodb.odm.persistent_collection_dir');

--- a/CacheWarmer/ProxyCacheWarmer.php
+++ b/CacheWarmer/ProxyCacheWarmer.php
@@ -50,12 +50,8 @@ class ProxyCacheWarmer implements CacheWarmerInterface
         return false;
     }
 
-    /**
-     * @param string $cacheDir
-     *
-     * @return string[]
-     */
-    public function warmUp($cacheDir)
+    /** @return string[] */
+    public function warmUp(string $cacheDir)
     {
         // we need the directory no matter the proxy cache generation strategy.
         $proxyCacheDir = (string) $this->container->getParameter('doctrine_mongodb.odm.proxy_dir');

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -126,7 +126,7 @@ class Configuration implements ConfigurationInterface
     /**
      * Adds the "document_managers" config section.
      */
-    private function addDocumentManagersSection(ArrayNodeDefinition $rootNode)
+    private function addDocumentManagersSection(ArrayNodeDefinition $rootNode): void
     {
         $rootNode
             ->fixXmlConfig('document_manager')
@@ -251,7 +251,7 @@ class Configuration implements ConfigurationInterface
     /**
      * Adds the "connections" config section.
      */
-    private function addConnectionsSection(ArrayNodeDefinition $rootNode)
+    private function addConnectionsSection(ArrayNodeDefinition $rootNode): void
     {
         $rootNode
             ->fixXmlConfig('connection')
@@ -362,7 +362,7 @@ class Configuration implements ConfigurationInterface
     /**
      * Adds the "resolve_target_documents" config section.
      */
-    private function addResolveTargetDocumentsSection(ArrayNodeDefinition $rootNode)
+    private function addResolveTargetDocumentsSection(ArrayNodeDefinition $rootNode): void
     {
         $rootNode
             ->fixXmlConfig('resolve_target_document')
@@ -379,7 +379,7 @@ class Configuration implements ConfigurationInterface
     /**
      * Adds the "types" config section.
      */
-    private function addTypesSection(ArrayNodeDefinition $rootNode)
+    private function addTypesSection(ArrayNodeDefinition $rootNode): void
     {
         $rootNode
             ->fixXmlConfig('type')

--- a/DependencyInjection/DoctrineMongoDBExtension.php
+++ b/DependencyInjection/DoctrineMongoDBExtension.php
@@ -135,16 +135,14 @@ class DoctrineMongoDBExtension extends AbstractDoctrineExtension
         $container->registerForAutoconfiguration(EventSubscriberInterface::class)
             ->addTag('doctrine_mongodb.odm.event_subscriber');
 
-        if (method_exists($container, 'registerAttributeForAutoconfiguration')) {
-            $container->registerAttributeForAutoconfiguration(AsDocumentListener::class, static function (ChildDefinition $definition, AsDocumentListener $attribute) {
-                $definition->addTag('doctrine_mongodb.odm.event_listener', [
-                    'event'      => $attribute->event,
-                    'method'     => $attribute->method,
-                    'lazy'       => $attribute->lazy,
-                    'connection' => $attribute->connection,
-                ]);
-            });
-        }
+        $container->registerAttributeForAutoconfiguration(AsDocumentListener::class, static function (ChildDefinition $definition, AsDocumentListener $attribute) {
+            $definition->addTag('doctrine_mongodb.odm.event_listener', [
+                'event'      => $attribute->event,
+                'method'     => $attribute->method,
+                'lazy'       => $attribute->lazy,
+                'connection' => $attribute->connection,
+            ]);
+        });
 
         $this->loadMessengerServices($container);
 
@@ -296,10 +294,11 @@ class DoctrineMongoDBExtension extends AbstractDoctrineExtension
         }
 
         $container->getAlias('doctrine_mongodb.odm.command_logger')
-            ->setDeprecated(...$this->buildDeprecationArgs(
+            ->setDeprecated(
+                'doctrine/mongodb-odm-bundle',
                 '4.4',
                 'The service %alias_id% is deprecated and will be dropped in DoctrineMongoDBBundle 5.0. Use "doctrine_mongodb.odm.psr_command_logger" instead.',
-            ));
+            );
 
         // logging
         if ($container->getParameterBag()->resolveValue($documentManager['logging'])) {
@@ -640,13 +639,5 @@ class DoctrineMongoDBExtension extends AbstractDoctrineExtension
         $container->setDefinition($cacheDriverServiceId, $cacheDef);
 
         return $cacheDriverServiceId;
-    }
-
-    private function buildDeprecationArgs(string $version, string $message): array
-    {
-        // @todo Remove when support for Symfony 5.1 and older is dropped
-        return method_exists(BaseNode::class, 'getDeprecation')
-            ? ['doctrine/mongodb-odm-bundle', $version, $message]
-            : [$message];
     }
 }

--- a/DependencyInjection/DoctrineMongoDBExtension.php
+++ b/DependencyInjection/DoctrineMongoDBExtension.php
@@ -24,7 +24,6 @@ use Symfony\Component\Cache\Adapter\ApcuAdapter;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\Cache\Adapter\MemcachedAdapter;
 use Symfony\Component\Cache\Adapter\RedisAdapter;
-use Symfony\Component\Config\Definition\BaseNode;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\Alias;
 use Symfony\Component\DependencyInjection\ChildDefinition;
@@ -42,7 +41,6 @@ use function class_implements;
 use function in_array;
 use function interface_exists;
 use function is_dir;
-use function method_exists;
 use function reset;
 use function sprintf;
 
@@ -418,7 +416,7 @@ class DoctrineMongoDBExtension extends AbstractDoctrineExtension
         $container->setParameter('doctrine_mongodb.odm.connections', $cons);
     }
 
-    private function loadMessengerServices(ContainerBuilder $container)
+    private function loadMessengerServices(ContainerBuilder $container): void
     {
         /** @psalm-suppress UndefinedClass Optional dependency */
         if (! interface_exists(MessageBusInterface::class) || ! class_exists(DoctrineClearEntityManagerWorkerSubscriber::class)) {
@@ -432,11 +430,11 @@ class DoctrineMongoDBExtension extends AbstractDoctrineExtension
     /**
      * Normalizes the driver options array
      *
-     * @param array $connection
+     * @param array<string, mixed> $connection
      *
-     * @return array|null
+     * @return array<string, mixed>
      */
-    private function normalizeDriverOptions(array $connection)
+    private function normalizeDriverOptions(array $connection): array
     {
         $driverOptions            = $connection['driver_options'] ?? [];
         $driverOptions['typeMap'] = DocumentManager::CLIENT_TYPEMAP;
@@ -507,8 +505,7 @@ class DoctrineMongoDBExtension extends AbstractDoctrineExtension
         $odmConfigDef->addMethodCall('setDocumentNamespaces', [$this->aliasMap]);
     }
 
-    /** @param string $name */
-    protected function getObjectManagerElementName($name): string
+    protected function getObjectManagerElementName(string $name): string
     {
         return 'doctrine_mongodb.odm.' . $name;
     }
@@ -561,15 +558,11 @@ class DoctrineMongoDBExtension extends AbstractDoctrineExtension
     /**
      * Loads a cache driver.
      *
-     * @param string $cacheName         The cache driver name
-     * @param string $objectManagerName The object manager name
-     * @param array  $cacheDriver       The cache driver mapping
-     *
      * @throws InvalidArgumentException
      *
      * @psalm-suppress UndefinedClass this won't be necessary when removing metadata cache configuration
      */
-    protected function loadCacheDriver($cacheName, $objectManagerName, array $cacheDriver, ContainerBuilder $container): string
+    protected function loadCacheDriver(string $cacheName, string $objectManagerName, array $cacheDriver, ContainerBuilder $container): string
     {
         if (isset($cacheDriver['namespace'])) {
             return parent::loadCacheDriver($cacheName, $objectManagerName, $cacheDriver, $container);

--- a/Form/ChoiceList/MongoDBQueryBuilderLoader.php
+++ b/Form/ChoiceList/MongoDBQueryBuilderLoader.php
@@ -56,12 +56,8 @@ class MongoDBQueryBuilderLoader implements EntityLoaderInterface
         return array_values($this->queryBuilder->getQuery()->execute()->toArray());
     }
 
-    /**
-     * @param string $identifier
-     *
-     * @return object[]
-     */
-    public function getEntitiesByIds($identifier, array $values): array
+    /** @return object[] */
+    public function getEntitiesByIds(string $identifier, array $values): array
     {
         $qb = clone $this->queryBuilder;
 

--- a/Form/DoctrineMongoDBTypeGuesser.php
+++ b/Form/DoctrineMongoDBTypeGuesser.php
@@ -38,13 +38,8 @@ class DoctrineMongoDBTypeGuesser implements FormTypeGuesserInterface
         $this->registry = $registry;
     }
 
-    /**
-     * @param string $class
-     * @param string $property
-     *
-     * @return TypeGuess|null
-     */
-    public function guessType($class, $property)
+    /** @return TypeGuess|null */
+    public function guessType(string $class, string $property)
     {
         $ret = $this->getMetadata($class);
         if (! $ret) {
@@ -121,13 +116,8 @@ class DoctrineMongoDBTypeGuesser implements FormTypeGuesserInterface
         }
     }
 
-    /**
-     * @param string $class
-     * @param string $property
-     *
-     * @return ValueGuess|null
-     */
-    public function guessRequired($class, $property)
+    /** @return ValueGuess|null */
+    public function guessRequired(string $class, string $property)
     {
         $ret = $this->getMetadata($class);
         if ($ret && $ret[0]->hasField($property)) {
@@ -147,13 +137,8 @@ class DoctrineMongoDBTypeGuesser implements FormTypeGuesserInterface
         return null;
     }
 
-    /**
-     * @param string $class
-     * @param string $property
-     *
-     * @return ValueGuess|null
-     */
-    public function guessMaxLength($class, $property)
+    /** @return ValueGuess|null */
+    public function guessMaxLength(string $class, string $property)
     {
         return null;
     }
@@ -165,13 +150,8 @@ class DoctrineMongoDBTypeGuesser implements FormTypeGuesserInterface
     {
     }
 
-    /**
-     * @param string $class
-     * @param string $property
-     *
-     * @return ValueGuess|null
-     */
-    public function guessPattern($class, $property)
+    /** @return ValueGuess|null */
+    public function guessPattern(string $class, string $property)
     {
         $ret = $this->getMetadata($class);
         if (! $ret || ! $ret[0]->hasField($property) || $ret[0]->hasAssociation($property)) {

--- a/Form/Type/DocumentType.php
+++ b/Form/Type/DocumentType.php
@@ -21,11 +21,7 @@ use function interface_exists;
  */
 class DocumentType extends DoctrineType
 {
-    /**
-     * @param object $queryBuilder
-     * @param string $class
-     */
-    public function getLoader(ObjectManager $manager, $queryBuilder, $class): EntityLoaderInterface
+    public function getLoader(ObjectManager $manager, object $queryBuilder, string $class): EntityLoaderInterface
     {
         return new MongoDBQueryBuilderLoader(
             $queryBuilder,
@@ -74,16 +70,6 @@ class DocumentType extends DoctrineType
     public function getBlockPrefix()
     {
         return 'document';
-    }
-
-    /**
-     * @internal Symfony 2.7 compatibility
-     *
-     * @return string
-     */
-    public function getName()
-    {
-        return $this->getBlockPrefix();
     }
 }
 

--- a/Loader/SymfonyFixturesLoader.php
+++ b/Loader/SymfonyFixturesLoader.php
@@ -127,7 +127,7 @@ final class SymfonyFixturesLoader extends ContainerAwareLoader implements Symfon
      *
      * @param string[] $groups
      */
-    private function addGroupsFixtureMapping(string $className, array $groups)
+    private function addGroupsFixtureMapping(string $className, array $groups): void
     {
         foreach ($groups as $group) {
             $this->groupsFixtureMapping[$group][$className] = true;

--- a/ManagerConfigurator.php
+++ b/ManagerConfigurator.php
@@ -28,6 +28,8 @@ class ManagerConfigurator
 
     /**
      * Create a connection by name.
+     *
+     * @return void
      */
     public function configure(DocumentManager $documentManager)
     {

--- a/README.markdown
+++ b/README.markdown
@@ -15,7 +15,7 @@ Compatibility
 The current version of this bundle has the following requirements:
  * PHP 7.4 or newer is required
  * `ext-mongodb` 1.5 or newer
- * Symfony 4.3 or newer is required
+ * Symfony 5.4 or newer is required
 
 Support for older Symfony, PHP and MongoDB versions is provided via the `3.0.x`
 releases (tracked in the `3.0` branch). This version sees bug and security fixes

--- a/Resources/doc/messenger.rst
+++ b/Resources/doc/messenger.rst
@@ -1,8 +1,9 @@
 Messenger Integration
 =====================
 
-When using Symfony 4.4 or later, the bundle automatically registers a `Messenger`_
-event subscriber that clears all document managers after handling messages, which
-helps to isolate each handler and guard against reading out-of-date document data.
+When `symfony/messenger` package is installed, the bundle automatically
+registers a `Messenger`_ event subscriber that clears all document managers
+after handling messages, which helps to isolate each handler and guard
+against reading out-of-date document data.
 
 .. _`Messenger`: https://symfony.com/doc/current/components/messenger.html

--- a/Tests/DependencyInjection/AbstractMongoDBExtensionTest.php
+++ b/Tests/DependencyInjection/AbstractMongoDBExtensionTest.php
@@ -500,10 +500,9 @@ abstract class AbstractMongoDBExtensionTest extends TestCase
      * Asserts that the given definition contains a call to the method that uses
      * the specified parameters.
      *
-     * @param string $methodName
-     * @param array  $params
+     * @param mixed[] $params
      */
-    private function assertDefinitionMethodCallAny(Definition $definition, $methodName, array $params): void
+    private function assertDefinitionMethodCallAny(Definition $definition, string $methodName, array $params): void
     {
         $calls     = $definition->getMethodCalls();
         $called    = false;
@@ -538,10 +537,9 @@ abstract class AbstractMongoDBExtensionTest extends TestCase
      * Asserts that the given definition contains exactly one call to the method
      * and that it uses the specified parameters.
      *
-     * @param string $methodName
-     * @param array  $params
+     * @param mixed[] $params
      */
-    private function assertDefinitionMethodCallOnce(Definition $definition, $methodName, array $params): void
+    private function assertDefinitionMethodCallOnce(Definition $definition, string $methodName, array $params): void
     {
         $calls  = $definition->getMethodCalls();
         $called = false;

--- a/Tests/DependencyInjection/DoctrineMongoDBExtensionTest.php
+++ b/Tests/DependencyInjection/DoctrineMongoDBExtensionTest.php
@@ -69,10 +69,6 @@ class DoctrineMongoDBExtensionTest extends TestCase
     /** @requires PHP 8 */
     public function testAsDocumentListenerAttribute()
     {
-        if (! method_exists(ContainerBuilder::class, 'getAutoconfiguredAttributes')) {
-            $this->markTestSkipped('symfony/dependency-injection 5.3.0 needed');
-        }
-
         $container = $this->getContainer('DocumentListenerBundle');
         $extension = new DoctrineMongoDBExtension();
         $container->registerExtension($extension);

--- a/Tests/DependencyInjection/DoctrineMongoDBExtensionTest.php
+++ b/Tests/DependencyInjection/DoctrineMongoDBExtensionTest.php
@@ -21,7 +21,6 @@ use function array_merge;
 use function class_exists;
 use function interface_exists;
 use function is_dir;
-use function method_exists;
 use function sys_get_temp_dir;
 
 class DoctrineMongoDBExtensionTest extends TestCase
@@ -67,7 +66,7 @@ class DoctrineMongoDBExtensionTest extends TestCase
     }
 
     /** @requires PHP 8 */
-    public function testAsDocumentListenerAttribute()
+    public function testAsDocumentListenerAttribute(): void
     {
         $container = $this->getContainer('DocumentListenerBundle');
         $extension = new DoctrineMongoDBExtension();

--- a/Tests/FixtureIntegrationTest.php
+++ b/Tests/FixtureIntegrationTest.php
@@ -297,8 +297,7 @@ class IntegrationTestKernel extends Kernel
         ];
     }
 
-    /** @return void */
-    protected function build(ContainerBuilder $container)
+    protected function build(ContainerBuilder $container): void
     {
         $container->prependExtensionConfig('doctrine_mongodb', [
             'connections' => ['default' => []],

--- a/Tests/Form/Type/DocumentTypeTest.php
+++ b/Tests/Form/Type/DocumentTypeTest.php
@@ -128,7 +128,7 @@ class DocumentTypeTest extends TypeTestCase
     }
 
     /** @return FormExtensionInterface[] */
-    protected function getExtensions()
+    protected function getExtensions(): array
     {
         return array_merge(parent::getExtensions(), [
             new DoctrineMongoDBExtension($this->dmRegistry),

--- a/Tests/Form/Type/TypeGuesserTest.php
+++ b/Tests/Form/Type/TypeGuesserTest.php
@@ -86,7 +86,7 @@ class TypeGuesserTest extends TypeTestCase
     }
 
     /** @return FormExtensionInterface[] */
-    protected function getExtensions()
+    protected function getExtensions(): array
     {
         return array_merge(parent::getExtensions(), [
             new DoctrineMongoDBExtension($this->dmRegistry),

--- a/Tests/Mapping/Driver/AbstractDriverTest.php
+++ b/Tests/Mapping/Driver/AbstractDriverTest.php
@@ -61,11 +61,11 @@ abstract class AbstractDriverTest extends TestCase
         $locator->findMappingFile('MyOtherNamespace\MyBundle\Document\Foo');
     }
 
-    abstract protected function getFileExtension();
+    abstract protected function getFileExtension(): string;
 
-    abstract protected function getFixtureDir();
+    abstract protected function getFixtureDir(): string;
 
-    abstract protected function getDriver(array $paths = []);
+    abstract protected function getDriver(array $paths = []): FileDriver;
 
     private function getDriverLocator(FileDriver $driver): FileLocator
     {

--- a/Tests/Mapping/Driver/XmlDriverTest.php
+++ b/Tests/Mapping/Driver/XmlDriverTest.php
@@ -8,20 +8,17 @@ use Doctrine\Bundle\MongoDBBundle\Mapping\Driver\XmlDriver;
 
 class XmlDriverTest extends AbstractDriverTest
 {
-    /** @return string */
-    protected function getFileExtension()
+    protected function getFileExtension(): string
     {
         return '.mongodb.xml';
     }
 
-    /** @return string */
-    protected function getFixtureDir()
+    protected function getFixtureDir(): string
     {
         return __DIR__ . '/Fixtures/xml';
     }
 
-    /** @return XmlDriver */
-    protected function getDriver(array $paths = [])
+    protected function getDriver(array $paths = []): XmlDriver
     {
         return new XmlDriver($paths, $this->getFileExtension());
     }

--- a/composer.json
+++ b/composer.json
@@ -18,14 +18,14 @@
         "doctrine/mongodb-odm": "^2.3",
         "doctrine/persistence": "^2.2|^3.0",
         "psr/log": "^1.0|^2.0|^3.0",
-        "symfony/config": "^4.4|^5.3|^6.0",
-        "symfony/console": "^4.4.6|^5.3|^6.0",
-        "symfony/dependency-injection": "^4.4|^5.3|^6.0",
+        "symfony/config": "^5.4|^6.2",
+        "symfony/console": "^5.4|^6.2",
+        "symfony/dependency-injection": "^5.4|^6.2",
         "symfony/deprecation-contracts": "^2.1|^3.0",
-        "symfony/doctrine-bridge": "^4.4|^5.3|^6.0",
-        "symfony/framework-bundle": "^4.4|^5.3|^6.0",
-        "symfony/http-kernel": "^4.4|^5.0|^6.0",
-        "symfony/options-resolver": "^4.4|^5.3|^6.0"
+        "symfony/doctrine-bridge": "^5.4|^6.2",
+        "symfony/framework-bundle": "^5.4|^6.2",
+        "symfony/http-kernel": "^5.4|^6.2",
+        "symfony/options-resolver": "^5.4|^6.2"
     },
     "conflict": {
         "doctrine/data-fixtures": "<1.3"
@@ -35,13 +35,12 @@
         "doctrine/data-fixtures": "^1.3",
         "phpunit/phpunit": "^9.5.5",
         "psalm/plugin-symfony": "^5.0",
-        "squizlabs/php_codesniffer": "^3.5",
-        "symfony/form": "^4.3.3|^5.0|^6.0",
-        "symfony/phpunit-bridge": "^6.0",
-        "symfony/security-bundle": "^4.4|^5.3|^6.0",
-        "symfony/stopwatch": "^4.4|^5.3|^6.0",
-        "symfony/validator": "^4.4|^5.3|^6.0",
-        "symfony/yaml": "^4.3.3|^5.3|^6.0",
+        "symfony/form": "^5.4|^6.2",
+        "symfony/phpunit-bridge": "^6.2",
+        "symfony/security-bundle": "^5.4|^6.2",
+        "symfony/stopwatch": "^5.4|^6.2",
+        "symfony/validator": "^5.4|^6.2",
+        "symfony/yaml": "^5.4|^6.2",
         "vimeo/psalm": "^5.6"
     },
     "suggest": {

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "symfony/console": "^5.4|^6.2",
         "symfony/dependency-injection": "^5.4|^6.2",
         "symfony/deprecation-contracts": "^2.1|^3.0",
-        "symfony/doctrine-bridge": "^5.4|^6.2",
+        "symfony/doctrine-bridge": "^5.4.19|^6.2",
         "symfony/framework-bundle": "^5.4|^6.2",
         "symfony/http-kernel": "^5.4|^6.2",
         "symfony/options-resolver": "^5.4|^6.2"


### PR DESCRIPTION
This includes Symfony 4.4, 6.0 and 6.1

These versions [are unmaintained](https://symfony.com/releases#symfony-releases-calendar) (4.4 is only getting security fixes). I wanted to see how much code was involved and looks like it isn't that much, so I'm also fine if we don't remove support in `4.6.0`.