### PR TITLE
Expose transaction setting

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -555,6 +555,7 @@ Full Default Configuration
                         host:                 ~
                         port:                 ~
                         instance_class:       ~
+                    use_transactional_flush:           false
                     mappings:
 
                         # Prototype

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -196,6 +196,7 @@ class Configuration implements ConfigurationInterface
                                     ->scalarNode('namespace')->end()
                                 ->end()
                             ->end()
+                            ->booleanNode('use_transactional_flush')->defaultFalse()->end()
                         ->end()
                         ->fixXmlConfig('mapping')
                         ->children()

--- a/src/DependencyInjection/DoctrineMongoDBExtension.php
+++ b/src/DependencyInjection/DoctrineMongoDBExtension.php
@@ -45,6 +45,7 @@ use function class_implements;
 use function in_array;
 use function interface_exists;
 use function is_dir;
+use function method_exists;
 use function sprintf;
 
 /**
@@ -249,8 +250,11 @@ class DoctrineMongoDBExtension extends AbstractDoctrineExtension
             'setPersistentCollectionDir' => '%doctrine_mongodb.odm.persistent_collection_dir%',
             'setPersistentCollectionNamespace' => '%doctrine_mongodb.odm.persistent_collection_namespace%',
             'setAutoGeneratePersistentCollectionClasses' => '%doctrine_mongodb.odm.auto_generate_persistent_collection_classes%',
-            'setUseTransactionalFlush' => $documentManager['use_transactional_flush'],
         ];
+
+        if (method_exists(ODMConfiguration::class, 'setUseTransactionalFlush')) {
+            $methods['setUseTransactionalFlush'] = $documentManager['use_transactional_flush'];
+        }
 
         if ($documentManager['repository_factory']) {
             $methods['setRepositoryFactory'] = new Reference($documentManager['repository_factory']);

--- a/src/DependencyInjection/DoctrineMongoDBExtension.php
+++ b/src/DependencyInjection/DoctrineMongoDBExtension.php
@@ -249,6 +249,7 @@ class DoctrineMongoDBExtension extends AbstractDoctrineExtension
             'setPersistentCollectionDir' => '%doctrine_mongodb.odm.persistent_collection_dir%',
             'setPersistentCollectionNamespace' => '%doctrine_mongodb.odm.persistent_collection_namespace%',
             'setAutoGeneratePersistentCollectionClasses' => '%doctrine_mongodb.odm.auto_generate_persistent_collection_classes%',
+            'setUseTransactionalFlush' => $documentManager['use_transactional_flush'],
         ];
 
         if ($documentManager['repository_factory']) {

--- a/tests/DependencyInjection/ConfigurationTest.php
+++ b/tests/DependencyInjection/ConfigurationTest.php
@@ -169,6 +169,7 @@ class ConfigurationTest extends TestCase
                         'enabled' => true,
                         'pretty'  => false,
                     ],
+                    'use_transactional_flush' => false,
                 ],
                 'dm2' => [
                     'connection'   => 'dm2_connection',
@@ -195,6 +196,7 @@ class ConfigurationTest extends TestCase
                         'enabled' => '%kernel.debug%',
                         'pretty'  => '%kernel.debug%',
                     ],
+                    'use_transactional_flush' => false,
                 ],
             ],
             'resolve_target_documents' => ['Foo\BarInterface' => 'Bar\FooClass'],
@@ -285,7 +287,7 @@ class ConfigurationTest extends TestCase
                 ['document_managers' => ['default' => ['mappings' => ['foomap' => ['type' => 'val1'], 'barmap' => ['dir' => 'val2']]]]],
                 ['document_managers' => ['default' => ['mappings' => ['barmap' => ['prefix' => 'val3']]]]],
             ],
-            ['document_managers' => ['default' => ['metadata_cache_driver' => ['type' => 'array'], 'logging' => '%kernel.debug%', 'profiler' => ['enabled' => '%kernel.debug%', 'pretty' => '%kernel.debug%'], 'auto_mapping' => false, 'default_document_repository_class' => DocumentRepository::class, 'default_gridfs_repository_class' => DefaultGridFSRepository::class, 'repository_factory' => 'doctrine_mongodb.odm.container_repository_factory', 'persistent_collection_factory' => null, 'filters' => [], 'mappings' => ['foomap' => ['type' => 'val1', 'mapping' => true], 'barmap' => ['prefix' => 'val3', 'mapping' => true]]]]],
+            ['document_managers' => ['default' => ['metadata_cache_driver' => ['type' => 'array'], 'logging' => '%kernel.debug%', 'profiler' => ['enabled' => '%kernel.debug%', 'pretty' => '%kernel.debug%'], 'auto_mapping' => false, 'default_document_repository_class' => DocumentRepository::class, 'default_gridfs_repository_class' => DefaultGridFSRepository::class, 'repository_factory' => 'doctrine_mongodb.odm.container_repository_factory', 'persistent_collection_factory' => null, 'filters' => [], 'mappings' => ['foomap' => ['type' => 'val1', 'mapping' => true], 'barmap' => ['prefix' => 'val3', 'mapping' => true]], 'use_transactional_flush' => false]]],
         ];
 
         // connections are merged non-recursively.
@@ -336,8 +338,8 @@ class ConfigurationTest extends TestCase
             ],
             [
                 'document_managers' => [
-                    'foodm' => ['database' => 'val1', 'metadata_cache_driver' => ['type' => 'array'], 'logging' => '%kernel.debug%', 'profiler' => ['enabled' => '%kernel.debug%', 'pretty' => '%kernel.debug%'], 'auto_mapping' => false, 'default_document_repository_class' => DocumentRepository::class, 'default_gridfs_repository_class' => DefaultGridFSRepository::class, 'repository_factory' => 'doctrine_mongodb.odm.container_repository_factory', 'persistent_collection_factory' => null, 'filters' => [], 'mappings' => []],
-                    'bardm' => ['database' => 'val3', 'metadata_cache_driver' => ['type' => 'array'], 'logging' => '%kernel.debug%', 'profiler' => ['enabled' => '%kernel.debug%', 'pretty' => '%kernel.debug%'], 'auto_mapping' => false, 'default_document_repository_class' => DocumentRepository::class, 'default_gridfs_repository_class' => DefaultGridFSRepository::class, 'repository_factory' => 'doctrine_mongodb.odm.container_repository_factory', 'persistent_collection_factory' => null, 'filters' => [], 'mappings' => []],
+                    'foodm' => ['database' => 'val1', 'metadata_cache_driver' => ['type' => 'array'], 'logging' => '%kernel.debug%', 'profiler' => ['enabled' => '%kernel.debug%', 'pretty' => '%kernel.debug%'], 'auto_mapping' => false, 'default_document_repository_class' => DocumentRepository::class, 'default_gridfs_repository_class' => DefaultGridFSRepository::class, 'repository_factory' => 'doctrine_mongodb.odm.container_repository_factory', 'persistent_collection_factory' => null, 'filters' => [], 'mappings' => [], 'use_transactional_flush' => false],
+                    'bardm' => ['database' => 'val3', 'metadata_cache_driver' => ['type' => 'array'], 'logging' => '%kernel.debug%', 'profiler' => ['enabled' => '%kernel.debug%', 'pretty' => '%kernel.debug%'], 'auto_mapping' => false, 'default_document_repository_class' => DocumentRepository::class, 'default_gridfs_repository_class' => DefaultGridFSRepository::class, 'repository_factory' => 'doctrine_mongodb.odm.container_repository_factory', 'persistent_collection_factory' => null, 'filters' => [], 'mappings' => [], 'use_transactional_flush' => false],
                 ],
             ],
         ];
@@ -393,8 +395,8 @@ class ConfigurationTest extends TestCase
             ],
             [
                 'document_managers' => [
-                    'foo' => ['connection' => 'conn1', 'metadata_cache_driver' => ['type' => 'array'], 'logging' => '%kernel.debug%', 'profiler' => ['enabled' => '%kernel.debug%', 'pretty' => '%kernel.debug%'], 'auto_mapping' => false, 'default_document_repository_class' => DocumentRepository::class, 'default_gridfs_repository_class' => DefaultGridFSRepository::class, 'repository_factory' => 'doctrine_mongodb.odm.container_repository_factory', 'persistent_collection_factory' => null, 'filters' => [], 'mappings' => []],
-                    'bar' => ['connection' => 'conn2', 'metadata_cache_driver' => ['type' => 'array'], 'logging' => '%kernel.debug%', 'profiler' => ['enabled' => '%kernel.debug%', 'pretty' => '%kernel.debug%'], 'auto_mapping' => false, 'default_document_repository_class' => DocumentRepository::class, 'default_gridfs_repository_class' => DefaultGridFSRepository::class, 'repository_factory' => 'doctrine_mongodb.odm.container_repository_factory', 'persistent_collection_factory' => null,'filters' => [], 'mappings' => []],
+                    'foo' => ['connection' => 'conn1', 'metadata_cache_driver' => ['type' => 'array'], 'logging' => '%kernel.debug%', 'profiler' => ['enabled' => '%kernel.debug%', 'pretty' => '%kernel.debug%'], 'auto_mapping' => false, 'default_document_repository_class' => DocumentRepository::class, 'default_gridfs_repository_class' => DefaultGridFSRepository::class, 'repository_factory' => 'doctrine_mongodb.odm.container_repository_factory', 'persistent_collection_factory' => null, 'filters' => [], 'mappings' => [], 'use_transactional_flush' => false],
+                    'bar' => ['connection' => 'conn2', 'metadata_cache_driver' => ['type' => 'array'], 'logging' => '%kernel.debug%', 'profiler' => ['enabled' => '%kernel.debug%', 'pretty' => '%kernel.debug%'], 'auto_mapping' => false, 'default_document_repository_class' => DocumentRepository::class, 'default_gridfs_repository_class' => DefaultGridFSRepository::class, 'repository_factory' => 'doctrine_mongodb.odm.container_repository_factory', 'persistent_collection_factory' => null,'filters' => [], 'mappings' => [], 'use_transactional_flush' => false],
                 ],
             ],
         ];
@@ -427,6 +429,7 @@ class ConfigurationTest extends TestCase
                         'profiler'     => ['enabled' => '%kernel.debug%', 'pretty' => '%kernel.debug%'],
                         'auto_mapping' => false,
                         'filters'      => [],
+                        'use_transactional_flush' => false,
                     ],
                 ],
             ],

--- a/tests/DependencyInjection/DoctrineMongoDBExtensionTest.php
+++ b/tests/DependencyInjection/DoctrineMongoDBExtensionTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Doctrine\Bundle\MongoDBBundle\Tests\DependencyInjection;
 
+use Composer\InstalledVersions;
+use Composer\Semver\VersionParser;
 use Doctrine\Bundle\MongoDBBundle\Attribute\MapDocument;
 use Doctrine\Bundle\MongoDBBundle\DependencyInjection\Configuration;
 use Doctrine\Bundle\MongoDBBundle\DependencyInjection\DoctrineMongoDBExtension;
@@ -375,7 +377,7 @@ class DoctrineMongoDBExtensionTest extends TestCase
 
     public function testTransactionalFlushConfigurationWhenNotSupported(): void
     {
-        if (method_exists(ODMConfiguration::class, 'setUseTransactionalFlush')) {
+        if (InstalledVersions::satisfies(new VersionParser(), 'doctrine/mongodb-odm', '>=2.7@dev')) {
             $this->markTestSkipped('Installed version of doctrine/mongodb-odm supports transactional flushes');
         }
 
@@ -393,7 +395,7 @@ class DoctrineMongoDBExtensionTest extends TestCase
 
     public function testDefaultTransactionalFlush(): void
     {
-        if (! method_exists(Configuration::class, 'setUseTransactionalFlush')) {
+        if (! InstalledVersions::satisfies(new VersionParser(), 'doctrine/mongodb-odm', '>=2.7@dev')) {
             $this->markTestSkipped('Installed version of doctrine/mongodb-odm does not support transactional flushes');
         }
 
@@ -417,7 +419,7 @@ class DoctrineMongoDBExtensionTest extends TestCase
 
     public function testUseTransactionalFlush(): void
     {
-        if (! method_exists(Configuration::class, 'setUseTransactionalFlush')) {
+        if (! InstalledVersions::satisfies(new VersionParser(), 'doctrine/mongodb-odm', '>=2.7@dev')) {
             $this->markTestSkipped('Installed version of doctrine/mongodb-odm does not support transactional flushes');
         }
 

--- a/tests/DependencyInjection/DoctrineMongoDBExtensionTest.php
+++ b/tests/DependencyInjection/DoctrineMongoDBExtensionTest.php
@@ -7,10 +7,8 @@ namespace Doctrine\Bundle\MongoDBBundle\Tests\DependencyInjection;
 use Composer\InstalledVersions;
 use Composer\Semver\VersionParser;
 use Doctrine\Bundle\MongoDBBundle\Attribute\MapDocument;
-use Doctrine\Bundle\MongoDBBundle\DependencyInjection\Configuration;
 use Doctrine\Bundle\MongoDBBundle\DependencyInjection\DoctrineMongoDBExtension;
 use Doctrine\Bundle\MongoDBBundle\Tests\DependencyInjection\Fixtures\Bundles\DocumentListenerBundle\EventListener\TestAttributeListener;
-use Doctrine\ODM\MongoDB\Configuration as ODMConfiguration;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bridge\Doctrine\Messenger\DoctrineClearEntityManagerWorkerSubscriber;
 use Symfony\Component\DependencyInjection\Alias;
@@ -25,7 +23,6 @@ use function array_merge;
 use function class_exists;
 use function interface_exists;
 use function is_dir;
-use function method_exists;
 use function sys_get_temp_dir;
 
 class DoctrineMongoDBExtensionTest extends TestCase

--- a/tests/DependencyInjection/DoctrineMongoDBExtensionTest.php
+++ b/tests/DependencyInjection/DoctrineMongoDBExtensionTest.php
@@ -369,4 +369,44 @@ class DoctrineMongoDBExtensionTest extends TestCase
         $container->compile();
         $this->assertEquals(new MapDocument(null, null, null, [], null, null, null, true), $container->get('controller_resolver_defaults'));
     }
+
+    public function testDefaultTransactionalFlush(): void
+    {
+        $container = $this->buildMinimalContainer();
+        $container->setParameter('kernel.debug', false);
+        $container->setParameter('kernel.bundles', []);
+        $container->setParameter('kernel.bundles_metadata', []);
+        $loader = new DoctrineMongoDBExtension();
+        $loader->load(self::buildConfiguration(), $container);
+
+        $configuration = $container->getDefinition('doctrine_mongodb.odm.default_configuration');
+
+        $this->assertContains(
+            [
+                'setUseTransactionalFlush',
+                [false],
+            ],
+            $configuration->getMethodCalls(),
+        );
+    }
+
+    public function testUseTransactionalFlush(): void
+    {
+        $container = $this->buildMinimalContainer();
+        $container->setParameter('kernel.debug', false);
+        $container->setParameter('kernel.bundles', []);
+        $container->setParameter('kernel.bundles_metadata', []);
+        $loader = new DoctrineMongoDBExtension();
+        $loader->load(self::buildConfiguration(['document_managers' => ['default' => ['use_transactional_flush' => true]]]), $container);
+
+        $configuration = $container->getDefinition('doctrine_mongodb.odm.default_configuration');
+
+        $this->assertContains(
+            [
+                'setUseTransactionalFlush',
+                [true],
+            ],
+            $configuration->getMethodCalls(),
+        );
+    }
 }


### PR DESCRIPTION
This complements https://github.com/doctrine/mongodb-odm/pull/2586 by exposing the `use_transactional_flush` setting to the bundle configuration.