### PR TITLE
Fix invalid expression in CI workflow

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -95,7 +95,7 @@ jobs:
       - name: "Upload coverage file"
         uses: "actions/upload-artifact@v4"
         with:
-          name: "phpunit-${{ matrix.php-version }}-${{ hashFiles(composer.lock) }}.coverage"
+          name: "phpunit-${{ matrix.php-version }}-${{ hashFiles('composer.lock') }}.coverage"
           path: "coverage.xml"
 
   upload_coverage:


### PR DESCRIPTION
This syntax error is the reason why the workflow didn't run on previous pull requests, unfortunately the corresponding error is a bit hard to figure out.