### PR TITLE
Revert "Add $buildDir parameter to warmUp method"

### DIFF
--- a/CacheWarmer/HydratorCacheWarmer.php
+++ b/CacheWarmer/HydratorCacheWarmer.php
@@ -46,7 +46,7 @@ class HydratorCacheWarmer implements CacheWarmerInterface
     }
 
     /** @return string[] */
-    public function warmUp(string $cacheDir, ?string $buildDir = null)
+    public function warmUp(string $cacheDir)
     {
         // we need the directory no matter the hydrator cache generation strategy.
         $hydratorCacheDir = (string) $this->container->getParameter('doctrine_mongodb.odm.hydrator_dir');

--- a/CacheWarmer/PersistentCollectionCacheWarmer.php
+++ b/CacheWarmer/PersistentCollectionCacheWarmer.php
@@ -47,7 +47,7 @@ class PersistentCollectionCacheWarmer implements CacheWarmerInterface
     }
 
     /** @return string[] */
-    public function warmUp(string $cacheDir, ?string $buildDir = null)
+    public function warmUp(string $cacheDir)
     {
         // we need the directory no matter the hydrator cache generation strategy.
         $collCacheDir = (string) $this->container->getParameter('doctrine_mongodb.odm.persistent_collection_dir');

--- a/CacheWarmer/ProxyCacheWarmer.php
+++ b/CacheWarmer/ProxyCacheWarmer.php
@@ -48,7 +48,7 @@ class ProxyCacheWarmer implements CacheWarmerInterface
     }
 
     /** @return string[] */
-    public function warmUp(string $cacheDir, ?string $buildDir = null)
+    public function warmUp(string $cacheDir)
     {
         // we need the directory no matter the proxy cache generation strategy.
         $proxyCacheDir = (string) $this->container->getParameter('doctrine_mongodb.odm.proxy_dir');

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -23,7 +23,7 @@
         <!-- <server name="DOCTRINE_MONGODB" value="/path/to/doctrine-mongodb/lib" /> -->
         <!-- <server name="DOCTRINE_COMMON" value="/path/to/doctrine-common/lib" /> -->
         <!-- Allow 1 direct deprecation until https://github.com/doctrine/DoctrineMongoDBBundle/pull/675 is merged -->
-        <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[direct]=1"/>
+        <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[direct]=1&amp;max[self]=3"/>
     </php>
 
     <coverage>


### PR DESCRIPTION
This reverts commit dc54819096a2e57b4d04dca3fd9e275d37024e46.

Since we are not adding BC breaks in `4.7`, should we maybe revert this commit? which was the only one adding a BC break in https://github.com/doctrine/DoctrineMongoDBBundle/pull/789