### PR TITLE
Fix phpdoc return type

### DIFF
--- a/Command/TailCursorDoctrineODMCommand.php
+++ b/Command/TailCursorDoctrineODMCommand.php
@@ -108,7 +108,7 @@ class TailCursorDoctrineODMCommand extends Command implements ContainerAwareInte
         return 0;
     }
 
-    /** @return ContainerInterface */
+    /** @return ContainerInterface|null */
     protected function getContainer()
     {
         return $this->container;


### PR DESCRIPTION
spotted in https://github.com/doctrine/DoctrineMongoDBBundle/actions/runs/5711475720/job/15473160391

https://github.com/symfony/symfony/blob/3034e8e423d0b160c2b44a170016377bd3a59ec7/src/Symfony/Component/DependencyInjection/ContainerAwareTrait.php#L19-L30

`$container` can be null