### PR TITLE
Mark all command and compiler pass classes as final

### DIFF
--- a/Command/ClearMetadataCacheDoctrineODMCommand.php
+++ b/Command/ClearMetadataCacheDoctrineODMCommand.php
@@ -14,7 +14,7 @@ use Symfony\Component\Console\Output\OutputInterface;
  *
  * @internal since version 4.7.0
  */
-class ClearMetadataCacheDoctrineODMCommand extends MetadataCommand
+final class ClearMetadataCacheDoctrineODMCommand extends MetadataCommand
 {
     protected function configure(): void
     {

--- a/Command/CreateSchemaDoctrineODMCommand.php
+++ b/Command/CreateSchemaDoctrineODMCommand.php
@@ -15,7 +15,7 @@ use Symfony\Component\Console\Output\OutputInterface;
  *
  * @internal since version 4.7.0
  */
-class CreateSchemaDoctrineODMCommand extends CreateCommand
+final class CreateSchemaDoctrineODMCommand extends CreateCommand
 {
     protected function configure(): void
     {

--- a/Command/DropSchemaDoctrineODMCommand.php
+++ b/Command/DropSchemaDoctrineODMCommand.php
@@ -15,7 +15,7 @@ use Symfony\Component\Console\Output\OutputInterface;
  *
  * @internal since version 4.7.0
  */
-class DropSchemaDoctrineODMCommand extends DropCommand
+final class DropSchemaDoctrineODMCommand extends DropCommand
 {
     protected function configure(): void
     {

--- a/Command/GenerateHydratorsDoctrineODMCommand.php
+++ b/Command/GenerateHydratorsDoctrineODMCommand.php
@@ -14,7 +14,7 @@ use Symfony\Component\Console\Output\OutputInterface;
  *
  * @internal since version 4.7.0
  */
-class GenerateHydratorsDoctrineODMCommand extends GenerateHydratorsCommand
+final class GenerateHydratorsDoctrineODMCommand extends GenerateHydratorsCommand
 {
     protected function configure(): void
     {

--- a/Command/GenerateProxiesDoctrineODMCommand.php
+++ b/Command/GenerateProxiesDoctrineODMCommand.php
@@ -14,7 +14,7 @@ use Symfony\Component\Console\Output\OutputInterface;
  *
  * @internal since version 4.7.0
  */
-class GenerateProxiesDoctrineODMCommand extends GenerateProxiesCommand
+final class GenerateProxiesDoctrineODMCommand extends GenerateProxiesCommand
 {
     protected function configure(): void
     {

--- a/Command/InfoDoctrineODMCommand.php
+++ b/Command/InfoDoctrineODMCommand.php
@@ -20,7 +20,7 @@ use function sprintf;
  *
  * @internal since version 4.7.0
  */
-class InfoDoctrineODMCommand extends DoctrineODMCommand
+final class InfoDoctrineODMCommand extends DoctrineODMCommand
 {
     protected function configure(): void
     {

--- a/Command/LoadDataFixturesDoctrineODMCommand.php
+++ b/Command/LoadDataFixturesDoctrineODMCommand.php
@@ -22,7 +22,7 @@ use function sprintf;
  *
  * @internal since version 4.7.0
  */
-class LoadDataFixturesDoctrineODMCommand extends DoctrineODMCommand
+final class LoadDataFixturesDoctrineODMCommand extends DoctrineODMCommand
 {
     public function __construct(ManagerRegistry $registry, private SymfonyFixturesLoaderInterface $fixturesLoader)
     {

--- a/Command/QueryDoctrineODMCommand.php
+++ b/Command/QueryDoctrineODMCommand.php
@@ -14,7 +14,7 @@ use Symfony\Component\Console\Output\OutputInterface;
  *
  * @internal since version 4.7.0
  */
-class QueryDoctrineODMCommand extends QueryCommand
+final class QueryDoctrineODMCommand extends QueryCommand
 {
     protected function configure(): void
     {

--- a/Command/ShardDoctrineODMCommand.php
+++ b/Command/ShardDoctrineODMCommand.php
@@ -15,7 +15,7 @@ use Symfony\Component\Console\Output\OutputInterface;
  *
  * @internal since version 4.7.0
  */
-class ShardDoctrineODMCommand extends ShardCommand
+final class ShardDoctrineODMCommand extends ShardCommand
 {
     protected function configure(): void
     {

--- a/Command/UpdateSchemaDoctrineODMCommand.php
+++ b/Command/UpdateSchemaDoctrineODMCommand.php
@@ -15,7 +15,7 @@ use Symfony\Component\Console\Output\OutputInterface;
  *
  * @internal since version 4.7.0
  */
-class UpdateSchemaDoctrineODMCommand extends UpdateCommand
+final class UpdateSchemaDoctrineODMCommand extends UpdateCommand
 {
     protected function configure(): void
     {

--- a/DataCollector/CommandDataCollector.php
+++ b/DataCollector/CommandDataCollector.php
@@ -20,7 +20,7 @@ use function MongoDB\BSON\fromPHP;
 use function MongoDB\BSON\toCanonicalExtendedJSON;
 
 /** @internal since version 4.7.0 */
-class CommandDataCollector extends DataCollector
+final class CommandDataCollector extends DataCollector
 {
     public function __construct(private CommandLogger $commandLogger)
     {

--- a/DependencyInjection/Compiler/CreateHydratorDirectoryPass.php
+++ b/DependencyInjection/Compiler/CreateHydratorDirectoryPass.php
@@ -15,7 +15,7 @@ use function mkdir;
 use function sprintf;
 
 /** @internal */
-class CreateHydratorDirectoryPass implements CompilerPassInterface
+final class CreateHydratorDirectoryPass implements CompilerPassInterface
 {
     public function process(ContainerBuilder $container): void
     {

--- a/DependencyInjection/Compiler/CreateProxyDirectoryPass.php
+++ b/DependencyInjection/Compiler/CreateProxyDirectoryPass.php
@@ -15,7 +15,7 @@ use function mkdir;
 use function sprintf;
 
 /** @internal since version 4.7.0 */
-class CreateProxyDirectoryPass implements CompilerPassInterface
+final class CreateProxyDirectoryPass implements CompilerPassInterface
 {
     public function process(ContainerBuilder $container): void
     {

--- a/DependencyInjection/Compiler/DoctrineMongoDBMappingsPass.php
+++ b/DependencyInjection/Compiler/DoctrineMongoDBMappingsPass.php
@@ -21,7 +21,7 @@ use Symfony\Component\DependencyInjection\Reference;
  *
  * @internal since version 4.7.0
  */
-class DoctrineMongoDBMappingsPass extends RegisterMappingsPass
+final class DoctrineMongoDBMappingsPass extends RegisterMappingsPass
 {
     /**
      * You should not directly instantiate this class but use one of the

--- a/UPGRADE-5.0.md
+++ b/UPGRADE-5.0.md
@@ -9,7 +9,7 @@ UPGRADE FROM 4.x to 5.0
   `findBundle` and `findBasePathForBundle` methods from
   `Doctrine\Bundle\MongoDBBundle\Command\DoctrineODMCommand` have been
   removed without replacement.
-* The `Doctrine\Bundle\MongoDBBundle\Command\DoctrineODMCommand` class is now
-  `@internal`, you should not extend from this class.
+* All command and compiler pass classes are internal and final. They cannot be
+  used directly or extended.
 * Remove support of Annotation mapping, you should use Attributes or XML instead.
 * Remove `--service` option from `doctrine:mongodb:fixtures:load` command


### PR DESCRIPTION
All the commands are glue code for Doctrine features. If some needs to change the behavior of a command, they can duplicate the code.
Maintenance is a lot easier when this classes are marked internal, as we don't have to keep backward-compatibility.