### PR TITLE
Add DocumentValueResolver and MapDocument

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -31,6 +31,7 @@ jobs:
         symfony-version:
           - "5.4.x"
           - "6.2.x"
+          - "6.3.x"
         driver-version:
           - "stable"
         dependencies:
@@ -45,6 +46,8 @@ jobs:
         exclude:
           - php-version: "7.4"
             symfony-version: "6.2.x"
+          - php-version: "7.4"
+            symfony-version: "6.3.x"
 
     services:
       mongodb:

--- a/ArgumentResolver/DocumentValueResolver.php
+++ b/ArgumentResolver/DocumentValueResolver.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Bundle\MongoDBBundle\ArgumentResolver;
+
+use Symfony\Bridge\Doctrine\ArgumentResolver\EntityValueResolver;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Controller\ValueResolverInterface;
+use Symfony\Component\HttpKernel\ControllerMetadata\ArgumentMetadata;
+
+/** @internal */
+final class DocumentValueResolver implements ValueResolverInterface
+{
+    public function __construct(
+        private EntityValueResolver $entityValueResolver,
+    ) {
+    }
+
+    public function resolve(Request $request, ArgumentMetadata $argument): array
+    {
+        return $this->entityValueResolver->resolve($request, $argument);
+    }
+}

--- a/Attribute/MapDocument.php
+++ b/Attribute/MapDocument.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Bundle\MongoDBBundle\Attribute;
+
+use Attribute;
+use Doctrine\Bundle\MongoDBBundle\ArgumentResolver\DocumentValueResolver;
+use Symfony\Bridge\Doctrine\Attribute\MapEntity;
+
+#[Attribute(Attribute::TARGET_PARAMETER)]
+class MapDocument extends MapEntity
+{
+    public function __construct(
+        public ?string $class = null,
+        public ?string $objectManager = null,
+        public ?string $expr = null,
+        public ?array $mapping = null,
+        public ?array $exclude = null,
+        public ?bool $stripNull = null,
+        public array|string|null $id = null,
+        bool $disabled = false,
+        string $resolver = DocumentValueResolver::class,
+    ) {
+        parent::__construct($class, $objectManager, $expr, $mapping, $exclude, $stripNull, $id, null, $disabled, $resolver);
+    }
+}

--- a/Resources/config/mongodb.xml
+++ b/Resources/config/mongodb.xml
@@ -208,13 +208,5 @@
         <service id="doctrine_mongodb.odm.symfony.fixtures.loader" class="Doctrine\Bundle\MongoDBBundle\Loader\SymfonyFixturesLoader" public="false">
             <argument type="service" id="service_container" />
         </service>
-
-        <service id="doctrine_mongodb.odm.entity_value_resolver" class="Symfony\Bridge\Doctrine\ArgumentResolver\EntityValueResolver">
-            <argument type="service" id="doctrine_mongodb" />
-            <argument type="service" id="doctrine_mongodb.odm.entity_value_resolver.expression_language" on-invalid="ignore" />
-            <tag name="controller.argument_value_resolver" priority="110" />
-        </service>
-
-        <service id="doctrine_mongodb.odm.entity_value_resolver.expression_language" class="Symfony\Component\ExpressionLanguage\ExpressionLanguage" />
     </services>
 </container>

--- a/Resources/config/value_resolver.xml
+++ b/Resources/config/value_resolver.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <services>
+        <service id="doctrine_mongodb.odm.entity_value_resolver" class="Symfony\Bridge\Doctrine\ArgumentResolver\EntityValueResolver">
+            <argument type="service" id="doctrine_mongodb" />
+            <argument type="service" id="doctrine_mongodb.odm.document_value_resolver.expression_language" on-invalid="ignore" />
+        </service>
+
+        <service id="doctrine_mongodb.odm.document_value_resolver.expression_language" class="Symfony\Component\ExpressionLanguage\ExpressionLanguage" />
+
+        <service id="doctrine_mongodb.odm.document_value_resolver" class="Doctrine\Bundle\MongoDBBundle\ArgumentResolver\DocumentValueResolver">
+            <argument type="service" id="doctrine_mongodb.odm.entity_value_resolver" />
+            <tag name="Doctrine\Bundle\MongoDBBundle\ArgumentResolver\DocumentValueResolver" priority="110">controller.argument_value_resolver</tag>
+        </service>
+    </services>
+</container>

