### PR TITLE
Deprecate `#[AsDocumentListener]` parameters `$method` and `$lazy` (not working)

### DIFF
--- a/Attribute/AsDocumentListener.php
+++ b/Attribute/AsDocumentListener.php
@@ -6,6 +6,8 @@ namespace Doctrine\Bundle\MongoDBBundle\Attribute;
 
 use Attribute;
 
+use function trigger_deprecation;
+
 /**
  * Service tag to autoconfigure document listeners.
  */
@@ -14,10 +16,28 @@ class AsDocumentListener
 {
     public function __construct(
         public ?string $event = null,
+        /** @deprecated the method name is the same as the event name */
         public ?string $method = null,
+        /** @deprecated not supported */
         public ?bool $lazy = null,
         public ?string $connection = null,
         public ?int $priority = null,
     ) {
+        // phpcs:disable SlevomatCodingStandard.ControlStructures.EarlyExit.EarlyExitNotUsed
+        if ($method !== null) {
+            trigger_deprecation(
+                'doctrine/mongodb-odm-bundle',
+                '4.7',
+                'The method name is the same as the event name, so it can be omitted.',
+            );
+        }
+
+        if ($lazy !== null) {
+            trigger_deprecation(
+                'doctrine/mongodb-odm-bundle',
+                '4.7',
+                'Lazy loading is not supported.',
+            );
+        }
     }
 }

--- a/Tests/DependencyInjection/DoctrineMongoDBExtensionTest.php
+++ b/Tests/DependencyInjection/DoctrineMongoDBExtensionTest.php
@@ -94,8 +94,8 @@ class DoctrineMongoDBExtensionTest extends TestCase
         self::assertSame([
             [
                 'event' => 'prePersist',
-                'method' => 'onPrePersist',
-                'lazy' => true,
+                'method' => null,
+                'lazy' => null,
                 'connection' => 'test',
                 'priority' => 10,
             ],

--- a/Tests/DependencyInjection/Fixtures/Bundles/DocumentListenerBundle/EventListener/TestAttributeListener.php
+++ b/Tests/DependencyInjection/Fixtures/Bundles/DocumentListenerBundle/EventListener/TestAttributeListener.php
@@ -6,10 +6,10 @@ namespace Doctrine\Bundle\MongoDBBundle\Tests\DependencyInjection\Fixtures\Bundl
 
 use Doctrine\Bundle\MongoDBBundle\Attribute\AsDocumentListener;
 
-#[AsDocumentListener(event: 'prePersist', method: 'onPrePersist', lazy: true, connection: 'test', priority: 10)]
+#[AsDocumentListener(event: 'prePersist', connection: 'test', priority: 10)]
 class TestAttributeListener
 {
-    public function onPrePersist(): void
+    public function prePersist(): void
     {
     }
 }


### PR DESCRIPTION
If you use the `TestAttributeListener` as it was, in a project, it will throw an exception:

> Attempted to call an undefined method named "prePersist" of class "TestAttributeListener". Did you mean to call "onPrePersist"?

Only the event name is used [when injected into the manager](https://github.com/symfony/symfony/blob/6.4/src/Symfony/Bridge/Doctrine/DependencyInjection/CompilerPass/RegisterEventListenersAndSubscribersPass.php#L118).

`lazy` and `method` have no effect.