### PR TITLE
Remove dependency to `jean85/pretty-package-versions`

### DIFF
--- a/DependencyInjection/DoctrineMongoDBExtension.php
+++ b/DependencyInjection/DoctrineMongoDBExtension.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\Bundle\MongoDBBundle\DependencyInjection;
 
+use Composer\InstalledVersions;
 use Doctrine\Bundle\MongoDBBundle\Attribute\AsDocumentListener;
 use Doctrine\Bundle\MongoDBBundle\Attribute\MapDocument;
 use Doctrine\Bundle\MongoDBBundle\Command\LoadDataFixturesDoctrineODMCommand;
@@ -18,7 +19,6 @@ use Doctrine\Common\DataFixtures\Loader as DataFixturesLoader;
 use Doctrine\Common\EventSubscriber;
 use Doctrine\ODM\MongoDB\DocumentManager;
 use InvalidArgumentException;
-use Jean85\PrettyVersions;
 use Symfony\Bridge\Doctrine\ArgumentResolver\EntityValueResolver;
 use Symfony\Bridge\Doctrine\DependencyInjection\AbstractDoctrineExtension;
 use Symfony\Bridge\Doctrine\Messenger\DoctrineClearEntityManagerWorkerSubscriber;
@@ -653,7 +653,7 @@ class DoctrineMongoDBExtension extends AbstractDoctrineExtension
     {
         if (self::$odmVersion === null) {
             try {
-                self::$odmVersion = PrettyVersions::getVersion('doctrine/mongodb-odm')->getPrettyVersion();
+                self::$odmVersion = InstalledVersions::getPrettyVersion('doctrine/mongodb-odm') ?? 'no version';
             } catch (Throwable) {
                 return 'unknown';
             }

--- a/composer.json
+++ b/composer.json
@@ -26,9 +26,9 @@
     "require": {
         "php": "^8.1",
         "ext-mongodb": "^1.5",
+        "composer-runtime-api": "^2.0",
         "doctrine/mongodb-odm": "^2.3",
         "doctrine/persistence": "^2.2 || ^3.0",
-        "jean85/pretty-package-versions": "^1.3.0 || ^2.0.1",
         "psr/log": "^1.0 || ^2.0 || ^3.0",
         "symfony/config": "^5.4 || ^6.2",
         "symfony/console": "^5.4 || ^6.2",


### PR DESCRIPTION
Thanks to Composer API v2, we have an easy solution to retrieve the version of a package that is installed.