### PR TITLE
Remove deprecations using Symfony 6.4

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -29,8 +29,7 @@ jobs:
           - "stable"
         symfony-version:
           - "5.4.*"
-          - "6.2.*"
-          - "6.3.*"
+          - "6.4.*"
         driver-version:
           - "stable"
         dependencies:

--- a/CacheWarmer/HydratorCacheWarmer.php
+++ b/CacheWarmer/HydratorCacheWarmer.php
@@ -46,7 +46,7 @@ class HydratorCacheWarmer implements CacheWarmerInterface
     }
 
     /** @return string[] */
-    public function warmUp(string $cacheDir)
+    public function warmUp(string $cacheDir, ?string $buildDir = null)
     {
         // we need the directory no matter the hydrator cache generation strategy.
         $hydratorCacheDir = (string) $this->container->getParameter('doctrine_mongodb.odm.hydrator_dir');

--- a/CacheWarmer/PersistentCollectionCacheWarmer.php
+++ b/CacheWarmer/PersistentCollectionCacheWarmer.php
@@ -47,7 +47,7 @@ class PersistentCollectionCacheWarmer implements CacheWarmerInterface
     }
 
     /** @return string[] */
-    public function warmUp(string $cacheDir)
+    public function warmUp(string $cacheDir, ?string $buildDir = null)
     {
         // we need the directory no matter the hydrator cache generation strategy.
         $collCacheDir = (string) $this->container->getParameter('doctrine_mongodb.odm.persistent_collection_dir');

--- a/CacheWarmer/ProxyCacheWarmer.php
+++ b/CacheWarmer/ProxyCacheWarmer.php
@@ -48,7 +48,7 @@ class ProxyCacheWarmer implements CacheWarmerInterface
     }
 
     /** @return string[] */
-    public function warmUp(string $cacheDir)
+    public function warmUp(string $cacheDir, ?string $buildDir = null)
     {
         // we need the directory no matter the proxy cache generation strategy.
         $proxyCacheDir = (string) $this->container->getParameter('doctrine_mongodb.odm.proxy_dir');

--- a/Command/TailCursorDoctrineODMCommand.php
+++ b/Command/TailCursorDoctrineODMCommand.php
@@ -14,7 +14,6 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
-use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 use Throwable;
 
 use function sleep;
@@ -28,7 +27,8 @@ use function trigger_deprecation;
  */
 class TailCursorDoctrineODMCommand extends Command implements ContainerAwareInterface
 {
-    use ContainerAwareTrait;
+    /** @var ContainerInterface|null */
+    protected $container;
 
     /** @return void */
     protected function configure()
@@ -106,6 +106,12 @@ class TailCursorDoctrineODMCommand extends Command implements ContainerAwareInte
         }
 
         return 0;
+    }
+
+    /** @return void */
+    public function setContainer(?ContainerInterface $container = null)
+    {
+        $this->container = $container;
     }
 
     /** @return ContainerInterface|null */

--- a/Loader/SymfonyFixturesLoader.php
+++ b/Loader/SymfonyFixturesLoader.php
@@ -8,23 +8,30 @@ use Doctrine\Bundle\MongoDBBundle\DependencyInjection\Compiler\FixturesCompilerP
 use Doctrine\Bundle\MongoDBBundle\Fixture\FixtureGroupInterface;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Common\DataFixtures\FixtureInterface;
+use Doctrine\Common\DataFixtures\Loader;
 use LogicException;
 use ReflectionClass;
 use RuntimeException;
-use Symfony\Bridge\Doctrine\DataFixtures\ContainerAwareLoader;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 use function array_key_exists;
 use function array_values;
 use function get_class;
 use function sprintf;
 
