### PR TITLE
Fix bundle path for profiler templates

### DIFF
--- a/src/DoctrineMongoDBBundle.php
+++ b/src/DoctrineMongoDBBundle.php
@@ -21,6 +21,7 @@ use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 use function assert;
+use function dirname;
 use function spl_autoload_register;
 use function spl_autoload_unregister;
 
@@ -57,6 +58,11 @@ class DoctrineMongoDBBundle extends Bundle
     public function getContainerExtension(): ?ExtensionInterface
     {
         return new DoctrineMongoDBExtension();
+    }
+
+    public function getPath(): string
+    {
+        return dirname(__DIR__);
     }
 
     public function boot(): void


### PR DESCRIPTION
Twig templates discovery have been broken by https://github.com/doctrine/DoctrineMongoDBBundle/pull/826

The bundle path must be the root of the repository, as defined in [`AbstractBundle`](https://github.com/symfony/symfony/blob/e9748122f6da5b9fc95c0ff04be91bbe40bba545/src/Symfony/Component/HttpKernel/Bundle/AbstractBundle.php#L54-L56).

Let's skip the `AbstractBundle` subclass and the reflection call to provide the path directly.