--- a/Tests/DependencyInjection/AbstractMongoDBExtensionTest.php
+++ b/Tests/DependencyInjection/AbstractMongoDBExtensionTest.php
@@ -23,7 +23,6 @@ use Doctrine\ODM\MongoDB\Mapping\Driver\AttributeDriver;
 use Doctrine\Persistence\Mapping\Driver\MappingDriverChain;
 use MongoDB\Client;
 use PHPUnit\Framework\AssertionFailedError;
-use Symfony\Bridge\Doctrine\SchemaListener\DoctrineDbalCacheAdapterSchemaSubscriber;
 use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntityValidator;
 use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -309,10 +308,6 @@ abstract class AbstractMongoDBExtensionTest extends TestCase
 
     public function testNewBundleStructureXmlBundleMappingDetection(): void
     {
-        if (! class_exists(DoctrineDbalCacheAdapterSchemaSubscriber::class)) {
-            $this->markTestSkipped('Test requires symfony/doctrine-bridge >=5.4');
-        }
-
         $container = $this->getContainer('NewXmlBundle');
         $loader    = new DoctrineMongoDBExtension();
         $config    = DoctrineMongoDBExtensionTest::buildConfiguration(

--- a/Tests/DependencyInjection/DoctrineMongoDBExtensionTest.php
+++ b/Tests/DependencyInjection/DoctrineMongoDBExtensionTest.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Doctrine\Bundle\MongoDBBundle\Tests\DependencyInjection;
 
+use Doctrine\Bundle\MongoDBBundle\Attribute\MapDocument;
 use Doctrine\Bundle\MongoDBBundle\DependencyInjection\DoctrineMongoDBExtension;
 use Doctrine\Bundle\MongoDBBundle\Tests\DependencyInjection\Fixtures\Bundles\DocumentListenerBundle\EventListener\TestAttributeListener;
 use PHPUnit\Framework\TestCase;
-use Symfony\Bridge\Doctrine\Attribute\MapEntity;
 use Symfony\Bridge\Doctrine\Messenger\DoctrineClearEntityManagerWorkerSubscriber;
 use Symfony\Component\DependencyInjection\Alias;
 use Symfony\Component\DependencyInjection\Container;
@@ -353,7 +353,10 @@ class DoctrineMongoDBExtensionTest extends TestCase
 
         $controllerResolver = $container->getDefinition('doctrine_mongodb.odm.entity_value_resolver');
 
-        $this->assertEquals([new Reference('doctrine_mongodb'), new Reference('doctrine_mongodb.odm.entity_value_resolver.expression_language', $container::IGNORE_ON_INVALID_REFERENCE)], $controllerResolver->getArguments());
+        $this->assertEquals([
+            new Reference('doctrine_mongodb'),
+            new Reference('doctrine_mongodb.odm.document_value_resolver.expression_language', $container::IGNORE_ON_INVALID_REFERENCE),
+        ], $controllerResolver->getArguments());
 
         $container = $this->getContainer();
 
@@ -366,6 +369,6 @@ class DoctrineMongoDBExtensionTest extends TestCase
 
         $container->setDefinition('controller_resolver_defaults', $container->getDefinition('doctrine_mongodb.odm.entity_value_resolver')->getArgument(2))->setPublic(true);
         $container->compile();
-        $this->assertEquals(new MapEntity(null, null, null, [], null, null, null, null, true), $container->get('controller_resolver_defaults'));
+        $this->assertEquals(new MapDocument(null, null, null, [], null, null, null, true), $container->get('controller_resolver_defaults'));
     }
 }