-final class SymfonyFixturesLoader extends ContainerAwareLoader implements SymfonyFixturesLoaderInterface
+final class SymfonyFixturesLoader extends Loader implements SymfonyFixturesLoaderInterface
 {
     /** @var FixtureInterface[] */
     private array $loadedFixtures = [];
 
     /** @var array<string, array<string, bool>> */
     private array $groupsFixtureMapping = [];
+
+    public function __construct(
+        private ContainerInterface $container,
+    ) {
+    }
 
     /**
      * @internal
@@ -58,6 +65,10 @@ final class SymfonyFixturesLoader extends ContainerAwareLoader implements Symfon
 
         if ($fixture instanceof FixtureGroupInterface) {
             $this->addGroupsFixtureMapping($class, $fixture::getGroups());
+        }
+
+        if ($fixture instanceof ContainerAwareInterface) {
+            $fixture->setContainer($this->container);
         }
 
         parent::addFixture($fixture);

--- a/Tests/DependencyInjection/Fixtures/Bundles/RepositoryServiceBundle/Document/TestCustomClassRepoDocument.php
+++ b/Tests/DependencyInjection/Fixtures/Bundles/RepositoryServiceBundle/Document/TestCustomClassRepoDocument.php
@@ -8,8 +8,10 @@ use Doctrine\Bundle\MongoDBBundle\Tests\DependencyInjection\Fixtures\Bundles\Rep
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
 /** @ODM\Document(repositoryClass=TestCustomClassRepoRepository::class) */
+#[ODM\Document(repositoryClass: TestCustomClassRepoRepository::class)]
 class TestCustomClassRepoDocument
 {
     /** @ODM\Id */
+    #[ODM\Id]
     private string $id;
 }

--- a/Tests/DependencyInjection/Fixtures/Bundles/RepositoryServiceBundle/Document/TestCustomClassRepoDocument.php
+++ b/Tests/DependencyInjection/Fixtures/Bundles/RepositoryServiceBundle/Document/TestCustomClassRepoDocument.php
@@ -7,11 +7,9 @@ namespace Doctrine\Bundle\MongoDBBundle\Tests\DependencyInjection\Fixtures\Bundl
 use Doctrine\Bundle\MongoDBBundle\Tests\DependencyInjection\Fixtures\Bundles\RepositoryServiceBundle\Repository\TestCustomClassRepoRepository;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
-/** @ODM\Document(repositoryClass=TestCustomClassRepoRepository::class) */
 #[ODM\Document(repositoryClass: TestCustomClassRepoRepository::class)]
 class TestCustomClassRepoDocument
 {
-    /** @ODM\Id */
     #[ODM\Id]
     private string $id;
 }

--- a/Tests/DependencyInjection/Fixtures/Bundles/RepositoryServiceBundle/Document/TestCustomServiceRepoDocument.php
+++ b/Tests/DependencyInjection/Fixtures/Bundles/RepositoryServiceBundle/Document/TestCustomServiceRepoDocument.php
@@ -8,8 +8,10 @@ use Doctrine\Bundle\MongoDBBundle\Tests\DependencyInjection\Fixtures\Bundles\Rep
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
 /** @ODM\Document(repositoryClass=TestCustomServiceRepoDocumentRepository::class) */
+#[ODM\Document(repositoryClass: TestCustomServiceRepoDocumentRepository::class)]
 class TestCustomServiceRepoDocument
 {
     /** @ODM\Id */
+    #[ODM\Id]
     private string $id;
 }

--- a/Tests/DependencyInjection/Fixtures/Bundles/RepositoryServiceBundle/Document/TestCustomServiceRepoDocument.php
+++ b/Tests/DependencyInjection/Fixtures/Bundles/RepositoryServiceBundle/Document/TestCustomServiceRepoDocument.php
@@ -7,11 +7,9 @@ namespace Doctrine\Bundle\MongoDBBundle\Tests\DependencyInjection\Fixtures\Bundl
 use Doctrine\Bundle\MongoDBBundle\Tests\DependencyInjection\Fixtures\Bundles\RepositoryServiceBundle\Repository\TestCustomServiceRepoDocumentRepository;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
-/** @ODM\Document(repositoryClass=TestCustomServiceRepoDocumentRepository::class) */
 #[ODM\Document(repositoryClass: TestCustomServiceRepoDocumentRepository::class)]
 class TestCustomServiceRepoDocument
 {
-    /** @ODM\Id */
     #[ODM\Id]
     private string $id;
 }

--- a/Tests/DependencyInjection/Fixtures/Bundles/RepositoryServiceBundle/Document/TestCustomServiceRepoFile.php
+++ b/Tests/DependencyInjection/Fixtures/Bundles/RepositoryServiceBundle/Document/TestCustomServiceRepoFile.php
@@ -8,8 +8,10 @@ use Doctrine\Bundle\MongoDBBundle\Tests\DependencyInjection\Fixtures\Bundles\Rep
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
 /** @ODM\File(repositoryClass=TestCustomServiceRepoGridFSRepository::class) */
+#[ODM\File(repositoryClass: TestCustomServiceRepoGridFSRepository::class)]
 class TestCustomServiceRepoFile
 {
     /** @ODM\Id */
+    #[ODM\Id]
     private string $id;
 }

--- a/Tests/DependencyInjection/Fixtures/Bundles/RepositoryServiceBundle/Document/TestCustomServiceRepoFile.php
+++ b/Tests/DependencyInjection/Fixtures/Bundles/RepositoryServiceBundle/Document/TestCustomServiceRepoFile.php
@@ -7,11 +7,9 @@ namespace Doctrine\Bundle\MongoDBBundle\Tests\DependencyInjection\Fixtures\Bundl
 use Doctrine\Bundle\MongoDBBundle\Tests\DependencyInjection\Fixtures\Bundles\RepositoryServiceBundle\Repository\TestCustomServiceRepoGridFSRepository;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
-/** @ODM\File(repositoryClass=TestCustomServiceRepoGridFSRepository::class) */
 #[ODM\File(repositoryClass: TestCustomServiceRepoGridFSRepository::class)]
 class TestCustomServiceRepoFile
 {
-    /** @ODM\Id */
     #[ODM\Id]
     private string $id;
 }

--- a/Tests/DependencyInjection/Fixtures/Bundles/RepositoryServiceBundle/Document/TestDefaultRepoDocument.php
+++ b/Tests/DependencyInjection/Fixtures/Bundles/RepositoryServiceBundle/Document/TestDefaultRepoDocument.php
@@ -7,8 +7,10 @@ namespace Doctrine\Bundle\MongoDBBundle\Tests\DependencyInjection\Fixtures\Bundl
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
 /** @ODM\Document */
+#[ODM\Document]
 class TestDefaultRepoDocument
 {
     /** @ODM\Id */
+    #[ODM\Id]
     private string $id;
 }

--- a/Tests/DependencyInjection/Fixtures/Bundles/RepositoryServiceBundle/Document/TestDefaultRepoDocument.php
+++ b/Tests/DependencyInjection/Fixtures/Bundles/RepositoryServiceBundle/Document/TestDefaultRepoDocument.php
@@ -6,11 +6,9 @@ namespace Doctrine\Bundle\MongoDBBundle\Tests\DependencyInjection\Fixtures\Bundl
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
-/** @ODM\Document */
 #[ODM\Document]
 class TestDefaultRepoDocument
 {
-    /** @ODM\Id */
     #[ODM\Id]
     private string $id;
 }

--- a/Tests/DependencyInjection/Fixtures/Bundles/RepositoryServiceBundle/Document/TestDefaultRepoFile.php
+++ b/Tests/DependencyInjection/Fixtures/Bundles/RepositoryServiceBundle/Document/TestDefaultRepoFile.php
@@ -6,11 +6,9 @@ namespace Doctrine\Bundle\MongoDBBundle\Tests\DependencyInjection\Fixtures\Bundl
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
-/** @ODM\File */
 #[ODM\File]
 class TestDefaultRepoFile
 {
-    /** @ODM\Id */
     #[ODM\Id]
     private string $id;
 }

--- a/Tests/DependencyInjection/Fixtures/Bundles/RepositoryServiceBundle/Document/TestDefaultRepoFile.php
+++ b/Tests/DependencyInjection/Fixtures/Bundles/RepositoryServiceBundle/Document/TestDefaultRepoFile.php
@@ -7,8 +7,10 @@ namespace Doctrine\Bundle\MongoDBBundle\Tests\DependencyInjection\Fixtures\Bundl
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
 /** @ODM\File */
+#[ODM\File]
 class TestDefaultRepoFile
 {
     /** @ODM\Id */
+    #[ODM\Id]
     private string $id;
 }

--- a/Tests/DependencyInjection/Fixtures/TestKernel.php
+++ b/Tests/DependencyInjection/Fixtures/TestKernel.php
@@ -45,7 +45,7 @@ class TestKernel extends Kernel
                     'default' => [
                         'mappings' => [
                             'RepositoryServiceBundle' => [
-                                'type' => 'annotation',
+                                'type' => 'attribute',
                                 'dir' => __DIR__ . '/Bundles/RepositoryServiceBundle/Document',
                                 'prefix' => 'Fixtures\Bundles\RepositoryServiceBundle\Document',
                             ],

--- a/Tests/Fixtures/Cache/Collections.php
+++ b/Tests/Fixtures/Cache/Collections.php
@@ -8,23 +8,18 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use MongoDB\BSON\ObjectId;
 
-/** @ODM\Document */
 #[ODM\Document]
 class Collections
 {
-    /** @ODM\Id */
     #[ODM\Id]
     public ?ObjectId $id = null;
 
-    /** @ODM\EmbedMany(collectionClass=SomeCollection::class) */
     #[ODM\EmbedMany(collectionClass: SomeCollection::class)]
     public SomeCollection $coll;
 
-    /** @ODM\ReferenceMany(collectionClass=SomeCollection::class) */
     #[ODM\ReferenceMany(collectionClass: SomeCollection::class)]
     public SomeCollection $refs;
 
-    /** @ODM\EmbedMany(collectionClass=AnotherCollection::class) */
     #[ODM\EmbedMany(collectionClass: AnotherCollection::class)]
     public AnotherCollection $another;
 }

--- a/Tests/Fixtures/Cache/Collections.php
+++ b/Tests/Fixtures/Cache/Collections.php
@@ -9,18 +9,23 @@ use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use MongoDB\BSON\ObjectId;
 
 /** @ODM\Document */
+#[ODM\Document]
 class Collections
 {
     /** @ODM\Id */
+    #[ODM\Id]
     public ?ObjectId $id = null;
 
     /** @ODM\EmbedMany(collectionClass=SomeCollection::class) */
+    #[ODM\EmbedMany(collectionClass: SomeCollection::class)]
     public SomeCollection $coll;
 
     /** @ODM\ReferenceMany(collectionClass=SomeCollection::class) */
+    #[ODM\ReferenceMany(collectionClass: SomeCollection::class)]
     public SomeCollection $refs;
 
     /** @ODM\EmbedMany(collectionClass=AnotherCollection::class) */
+    #[ODM\EmbedMany(collectionClass: AnotherCollection::class)]
     public AnotherCollection $another;
 }
 

--- a/Tests/Fixtures/CommandBundle/Document/User.php
+++ b/Tests/Fixtures/CommandBundle/Document/User.php
@@ -7,8 +7,10 @@ namespace Doctrine\Bundle\MongoDBBundle\Tests\Fixtures\CommandBundle\Document;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
 /** @ODM\Document */
+#[ODM\Document]
 class User
 {
     /** @ODM\Id */
+    #[ODM\Id]
     private ?string $id = null;
 }

--- a/Tests/Fixtures/CommandBundle/Document/User.php
+++ b/Tests/Fixtures/CommandBundle/Document/User.php
@@ -6,11 +6,9 @@ namespace Doctrine\Bundle\MongoDBBundle\Tests\Fixtures\CommandBundle\Document;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
-/** @ODM\Document */
 #[ODM\Document]
 class User
 {
-    /** @ODM\Id */
     #[ODM\Id]
     private ?string $id = null;
 }

--- a/Tests/Fixtures/DataCollector/Category.php
+++ b/Tests/Fixtures/DataCollector/Category.php
@@ -8,15 +8,12 @@ use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Doctrine\ODM\MongoDB\Types\Type;
 use MongoDB\BSON\ObjectId;
 
-/** @ODM\Document */
 #[ODM\Document]
 class Category
 {
-    /** @ODM\Id */
     #[ODM\Id]
     protected ?ObjectId $id = null;
 
-    /** @ODM\Field(type="string") */
     #[ODM\Field(type: Type::STRING)]
     public string $name;
 

--- a/Tests/Fixtures/DataCollector/Category.php
+++ b/Tests/Fixtures/DataCollector/Category.php
@@ -5,15 +5,19 @@ declare(strict_types=1);
 namespace Doctrine\Bundle\MongoDBBundle\Tests\Fixtures\DataCollector;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Types\Type;
 use MongoDB\BSON\ObjectId;
 
 /** @ODM\Document */
+#[ODM\Document]
 class Category
 {
     /** @ODM\Id */
+    #[ODM\Id]
     protected ?ObjectId $id = null;
 
     /** @ODM\Field(type="string") */
+    #[ODM\Field(type: Type::STRING)]
     public string $name;
 
     public function __construct(string $name)

--- a/Tests/Fixtures/Form/Category.php
+++ b/Tests/Fixtures/Form/Category.php
@@ -10,26 +10,16 @@ use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Doctrine\ODM\MongoDB\Types\Type;
 use MongoDB\BSON\ObjectId;
 
-/** @ODM\Document */
 #[ODM\Document]
 class Category
 {
-    /** @ODM\Id */
     #[ODM\Id]
     protected ObjectId|string|null $id;
 
-    /** @ODM\Field(type="string") */
     #[ODM\Field(type: Type::STRING)]
     public string $name;
 
-    /**
-     * @ODM\ReferenceMany(
-     *     targetDocument="Doctrine\Bundle\MongoDBBundle\Tests\Fixtures\Form\Document",
-     *     mappedBy="categories"
-     * )
-     *
-     * @var Collection<int, Document>
-     */
+    /** @var Collection<int, Document> */
     #[ODM\ReferenceMany(
         targetDocument: Document::class,
         mappedBy: 'categories',

--- a/Tests/Fixtures/Form/Category.php
+++ b/Tests/Fixtures/Form/Category.php
@@ -7,15 +7,19 @@ namespace Doctrine\Bundle\MongoDBBundle\Tests\Fixtures\Form;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Types\Type;
 use MongoDB\BSON\ObjectId;
 
 /** @ODM\Document */
+#[ODM\Document]
 class Category
 {
     /** @ODM\Id */
+    #[ODM\Id]
     protected ObjectId|string|null $id;
 
     /** @ODM\Field(type="string") */
+    #[ODM\Field(type: Type::STRING)]
     public string $name;
 
     /**
@@ -26,6 +30,10 @@ class Category
      *
      * @var Collection<int, Document>
      */
+    #[ODM\ReferenceMany(
+        targetDocument: Document::class,
+        mappedBy: 'categories',
+    )]
     public Collection $documents;
 
     public function __construct(string $name)

--- a/Tests/Fixtures/Form/Document.php
+++ b/Tests/Fixtures/Form/Document.php
@@ -7,15 +7,20 @@ namespace Doctrine\Bundle\MongoDBBundle\Tests\Fixtures\Form;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
+use Doctrine\ODM\MongoDB\Types\Type;
 use MongoDB\BSON\ObjectId;
 
 /** @ODM\Document */
+#[ODM\Document]
 class Document
 {
     /** @ODM\Id(strategy="none") */
+    #[ODM\Id(strategy: 'none')]
     protected ObjectId $id;
 
     /** @ODM\Field(type="string") */
+    #[ODM\Field(type: Type::STRING)]
     public string $name;
 
     /**
@@ -27,6 +32,11 @@ class Document
      *
      * @var Collection<int, Category>
      */
+    #[ODM\ReferenceMany(
+        targetDocument: Category::class,
+        inversedBy: 'documents',
+        strategy: ClassMetadata::STORAGE_STRATEGY_ATOMIC_SET_ARRAY,
+    )]
     public Collection $categories;
 
     public function __construct(ObjectId $id, string $name)

--- a/Tests/Fixtures/Form/Document.php
+++ b/Tests/Fixtures/Form/Document.php
@@ -11,27 +11,16 @@ use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
 use Doctrine\ODM\MongoDB\Types\Type;
 use MongoDB\BSON\ObjectId;
 
-/** @ODM\Document */
 #[ODM\Document]
 class Document
 {
-    /** @ODM\Id(strategy="none") */
     #[ODM\Id(strategy: 'none')]
     protected ObjectId $id;
 
-    /** @ODM\Field(type="string") */
     #[ODM\Field(type: Type::STRING)]
     public string $name;
 
-    /**
-     * @ODM\ReferenceMany(
-     *     targetDocument="Doctrine\Bundle\MongoDBBundle\Tests\Fixtures\Form\Category",
-     *     inversedBy="documents",
-     *     strategy="atomicSetArray"
-     * )
-     *
-     * @var Collection<int, Category>
-     */
+    /** @var Collection<int, Category> */
     #[ODM\ReferenceMany(
         targetDocument: Category::class,
         inversedBy: 'documents',

--- a/Tests/Fixtures/Form/Guesser.php
+++ b/Tests/Fixtures/Form/Guesser.php
@@ -7,21 +7,28 @@ namespace Doctrine\Bundle\MongoDBBundle\Tests\Fixtures\Form;
 use DateTime;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
+use Doctrine\ODM\MongoDB\Types\Type;
 use MongoDB\BSON\ObjectId;
 
 /** @ODM\Document */
+#[ODM\Document]
 class Guesser
 {
     /** @ODM\Id(strategy="none") */
+    #[ODM\Id(strategy: 'none')]
     protected ?ObjectId $id = null;
 
     /** @ODM\Field() */
+    #[ODM\Field]
     public ?string $name = null;
 
     /** @ODM\Field(type="date") */
+    #[ODM\Field(type: Type::DATE)]
     public ?DateTime $date = null;
 
     /** @ODM\Field(type="timestamp") */
+    #[ODM\Field(type: Type::TIMESTAMP)]
     public DateTime $ts;
 
     /**
@@ -33,15 +40,23 @@ class Guesser
      *
      * @var Collection<int, Category>
      */
+    #[ODM\ReferenceMany(
+        targetDocument: Category::class,
+        inversedBy: 'documents',
+        strategy: ClassMetadata::STORAGE_STRATEGY_ATOMIC_SET_ARRAY,
+    )]
     public Collection $categories;
 
     /** @ODM\Field(type="bool") */
+    #[ODM\Field(type: Type::BOOL)]
     public ?bool $boolField = null;
 
     /** @ODM\Field(type="float") */
+    #[ODM\Field(type: Type::FLOAT)]
     public ?float $floatField = null;
 
     /** @ODM\Field(type="int") */
+    #[ODM\Field(type: Type::INT)]
     public ?int $intField = null;
 
     /**
@@ -49,6 +64,7 @@ class Guesser
      *
      * @var array
      */
+    #[ODM\Field(type: Type::COLLECTION)]
     public array $collectionField;
 
     public mixed $nonMappedField;

--- a/Tests/Fixtures/Form/Guesser.php
+++ b/Tests/Fixtures/Form/Guesser.php
@@ -11,35 +11,22 @@ use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
 use Doctrine\ODM\MongoDB\Types\Type;
 use MongoDB\BSON\ObjectId;
 
-/** @ODM\Document */
 #[ODM\Document]
 class Guesser
 {
-    /** @ODM\Id(strategy="none") */
     #[ODM\Id(strategy: 'none')]
     protected ?ObjectId $id = null;
 
-    /** @ODM\Field() */
     #[ODM\Field]
     public ?string $name = null;
 
-    /** @ODM\Field(type="date") */
     #[ODM\Field(type: Type::DATE)]
     public ?DateTime $date = null;
 
-    /** @ODM\Field(type="timestamp") */
     #[ODM\Field(type: Type::TIMESTAMP)]
     public DateTime $ts;
 
-    /**
-     * @ODM\ReferenceMany(
-     *     targetDocument="Doctrine\Bundle\MongoDBBundle\Tests\Fixtures\Form\Category",
-     *     inversedBy="documents",
-     *     strategy="atomicSetArray"
-     * )
-     *
-     * @var Collection<int, Category>
-     */
+    /** @var Collection<int, Category> */
     #[ODM\ReferenceMany(
         targetDocument: Category::class,
         inversedBy: 'documents',
@@ -47,23 +34,16 @@ class Guesser
     )]
     public Collection $categories;
 
-    /** @ODM\Field(type="bool") */
     #[ODM\Field(type: Type::BOOL)]
     public ?bool $boolField = null;
 
-    /** @ODM\Field(type="float") */
     #[ODM\Field(type: Type::FLOAT)]
     public ?float $floatField = null;
 
-    /** @ODM\Field(type="int") */
     #[ODM\Field(type: Type::INT)]
     public ?int $intField = null;
 
-    /**
-     * @ODM\Field(type="collection")
-     *
-     * @var array
-     */
+    /** @var array */
     #[ODM\Field(type: Type::COLLECTION)]
     public array $collectionField;
 

--- a/Tests/Fixtures/Security/User.php
+++ b/Tests/Fixtures/Security/User.php
@@ -5,16 +5,20 @@ declare(strict_types=1);
 namespace Doctrine\Bundle\MongoDBBundle\Tests\Fixtures\Security;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Types\Type;
 use MongoDB\BSON\ObjectId;
 use Symfony\Component\Security\Core\User\UserInterface;
 
 /** @ODM\Document */
+#[ODM\Document]
 class User implements UserInterface
 {
     /** @ODM\Id(strategy="none") */
+    #[ODM\Id(strategy: 'none')]
     protected ObjectId $id;
 
     /** @ODM\Field(type="string") */
+    #[ODM\Field(type: Type::STRING)]
     public string $name;
 
     public function __construct(ObjectId $id, string $name)

--- a/Tests/Fixtures/Security/User.php
+++ b/Tests/Fixtures/Security/User.php
@@ -9,15 +9,12 @@ use Doctrine\ODM\MongoDB\Types\Type;
 use MongoDB\BSON\ObjectId;
 use Symfony\Component\Security\Core\User\UserInterface;
 
-/** @ODM\Document */
 #[ODM\Document]
 class User implements UserInterface
 {
-    /** @ODM\Id(strategy="none") */
     #[ODM\Id(strategy: 'none')]
     protected ObjectId $id;
 
-    /** @ODM\Field(type="string") */
     #[ODM\Field(type: Type::STRING)]
     public string $name;
 

--- a/Tests/Fixtures/Validator/Document.php
+++ b/Tests/Fixtures/Validator/Document.php
@@ -8,47 +8,30 @@ use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Doctrine\ODM\MongoDB\Types\Type;
 use MongoDB\BSON\ObjectId;
 
-/** @ODM\Document(collection="DoctrineMongoDBBundle_Tests_Validator_Document") */
 #[ODM\Document(collection: 'DoctrineMongoDBBundle_Tests_Validator_Document')]
 class Document
 {
-    /** @ODM\Id(strategy="none") */
     #[ODM\Id(strategy: 'none')]
     protected ObjectId $id;
 
-    /** @ODM\Field(type="string") */
     #[ODM\Field(type: Type::STRING)]
     public string $name;
 
-    /**
-     * @ODM\Field(type="hash")
-     *
-     * @var array
-     */
+    /** @var array */
     #[ODM\Field(type: Type::HASH)]
     public array $hash;
 
-    /**
-     * @ODM\Field(type="collection")
-     *
-     * @var array
-     */
+    /** @var array */
     #[ODM\Field(type: Type::COLLECTION)]
     public array $collection;
 
-    /** @ODM\ReferenceOne(targetDocument="Doctrine\Bundle\MongoDBBundle\Tests\Fixtures\Validator\Document") */
     #[ODM\ReferenceOne(targetDocument: self::class)]
     public ?Document $referenceOne = null;
 
-    /** @ODM\EmbedOne(targetDocument="Doctrine\Bundle\MongoDBBundle\Tests\Fixtures\Validator\EmbeddedDocument") */
     #[ODM\EmbedOne(targetDocument: EmbeddedDocument::class)]
     public ?EmbeddedDocument $embedOne = null;
 
-    /**
-     * @ODM\EmbedMany(targetDocument="Doctrine\Bundle\MongoDBBundle\Tests\Fixtures\Validator\EmbeddedDocument")
-     *
-     * @var EmbeddedDocument[]
-     */
+    /** @var EmbeddedDocument[] */
     #[ODM\EmbedMany(targetDocument: EmbeddedDocument::class)]
     public array $embedMany = [];
 
@@ -58,11 +41,9 @@ class Document
     }
 }
 
-/** @ODM\EmbeddedDocument */
 #[ODM\EmbeddedDocument]
 class EmbeddedDocument
 {
-    /** @ODM\Field(type="string") */
     #[ODM\Field(type: Type::STRING)]
     public string $name;
 }

--- a/Tests/Fixtures/Validator/Document.php
+++ b/Tests/Fixtures/Validator/Document.php
@@ -5,15 +5,19 @@ declare(strict_types=1);
 namespace Doctrine\Bundle\MongoDBBundle\Tests\Fixtures\Validator;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Types\Type;
 use MongoDB\BSON\ObjectId;
 
 /** @ODM\Document(collection="DoctrineMongoDBBundle_Tests_Validator_Document") */
+#[ODM\Document(collection: 'DoctrineMongoDBBundle_Tests_Validator_Document')]
 class Document
 {
     /** @ODM\Id(strategy="none") */
+    #[ODM\Id(strategy: 'none')]
     protected ObjectId $id;
 
     /** @ODM\Field(type="string") */
+    #[ODM\Field(type: Type::STRING)]
     public string $name;
 
     /**
@@ -21,6 +25,7 @@ class Document
      *
      * @var array
      */
+    #[ODM\Field(type: Type::HASH)]
     public array $hash;
 
     /**
@@ -28,12 +33,15 @@ class Document
      *
      * @var array
      */
+    #[ODM\Field(type: Type::COLLECTION)]
     public array $collection;
 
     /** @ODM\ReferenceOne(targetDocument="Doctrine\Bundle\MongoDBBundle\Tests\Fixtures\Validator\Document") */
+    #[ODM\ReferenceOne(targetDocument: self::class)]
     public ?Document $referenceOne = null;
 
     /** @ODM\EmbedOne(targetDocument="Doctrine\Bundle\MongoDBBundle\Tests\Fixtures\Validator\EmbeddedDocument") */
+    #[ODM\EmbedOne(targetDocument: EmbeddedDocument::class)]
     public ?EmbeddedDocument $embedOne = null;
 
     /**
@@ -41,6 +49,7 @@ class Document
      *
      * @var EmbeddedDocument[]
      */
+    #[ODM\EmbedMany(targetDocument: EmbeddedDocument::class)]
     public array $embedMany = [];
 
     public function __construct(ObjectId $id)
@@ -50,8 +59,10 @@ class Document
 }
 
 /** @ODM\EmbeddedDocument */
+#[ODM\EmbeddedDocument]
 class EmbeddedDocument
 {
     /** @ODM\Field(type="string") */
+    #[ODM\Field(type: Type::STRING)]
     public string $name;
 }

--- a/Tests/ServiceRepositoryTest.php
+++ b/Tests/ServiceRepositoryTest.php
@@ -60,7 +60,7 @@ class ServiceRepositoryTest extends TestCase
                     'default' => [
                         'mappings' => [
                             'RepositoryServiceBundle' => [
-                                'type' => 'annotation',
+                                'type' => 'attribute',
                                 'dir' => __DIR__ . '/DependencyInjection/Fixtures/Bundles/RepositoryServiceBundle/Document',
                                 'prefix' => 'Doctrine\Bundle\MongoDBBundle\Tests\DependencyInjection\Fixtures\Bundles\RepositoryServiceBundle\Document',
                             ],

--- a/Tests/TestCase.php
+++ b/Tests/TestCase.php
@@ -4,10 +4,9 @@ declare(strict_types=1);
 
 namespace Doctrine\Bundle\MongoDBBundle\Tests;
 
-use Doctrine\Common\Annotations\AnnotationReader;
 use Doctrine\ODM\MongoDB\Configuration;
 use Doctrine\ODM\MongoDB\DocumentManager;
-use Doctrine\ODM\MongoDB\Mapping\Driver\AnnotationDriver;
+use Doctrine\ODM\MongoDB\Mapping\Driver\AttributeDriver;
 use PHPUnit\Framework\TestCase as BaseTestCase;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 
@@ -24,7 +23,7 @@ class TestCase extends BaseTestCase
         $config->setHydratorDir(sys_get_temp_dir());
         $config->setProxyNamespace('SymfonyTests\Doctrine');
         $config->setHydratorNamespace('SymfonyTests\Doctrine');
-        $config->setMetadataDriverImpl(new AnnotationDriver(new AnnotationReader(), $paths));
+        $config->setMetadataDriverImpl(new AttributeDriver($paths));
         $config->setMetadataCache(new ArrayAdapter());
 
         return DocumentManager::create(null, $config);

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,14 +1,54 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="5.12.0@f90118cdeacd0088e7215e64c0c99ceca819e176">
+<files psalm-version="5.17.0@c620f6e80d0abfca532b00bda366062aaedf6e5d">
+  <file src="Command/ClearMetadataCacheDoctrineODMCommand.php">
+    <MethodSignatureMismatch>
+      <code>protected function execute(InputInterface $input, OutputInterface $output)</code>
+    </MethodSignatureMismatch>
+  </file>
+  <file src="Command/CreateSchemaDoctrineODMCommand.php">
+    <MethodSignatureMismatch>
+      <code>protected function execute(InputInterface $input, OutputInterface $output)</code>
+    </MethodSignatureMismatch>
+  </file>
+  <file src="Command/DropSchemaDoctrineODMCommand.php">
+    <MethodSignatureMismatch>
+      <code>protected function execute(InputInterface $input, OutputInterface $output)</code>
+    </MethodSignatureMismatch>
+  </file>
+  <file src="Command/GenerateHydratorsDoctrineODMCommand.php">
+    <MethodSignatureMismatch>
+      <code>protected function execute(InputInterface $input, OutputInterface $output)</code>
+    </MethodSignatureMismatch>
+  </file>
+  <file src="Command/GenerateProxiesDoctrineODMCommand.php">
+    <MethodSignatureMismatch>
+      <code>protected function execute(InputInterface $input, OutputInterface $output)</code>
+    </MethodSignatureMismatch>
+  </file>
   <file src="Command/LoadDataFixturesDoctrineODMCommand.php">
     <UndefinedInterfaceMethod>
       <code>ask</code>
     </UndefinedInterfaceMethod>
   </file>
+  <file src="Command/QueryDoctrineODMCommand.php">
+    <MethodSignatureMismatch>
+      <code>protected function execute(InputInterface $input, OutputInterface $output)</code>
+    </MethodSignatureMismatch>
+  </file>
+  <file src="Command/ShardDoctrineODMCommand.php">
+    <MethodSignatureMismatch>
+      <code>protected function execute(InputInterface $input, OutputInterface $output)</code>
+    </MethodSignatureMismatch>
+  </file>
   <file src="Command/TailCursorDoctrineODMCommand.php">
     <InvalidReturnType>
       <code>int</code>
     </InvalidReturnType>
+  </file>
+  <file src="Command/UpdateSchemaDoctrineODMCommand.php">
+    <MethodSignatureMismatch>
+      <code>protected function execute(InputInterface $input, OutputInterface $output)</code>
+    </MethodSignatureMismatch>
   </file>
   <file src="DependencyInjection/Configuration.php">
     <UndefinedInterfaceMethod>
@@ -21,10 +61,10 @@
       <code>children</code>
     </UndefinedMethod>
   </file>
-  <file src="Form/Type/DocumentType.php">
-    <MethodSignatureMustProvideReturnType>
-      <code>configureOptions</code>
-    </MethodSignatureMustProvideReturnType>
+  <file src="Loader/SymfonyFixturesLoader.php">
+    <ContainerDependency>
+      <code>private ContainerInterface $container</code>
+    </ContainerDependency>
   </file>
   <file src="Tests/Form/Type/GuesserTestType.php">
     <MissingTemplateParam>


### PR DESCRIPTION
Because of https://github.com/symfony/symfony/pull/50391 there are these deprecations:

```
1x: The "Doctrine\Bundle\MongoDBBundle\CacheWarmer\HydratorCacheWarmer::warmUp()" method will require a new "string|null $buildDir" argument in the next major version of its interface "Symfony\Component\HttpKernel\CacheWarmer\WarmableInterface", not defining it is deprecated.
    1x in HydratorCacheWarmerTest::setUp from Doctrine\Bundle\MongoDBBundle\Tests\CacheWarmer

  1x: The "Doctrine\Bundle\MongoDBBundle\CacheWarmer\PersistentCollectionCacheWarmer::warmUp()" method will require a new "string|null $buildDir" argument in the next major version of its interface "Symfony\Component\HttpKernel\CacheWarmer\WarmableInterface", not defining it is deprecated.
    1x in PersistentCollectionCacheWarmerTest::setUp from Doctrine\Bundle\MongoDBBundle\Tests\CacheWarmer

  1x: The "Doctrine\Bundle\MongoDBBundle\CacheWarmer\ProxyCacheWarmer::warmUp()" method will require a new "string|null $buildDir" argument in the next major version of its interface "Symfony\Component\HttpKernel\CacheWarmer\WarmableInterface", not defining it is deprecated.
    1x in ProxyCacheWarmerTest::setUp from Doctrine\Bundle\MongoDBBundle\Tests\CacheWarmer
```

I've created a second commit to silence these ones, but the changes are not BC, so we have to decide if we are fine with that or we should ignore it for now.

There are some other deprecations that we have to take a look.