### PR TITLE
Fix missing driver instrumentation

### DIFF
--- a/DependencyInjection/DoctrineMongoDBExtension.php
+++ b/DependencyInjection/DoctrineMongoDBExtension.php
@@ -16,6 +16,7 @@ use Doctrine\Common\DataFixtures\Loader as DataFixturesLoader;
 use Doctrine\Common\EventSubscriber;
 use Doctrine\ODM\MongoDB\DocumentManager;
 use InvalidArgumentException;
+use Jean85\PrettyVersions;
 use Symfony\Bridge\Doctrine\DependencyInjection\AbstractDoctrineExtension;
 use Symfony\Bridge\Doctrine\Messenger\DoctrineClearEntityManagerWorkerSubscriber;
 use Symfony\Component\Cache\Adapter\ApcuAdapter;
@@ -31,6 +32,7 @@ use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\Messenger\MessageBusInterface;
+use Throwable;
 
 use function array_keys;
 use function array_merge;
@@ -48,6 +50,9 @@ use function sprintf;
  */
 class DoctrineMongoDBExtension extends AbstractDoctrineExtension
 {
+    /** @var string */
+    private static $odmVersion;
+
     /** @internal */
     public const CONFIGURATION_TAG = 'doctrine.odm.configuration';
 
@@ -407,6 +412,11 @@ class DoctrineMongoDBExtension extends AbstractDoctrineExtension
             $driverOptions['context'] = new Reference($driverOptions['context']);
         }
 
+        $driverOptions['driver'] = [
+            'name' => 'symfony-mongodb',
+            'version' => self::getODMVersion(),
+        ];
+
         return $driverOptions;
     }
 
@@ -609,5 +619,18 @@ class DoctrineMongoDBExtension extends AbstractDoctrineExtension
         return method_exists(BaseNode::class, 'getDeprecation')
             ? ['doctrine/mongodb-odm-bundle', $version, $message]
             : [$message];
+    }
+
+    private static function getODMVersion(): string
+    {
+        if (self::$odmVersion === null) {
+            try {
+                self::$odmVersion = PrettyVersions::getVersion('doctrine/mongodb-odm')->getPrettyVersion();
+            } catch (Throwable $t) {
+                return 'unknown';
+            }
+        }
+
+        return self::$odmVersion;
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
         "doctrine/annotations": "^1.13",
         "doctrine/mongodb-odm": "^2.3",
         "doctrine/persistence": "^2.2|^3.0",
+        "jean85/pretty-package-versions": "^1.3.0 || ^2.0.1",
         "psr/log": "^1.0|^2.0|^3.0",
         "symfony/config": "^4.4|^5.3|^6.0",
         "symfony/console": "^4.4.6|^5.3|^6.0",


### PR DESCRIPTION
The ODM sends its own version data to servers to augment the driver version info. When using the bundle, the client isn't created by the DocumentManager, so this driver data is missing. This PR fixes this issue by adding the correct version info for Doctrine ODM.

Note that the added dependency is already a dependency of the ODM itself and does not add to the dependency chain. It is merely added here to avoid relying on a transitive dependency.