### PR TITLE
Backport UPGRADE-5.0

### DIFF
--- a/UPGRADE-5.0.md
+++ b/UPGRADE-5.0.md
@@ -1,6 +1,19 @@
 UPGRADE FROM 4.x to 5.0
 =======================
 
+## PHP version and dependencies
+
+* Add support for Symfony 7.0 and require at least Symfony 6.4
+* `doctrine/mongodb-odm` 2.6 and `doctrine/persistence` 3.0 are required
+
+## Annotations
+
+* Remove support of Annotation mapping, you should use Attributes or XML instead.
+
+## Commands
+
+* All command and compiler pass classes are internal and final. They cannot be
+  used directly or extended.
 * The `doctrine:mongodb:tail-cursor` command and
   `Doctrine\Bundle\MongoDBBundle\Cursor\TailableCursorProcessorInterface`
   interface have been dropped. You should use
@@ -9,7 +22,41 @@ UPGRADE FROM 4.x to 5.0
   `findBundle` and `findBasePathForBundle` methods from
   `Doctrine\Bundle\MongoDBBundle\Command\DoctrineODMCommand` have been
   removed without replacement.
-* The `Doctrine\Bundle\MongoDBBundle\Command\DoctrineODMCommand` class is now
-  `@internal`, you should not extend from this class.
-* `Doctrine\Bundle\MongoDBBundle\EventSubscriber\EventSubscriberInterface` has
-  been removed. Use the `#[AsDocumentListener]` attribute instead.
+
+## Configuration
+
+Remove all `doctrine_mongodb.odm.*` parameters.
+
+Deprecated options have been removed:
+
+| namespace                | removed     | replaced by        |
+|--------------------------|-------------|--------------------|
+| `default_commit_options` | `fsync`     | `j`                |
+| `default_commit_options` | `safe`      | `w`                |
+| `connections.*.options`  | `fsync`     | `journal`          |
+| `connections.*.options`  | `slaveOkay` | `readPreference`   |
+| `connections.*.options`  | `timeout`   | `connectTimeoutMS` |
+| `connections.*.options`  | `wTimeout`  | `wTimeoutMS`       |
+
+## Event Subscriber
+
+* Remove `Doctrine\Bundle\MongoDBBundle\EventSubscriber\EventSubscriberInterface`.
+  Use the `#[AsDocumentListener]` attribute instead.
+* Remove parameters `$method` and `$lazy` of `#[AsDocumentListener]`, they are
+  not used.
+
+## Fixtures
+
+* Remove `--service` option from `doctrine:mongodb:fixtures:load` command
+* Remove automatic injection of the container in fixtures classes implementing
+  `ContainerAwareInterface`. You should use dependency injection instead.
+* Remove the `fixture_loader` configuration
+
+## Cache
+
+The `Doctrine\Common\Cache\` providers are not supported anymore. The configuration
+uses `Symfony\Component\Cache\Adapter\` providers instead, for PSR-6 compatibility.
+
+If you want to use redis or memcached, the configuration of `host`, `port` and `instance_class`
+must be done for each document manager. The parameters `doctrine_mongodb.odm.cache.memcached_*`
+and `doctrine_mongodb.odm.cache.redis_*` are not read anymore.


### PR DESCRIPTION
I'm not sure why we maintain this file in the previous branch. We decided to no longer do that in Symfony (see [UPGRADE-7.0 on branch 6.4](https://github.com/symfony/symfony/blob/6.4/UPGRADE-7.0.md))