### PR TITLE
Remove unused mapping services

### DIFF
--- a/DependencyInjection/Compiler/DoctrineMongoDBMappingsPass.php
+++ b/DependencyInjection/Compiler/DoctrineMongoDBMappingsPass.php
@@ -108,7 +108,7 @@ class DoctrineMongoDBMappingsPass extends RegisterMappingsPass
      */
     public static function createAttributeMappingDriver(array $namespaces, array $directories, array $managerParameters, $enabledParameter = false, array $aliasMap = [])
     {
-        $driver = new Definition(AttributeDriver::class, [$directories, new Reference('doctrine_mongodb.odm.metadata.attribute_reader')]);
+        $driver = new Definition(AttributeDriver::class, [$directories]);
 
         return new DoctrineMongoDBMappingsPass($driver, $namespaces, $managerParameters, $enabledParameter, $aliasMap);
     }

--- a/Resources/config/mongodb.xml
+++ b/Resources/config/mongodb.xml
@@ -32,7 +32,6 @@
         <!-- metadata -->
         <parameter key="doctrine_mongodb.odm.metadata.driver_chain.class">Doctrine\Persistence\Mapping\Driver\MappingDriverChain</parameter>
         <parameter key="doctrine_mongodb.odm.metadata.attribute.class">Doctrine\ODM\MongoDB\Mapping\Driver\AttributeDriver</parameter>
-        <parameter key="doctrine_mongodb.odm.metadata.attribute_reader.class">Doctrine\ODM\MongoDB\Mapping\Driver\AttributeReader</parameter>
         <parameter key="doctrine_mongodb.odm.metadata.xml.class">Doctrine\Bundle\MongoDBBundle\Mapping\Driver\XmlDriver</parameter>
 
         <!-- directories -->
@@ -107,17 +106,6 @@
         <service id="form.type_guesser.doctrine.mongodb" class="Doctrine\Bundle\MongoDBBundle\Form\DoctrineMongoDBTypeGuesser">
             <tag name="form.type_guesser" />
             <argument type="service" id="doctrine_mongodb" />
-        </service>
-
-        <!-- metadata -->
-        <service id="doctrine_mongodb.odm.metadata.chain" class="%doctrine_mongodb.odm.metadata.driver_chain.class%" />
-        <service id="doctrine_mongodb.odm.metadata.attribute" class="%doctrine_mongodb.odm.metadata.attribute.class%">
-            <argument>%doctrine_mongodb.odm.document_dirs%</argument>
-            <argument type="service" id="doctrine_mongodb.odm.metadata.attribute_reader" />
-        </service>
-        <service id="doctrine_mongodb.odm.metadata.attribute_reader" class="%doctrine_mongodb.odm.metadata.attribute_reader.class%" />
-        <service id="doctrine_mongodb.odm.metadata.xml" class="%doctrine_mongodb.odm.metadata.xml.class%">
-            <argument>%doctrine_mongodb.odm.xml_mapping_dirs%</argument>
         </service>
 
         <service id="doctrine_mongodb.odm.container_repository_factory" class="Doctrine\Bundle\MongoDBBundle\Repository\ContainerRepositoryFactory" public="false">


### PR DESCRIPTION
Follow-up of https://github.com/doctrine/DoctrineMongoDBBundle/pull/793

While removing annotation mapping support in https://github.com/doctrine/DoctrineMongoDBBundle/pull/793, I've notice that these services are not necessary.

So mapping drivers are registered in [`AbstractDoctrineExtension::registerMappingDrivers()`](https://github.com/symfony/symfony/blob/fec89090f178f32b686099bec5b2d1521673c514/src/Symfony/Bridge/Doctrine/DependencyInjection/AbstractDoctrineExtension.php#L184).

For example for `attribute` it executes [this code](https://github.com/symfony/symfony/blob/fec89090f178f32b686099bec5b2d1521673c514/src/Symfony/Bridge/Doctrine/DependencyInjection/AbstractDoctrineExtension.php#L205-L207) which in our case uses `doctrine_mongodb.odm.metadata.attribute.class` to create the AttributeDriver service.