### PR TITLE
Fix TailCursorDoctrineODMCommand Static Analysis

### DIFF
--- a/Command/TailCursorDoctrineODMCommand.php
+++ b/Command/TailCursorDoctrineODMCommand.php
@@ -108,7 +108,7 @@ class TailCursorDoctrineODMCommand extends Command implements ContainerAwareInte
         return 0;
     }
 
-    /** @return ContainerInterface */
+    /** @return ContainerInterface|null */
     protected function getContainer()
     {
         return $this->container;


### PR DESCRIPTION
Fix the following complaints from Static Analysis.

```
[InvalidNullableReturnType: Command/TailCursorDoctrineODMCommand.php#L111](https://github.com/mustanggb/DoctrineMongoDBBundle/commit/294b0fb99432bd5a21dbcc24f87f195bcb2cf7b8#annotation_15142273754)
Command/TailCursorDoctrineODMCommand.php:111:17: InvalidNullableReturnType: The declared return type 'Psr\Container\ContainerInterface' for Doctrine\Bundle\MongoDBBundle\Command\TailCursorDoctrineODMCommand::getContainer is not nullable, but 'Symfony\Component\DependencyInjection\ContainerInterface|null' contains null (see https://psalm.dev/144)
```

```
[NullableReturnStatement: Command/TailCursorDoctrineODMCommand.php#L114](https://github.com/mustanggb/DoctrineMongoDBBundle/commit/294b0fb99432bd5a21dbcc24f87f195bcb2cf7b8#annotation_15142273760)
Command/TailCursorDoctrineODMCommand.php:114:16: NullableReturnStatement: The declared return type 'Psr\Container\ContainerInterface' for Doctrine\Bundle\MongoDBBundle\Command\TailCursorDoctrineODMCommand::getContainer is not nullable, but the function returns 'Symfony\Component\DependencyInjection\ContainerInterface|null' (see https://psalm.dev/139)
```