### PR TITLE
Deprecate `EventSubscriberInterface` in favor of `#[AsDocumentListener]`

### DIFF
--- a/EventSubscriber/EventSubscriberInterface.php
+++ b/EventSubscriber/EventSubscriberInterface.php
@@ -6,6 +6,7 @@ namespace Doctrine\Bundle\MongoDBBundle\EventSubscriber;
 
 use Doctrine\Common\EventSubscriber;
 
+/** @deprecated since 4.7.0, use the {@see \Doctrine\Bundle\MongoDBBundle\Attribute\AsDocumentListener} attribute instead */
 interface EventSubscriberInterface extends EventSubscriber
 {
 }

--- a/UPGRADE-4.7.md
+++ b/UPGRADE-4.7.md
@@ -6,6 +6,11 @@ UPGRADE FROM 4.6 to 4.7
 * The bundle now requires PHP 8.1 or newer. If you're not running PHP 8.1 yet,
   it's recommended that you upgrade to PHP 8.1 before upgrading the bundle.
 
+## Event Subscriber
+
+* `Doctrine\Bundle\MongoDBBundle\EventSubscriber\EventSubscriberInterface` has
+  been deprecated. Use the `#[AsDocumentListener]` attribute instead.
+
 ## Fixtures
 
 * The `fixture_loader` configuration option was deprecated and will be removed

--- a/UPGRADE-5.0.md
+++ b/UPGRADE-5.0.md
@@ -11,3 +11,5 @@ UPGRADE FROM 4.x to 5.0
   removed without replacement.
 * The `Doctrine\Bundle\MongoDBBundle\Command\DoctrineODMCommand` class is now
   `@internal`, you should not extend from this class.
+* `Doctrine\Bundle\MongoDBBundle\EventSubscriber\EventSubscriberInterface` has
+  been removed. Use the `#[AsDocumentListener]` attribute instead.


### PR DESCRIPTION
Same as https://github.com/doctrine/DoctrineBundle/pull/1664.

Fix https://github.com/doctrine/DoctrineMongoDBBundle/issues/816

I rewrote the documentation, by merging [`DoctrineBundle` event doc](https://github.com/doctrine/DoctrineBundle/blob/2.11.x/Resources/doc/event-listeners.rst) and the good parts of this bundle doc. All mentions to the `EventSubscriberInterface` have been removed.