--- a/Tests/DocumentValueResolverFunctionalTest.php
+++ b/Tests/DocumentValueResolverFunctionalTest.php
@@ -1,0 +1,150 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Bundle\MongoDBBundle\Tests;
+
+use Doctrine\Bundle\MongoDBBundle\DoctrineMongoDBBundle;
+use Doctrine\Bundle\MongoDBBundle\Tests\Fixtures\FooBundle\Controller\DocumentValueResolverController;
+use Doctrine\Bundle\MongoDBBundle\Tests\Fixtures\FooBundle\Document\User;
+use Doctrine\Bundle\MongoDBBundle\Tests\Fixtures\FooBundle\FooBundle;
+use Doctrine\ODM\MongoDB\DocumentManager;
+use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
+use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\Config\Loader\LoaderInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\HttpKernel\Kernel;
+use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
+
+use function sys_get_temp_dir;
+use function uniqid;
+
+/**
+ * @requires PHP 8.0
+ * @requires function \Symfony\Bridge\Doctrine\Attribute\MapEntity::__construct
+ */
+class DocumentValueResolverFunctionalTest extends WebTestCase
+{
+    public function testWithoutConfiguration(): void
+    {
+        $client = static::createClient();
+
+        $dm   = static::getContainer()->get(DocumentManager::class);
+        $user = new User('user-identifier');
+
+        $dm->persist($user);
+        $dm->flush();
+
+        $client->request('GET', '/user/user-identifier');
+
+        $this->assertResponseIsSuccessful();
+        $this->assertSame('user-identifier', $client->getResponse()->getContent());
+
+        $dm->remove($user);
+    }
+
+    public function testWithConfiguration(): void
+    {
+        $client = static::createClient();
+
+        $dm   = static::getContainer()->get(DocumentManager::class);
+        $user = new User('user-identifier');
+
+        $dm->persist($user);
+        $dm->flush();
+
+        $client->request('GET', '/user_with_mapping/user-identifier');
+
+        $this->assertResponseIsSuccessful();
+        $this->assertSame('user-identifier', $client->getResponse()->getContent());
+
+        $dm->remove($user);
+    }
+
+    protected static function getKernelClass(): string
+    {
+        return FooTestKernel::class;
+    }
+}
+
+class FooTestKernel extends Kernel
+{
+    use MicroKernelTrait;
+
+    private string $randomKey;
+
+    public function __construct()
+    {
+        $this->randomKey = uniqid('');
+
+        parent::__construct('test', false);
+    }
+
+    protected function getContainerClass(): string
+    {
+        return 'test' . $this->randomKey . parent::getContainerClass();
+    }
+
+    public function registerBundles(): array
+    {
+        return [
+            new FrameworkBundle(),
+            new DoctrineMongoDBBundle(),
+            new FooBundle(),
+        ];
+    }
+
+    protected function configureRoutes(RoutingConfigurator $routes): void
+    {
+        $routes->add('tv_user_show', '/user/{id}')
+            ->controller([DocumentValueResolverController::class, 'showUserByDefault']);
+
+        $routes->add('user_with_mapping', '/user_with_mapping/{identifier}')
+            ->controller([DocumentValueResolverController::class, 'showUserWithMapping']);
+    }
+
+    protected function configureContainer(ContainerBuilder $c, LoaderInterface $loader): void
+    {
+        $c->loadFromExtension('framework', [
+            'secret' => 'foo',
+            'router' => ['utf8' => false],
+            'http_method_override' => false,
+            'test' => true,
+        ]);
+
+        $c->loadFromExtension('doctrine_mongodb', [
+            'connections' => ['default' => []],
+            'document_managers' => [
+                'default' => [
+                    'mappings' => [
+                        'App' => [
+                            'is_bundle' => false,
+                            'type' => 'attribute',
+                            'dir' => '%kernel.project_dir%/Document',
+                            'prefix' => 'Doctrine\Bundle\MongoDBBundle\Tests\Fixtures\FooBundle',
+                            'alias' => 'Doctrine\Bundle\MongoDBBundle\Tests\Fixtures\FooBundle',
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        $loader->load(__DIR__ . '/Fixtures/FooBundle/config/services.php');
+    }
+
+    public function getProjectDir(): string
+    {
+        return __DIR__ . '/Fixtures/FooBundle/';
+    }
+
+    public function getCacheDir(): string
+    {
+        return sys_get_temp_dir() . '/doctrine_mongodb_odm_bundle' . $this->randomKey;
+    }
+
+    public function getLogDir(): string
+    {
+        return sys_get_temp_dir();
+    }
+}

--- a/Tests/Fixtures/FooBundle/Controller/DocumentValueResolverController.php
+++ b/Tests/Fixtures/FooBundle/Controller/DocumentValueResolverController.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Bundle\MongoDBBundle\Tests\Fixtures\FooBundle\Controller;
+
+use Doctrine\Bundle\MongoDBBundle\Attribute\MapDocument;
+use Doctrine\Bundle\MongoDBBundle\Tests\Fixtures\FooBundle\Document\User;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\Routing\Annotation\Route;
+
+#[AsController]
+final class DocumentValueResolverController
+{
+    #[Route(path: '/user/{id}', name: 'tv_user_show')]
+    public function showUserByDefault(
+        User $user
+    ): Response {
+        return new Response($user->getId());
+    }
+
+    #[Route(path: '/user_with_identifier/{identifier}', name: 'tv_user_show_with_identifier')]
+    public function showUserWithMapping(
+        #[MapDocument(mapping: ['identifier' => 'id'])]
+        User $user
+    ): Response {
+        return new Response($user->getId());
+    }
+}

--- a/Tests/Fixtures/FooBundle/Document/User.php
+++ b/Tests/Fixtures/FooBundle/Document/User.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Bundle\MongoDBBundle\Tests\Fixtures\FooBundle\Document;
+
+use Doctrine\ODM\MongoDB\Mapping\Annotations\Document;
+use Doctrine\ODM\MongoDB\Mapping\Annotations\Id;
+
+#[Document(collection: 'doctrine_mongodb_test_user')]
+class User
+{
+    public function __construct(
+        #[Id(strategy: 'NONE')]
+        private string $id,
+    ) {
+    }
+
+    public function getId(): string
+    {
+        return $this->id;
+    }
+}

--- a/Tests/Fixtures/FooBundle/config/services.php
+++ b/Tests/Fixtures/FooBundle/config/services.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $services = $containerConfigurator->services()
+        ->defaults()
+        ->autowire()
+        ->autoconfigure();
+
+    $services->load('Doctrine\\Bundle\\MongoDBBundle\\Tests\\Fixtures\\FooBundle\\', '..')
+        ->exclude('../{config,DataFixtures,Document}');
+};

--- a/composer.json
+++ b/composer.json
@@ -45,6 +45,7 @@
         "doctrine/data-fixtures": "^1.3",
         "phpunit/phpunit": "^9.5.5",
         "psalm/plugin-symfony": "^5.0",
+        "symfony/browser-kit": "^5.4 || ^6.2",
         "symfony/form": "^5.4 || ^6.2",
         "symfony/phpunit-bridge": "^6.2",
         "symfony/security-bundle": "^5.4 || ^6.2",


### PR DESCRIPTION
Alternative to https://github.com/doctrine/DoctrineMongoDBBundle/pull/773

[Since we cannot use `EntityValueResolver` and `MapEntity`](https://github.com/doctrine/DoctrineMongoDBBundle/pull/773#issuecomment-1548156064), this is an alternative to make it work.

The problem is that since Symfony 6.3, because targeted resolvers, `MapEntity` cannot be used when using ORM + ODM.

Closes #770 
Closes #773