### PR TITLE
Add priority to `#[AsDocumentListener]`

### DIFF
--- a/Attribute/AsDocumentListener.php
+++ b/Attribute/AsDocumentListener.php
@@ -17,6 +17,7 @@ class AsDocumentListener
         public ?string $method = null,
         public ?bool $lazy = null,
         public ?string $connection = null,
+        public ?int $priority = null,
     ) {
     }
 }

--- a/DependencyInjection/DoctrineMongoDBExtension.php
+++ b/DependencyInjection/DoctrineMongoDBExtension.php
@@ -141,6 +141,7 @@ class DoctrineMongoDBExtension extends AbstractDoctrineExtension
                 'method'     => $attribute->method,
                 'lazy'       => $attribute->lazy,
                 'connection' => $attribute->connection,
+                'priority'   => $attribute->priority,
             ]);
         });
 

--- a/Tests/DependencyInjection/DoctrineMongoDBExtensionTest.php
+++ b/Tests/DependencyInjection/DoctrineMongoDBExtensionTest.php
@@ -97,6 +97,7 @@ class DoctrineMongoDBExtensionTest extends TestCase
                 'method' => 'onPrePersist',
                 'lazy' => true,
                 'connection' => 'test',
+                'priority' => 10,
             ],
         ], $listenerDefinition->getTag('doctrine_mongodb.odm.event_listener'));
     }

--- a/Tests/DependencyInjection/Fixtures/Bundles/DocumentListenerBundle/EventListener/TestAttributeListener.php
+++ b/Tests/DependencyInjection/Fixtures/Bundles/DocumentListenerBundle/EventListener/TestAttributeListener.php
@@ -6,7 +6,7 @@ namespace Doctrine\Bundle\MongoDBBundle\Tests\DependencyInjection\Fixtures\Bundl
 
 use Doctrine\Bundle\MongoDBBundle\Attribute\AsDocumentListener;
 
-#[AsDocumentListener(event: 'prePersist', method: 'onPrePersist', lazy: true, connection: 'test')]
+#[AsDocumentListener(event: 'prePersist', method: 'onPrePersist', lazy: true, connection: 'test', priority: 10)]
 class TestAttributeListener
 {
     public function onPrePersist(): void


### PR DESCRIPTION
After examining the `#AsDocumentListener` attributes of `DoctrineMongoDBBundle`, and comparing them with `#[AsDoctrineListener]` from `DoctrineBundle`, I conclude that they serve the same purpose.

This PR adds the missing `priority` property. It is correctly handled by [`Symfony\Bridge\Doctrine\DependencyInjection\CompilerPassRegisterEventListenersAndSubscribersPass::findAndSortTags`](https://github.com/symfony/symfony/blob/a41993a7586279435917611f2f0cc42a5c1269ce/src/Symfony/Bridge/Doctrine/DependencyInjection/CompilerPass/RegisterEventListenersAndSubscribersPass.php#L146-L147).