### PR TITLE
Fix deprecations in CommandDataCollector

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     "homepage": "http://www.doctrine-project.org",
     "require": {
         "php": "^8.1",
-        "ext-mongodb": "^1.5",
+        "ext-mongodb": "^1.16",
         "composer-runtime-api": "^2.0",
         "doctrine/mongodb-odm": "^2.6",
         "doctrine/persistence": "^3.0",

--- a/src/DataCollector/CommandDataCollector.php
+++ b/src/DataCollector/CommandDataCollector.php
@@ -6,6 +6,7 @@ namespace Doctrine\Bundle\MongoDBBundle\DataCollector;
 
 use Doctrine\ODM\MongoDB\APM\Command;
 use Doctrine\ODM\MongoDB\APM\CommandLogger;
+use MongoDB\BSON\Document;
 use stdClass;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -16,8 +17,6 @@ use function array_map;
 use function array_reduce;
 use function count;
 use function json_decode;
-use function MongoDB\BSON\fromPHP;
-use function MongoDB\BSON\toCanonicalExtendedJSON;
 
 /** @internal */
 final class CommandDataCollector extends DataCollector
@@ -33,10 +32,11 @@ final class CommandDataCollector extends DataCollector
             'commands' => array_map(
                 static function (Command $command): array {
                     $dbProperty = '$db';
+                    $document = Document::fromPHP($command->getCommand());
 
                     return [
                         'database' => $command->getCommand()->$dbProperty ?? '',
-                        'command' => json_decode(toCanonicalExtendedJSON(fromPHP($command->getCommand()))),
+                        'command' => json_decode($document->toCanonicalExtendedJSON()),
                         'durationMicros' => $command->getDurationMicros(),
                     ];
                 },

--- a/src/DataCollector/CommandDataCollector.php
+++ b/src/DataCollector/CommandDataCollector.php
@@ -32,7 +32,7 @@ final class CommandDataCollector extends DataCollector
             'commands' => array_map(
                 static function (Command $command): array {
                     $dbProperty = '$db';
-                    $document = Document::fromPHP($command->getCommand());
+                    $document   = Document::fromPHP($command->getCommand());
 
                     return [
                         'database' => $command->getCommand()->$dbProperty ?? '',


### PR DESCRIPTION
### Description

Fix deprecations in method `collect()` of class `\Doctrine\Bundle\MongoDBBundle\DataCollector\CommandDataCollector`.

| Q             | A
| ------------- | ---
| Branch?       | 4.7.x
| Bug fix?      | no
| New feature?  | no
| Deprecations? | yes
| Tickets       | Fix issue #855
| License       | MIT
| Doc PR        |  -

Fix deprecations on PHP version **8.3** and `ext-mongodb` version **1.20**:

`Deprecated:  Function MongoDB\BSON\fromPHP() is deprecated in vendor/doctrine/mongodb-odm-bundle/DataCollector/CommandDataCollector.php on line 39.`

`Deprecated:  Function MongoDB\BSON\toCanonicalExtendedJSON() is deprecated in vendor/doctrine/mongodb-odm-bundle/DataCollector/CommandDataCollector.php on line 39.`
