### PR TITLE
Fix type for `dm` option in commands: `ManagerRegistry::getManager()` accepts `null`

### DIFF
--- a/src/Command/DoctrineODMCommand.php
+++ b/src/Command/DoctrineODMCommand.php
@@ -21,7 +21,7 @@ abstract class DoctrineODMCommand extends Command
         parent::__construct();
     }
 
-    public static function setApplicationDocumentManager(Application $application, string $dmName): void
+    public static function setApplicationDocumentManager(Application $application, ?string $dmName): void
     {
         $dm        = $application->getKernel()->getContainer()->get('doctrine_mongodb')->getManager($dmName);
         $helperSet = $application->getHelperSet();

--- a/tests/Command/DoctrineODMCommandTest.php
+++ b/tests/Command/DoctrineODMCommandTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Bundle\MongoDBBundle\Tests\Command;
+
+use Doctrine\Bundle\MongoDBBundle\Command\DoctrineODMCommand;
+use Doctrine\ODM\MongoDB\Tools\Console\Helper\DocumentManagerHelper;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+class DoctrineODMCommandTest extends KernelTestCase
+{
+    /** @dataProvider provideDmName */
+    public function testSetApplicationManager(?string $dmName): void
+    {
+        $kernel = new CommandTestKernel('test', false);
+        $kernel->boot();
+        $application = new Application($kernel);
+
+        DoctrineODMCommand::setApplicationDocumentManager($application, $dmName);
+
+        $this->assertInstanceOf(DocumentManagerHelper::class, $application->getHelperSet()->get('dm'));
+    }
+
+    public static function provideDmName(): iterable
+    {
+        yield ['command_test'];
+        yield [null];
+    }
+}


### PR DESCRIPTION
Fix #836