### PR TITLE
Update to psalm 5.25 and remove unused psalm baseline entry

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -50,7 +50,7 @@
         "symfony/stopwatch": "^6.4 || ^7.0",
         "symfony/validator": "^6.4 || ^7.0",
         "symfony/yaml": "^6.4 || ^7.0",
-        "vimeo/psalm": "^5.12"
+        "vimeo/psalm": "^5.25"
     },
     "conflict": {
         "doctrine/data-fixtures": "<1.3"

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="5.24.0@462c80e31c34e58cc4f750c656be3927e80e550e">
+<files psalm-version="5.25.0@01a8eb06b9e9cc6cfb6a320bf9fb14331919d505">
   <file src="config/value_resolver.php">
     <UndefinedClass>
       <code><![CDATA[ExpressionLanguage]]></code>
@@ -20,12 +20,6 @@
     <UndefinedMethod>
       <code><![CDATA[children]]></code>
     </UndefinedMethod>
-  </file>
-  <file src="tests/DocumentValueResolverFunctionalTest.php">
-    <InvalidArgument>
-      <code><![CDATA[[DocumentValueResolverController::class, 'showUserByDefault']]]></code>
-      <code><![CDATA[[DocumentValueResolverController::class, 'showUserWithMapping']]]></code>
-    </InvalidArgument>
   </file>
   <file src="tests/Form/Type/GuesserTestType.php">
     <MissingTemplateParam>


### PR DESCRIPTION
Fix [psalm issue](https://github.com/doctrine/DoctrineMongoDBBundle/actions/runs/9759854039/job/26937417861):
```
Error: tests/DocumentValueResolverFunctionalTest.php:0:0: UnusedBaselineEntry: Baseline for issue "InvalidArgument" has 2 extra entries. (see https://psalm.dev/316)
```

This lines were added by https://github.com/doctrine/DoctrineMongoDBBundle/commit/9251fa5e6c992b5c2deec35ff8de6a564b5492f7