### PR TITLE
Remove deprecated parameters of `#[AsDocumentListener]`

### DIFF
--- a/UPGRADE-5.0.md
+++ b/UPGRADE-5.0.md
@@ -42,6 +42,8 @@ Deprecated options have been removed:
 
 * Remove `Doctrine\Bundle\MongoDBBundle\EventSubscriber\EventSubscriberInterface`.
   Use the `#[AsDocumentListener]` attribute instead.
+* Remove parameters `$method` and `$lazy` of `#[AsDocumentListener]`, they are
+  not used.
 
 ## Fixtures
 

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,6 @@
         "symfony/config": "^6.4 || ^7.0",
         "symfony/console": "^6.4 || ^7.0",
         "symfony/dependency-injection": "^6.4 || ^7.0",
-        "symfony/deprecation-contracts": "^2.1 || ^3.0",
         "symfony/doctrine-bridge": "^6.4 || ^7.0",
         "symfony/framework-bundle": "^6.4 || ^7.0",
         "symfony/http-kernel": "^6.4 || ^7.0",

--- a/src/Attribute/AsDocumentListener.php
+++ b/src/Attribute/AsDocumentListener.php
@@ -6,8 +6,6 @@ namespace Doctrine\Bundle\MongoDBBundle\Attribute;
 
 use Attribute;
 
-use function trigger_deprecation;
-
 /**
  * Service tag to autoconfigure document listeners.
  */
@@ -16,28 +14,8 @@ class AsDocumentListener
 {
     public function __construct(
         public ?string $event = null,
-        /** @deprecated the method name is the same as the event name */
-        public ?string $method = null,
-        /** @deprecated not supported */
-        public ?bool $lazy = null,
         public ?string $connection = null,
         public ?int $priority = null,
     ) {
-        // phpcs:disable SlevomatCodingStandard.ControlStructures.EarlyExit.EarlyExitNotUsed
-        if ($method !== null) {
-            trigger_deprecation(
-                'doctrine/mongodb-odm-bundle',
-                '4.7',
-                'The method name is the same as the event name, so it can be omitted.',
-            );
-        }
-
-        if ($lazy !== null) {
-            trigger_deprecation(
-                'doctrine/mongodb-odm-bundle',
-                '4.7',
-                'Lazy loading is not supported.',
-            );
-        }
     }
 }

--- a/src/DependencyInjection/DoctrineMongoDBExtension.php
+++ b/src/DependencyInjection/DoctrineMongoDBExtension.php
@@ -138,8 +138,6 @@ class DoctrineMongoDBExtension extends AbstractDoctrineExtension
         $container->registerAttributeForAutoconfiguration(AsDocumentListener::class, static function (ChildDefinition $definition, AsDocumentListener $attribute): void {
             $definition->addTag('doctrine_mongodb.odm.event_listener', [
                 'event'      => $attribute->event,
-                'method'     => $attribute->method,
-                'lazy'       => $attribute->lazy,
                 'connection' => $attribute->connection,
                 'priority'   => $attribute->priority,
             ]);

--- a/tests/DependencyInjection/DoctrineMongoDBExtensionTest.php
+++ b/tests/DependencyInjection/DoctrineMongoDBExtensionTest.php
@@ -94,8 +94,6 @@ class DoctrineMongoDBExtensionTest extends TestCase
         self::assertSame([
             [
                 'event' => 'prePersist',
-                'method' => null,
-                'lazy' => null,
                 'connection' => 'test',
                 'priority' => 10,
             ],


### PR DESCRIPTION
Follows https://github.com/doctrine/DoctrineMongoDBBundle/pull/825
