### PR TITLE
Deprecate container injection in fixture classes with `ContainerAwareInterface`

### DIFF
--- a/Loader/SymfonyFixturesLoader.php
+++ b/Loader/SymfonyFixturesLoader.php
@@ -19,6 +19,7 @@ use function array_key_exists;
 use function array_values;
 use function get_class;
 use function sprintf;
+use function trigger_deprecation;
 
 final class SymfonyFixturesLoader extends Loader implements SymfonyFixturesLoaderInterface
 {
@@ -68,6 +69,8 @@ final class SymfonyFixturesLoader extends Loader implements SymfonyFixturesLoade
         }
 
         if ($fixture instanceof ContainerAwareInterface) {
+            trigger_deprecation('doctrine/mongodb-odm-bundle', '4.7', 'Implementing "%s" with "%s" is deprecated, use dependency injection instead.', ContainerAwareInterface::class, FixtureInterface::class);
+
             $fixture->setContainer($this->container);
         }
 

--- a/UPGRADE-4.7.md
+++ b/UPGRADE-4.7.md
@@ -9,3 +9,5 @@ UPGRADE FROM 4.6 to 4.7
 * The `fixture_loader` configuration option was deprecated and will be removed
   in 5.0.
 * The `doctrine_mongodb.odm.fixture_loader` parameter has been removed.
+* Implementing `ContainerAwareInterface` on fixtures classes is deprecated,
+  use dependency injection instead.


### PR DESCRIPTION
[`ContainerAwareInterface`](https://github.com/symfony/symfony/blob/6.4/src/Symfony/Component/DependencyInjection/ContainerAwareInterface.php) is deprecated since Symfony 6.4. It was used before, for fixture classes that were not defined as services. As all fixture classes must declared as services to be used by the command, proper dependency injection is easy to do.

Let's deprecate this automatic injection and remove it in 5.0 #802 