### PR TITLE
Use AbstractLogger instead of Closure in LoadDataFixturesDoctrineODMCommand.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
     },
     "require-dev": {
         "doctrine/coding-standard": "^11.0",
-        "doctrine/data-fixtures": "^1.7",
+        "doctrine/data-fixtures": "^1.8 || ^2.0",
         "phpunit/phpunit": "^9.5.5",
         "psalm/plugin-symfony": "^5.0",
         "symfony/browser-kit": "^6.4 || ^7.0",
@@ -53,7 +53,7 @@
         "vimeo/psalm": "^5.25"
     },
     "conflict": {
-        "doctrine/data-fixtures": "<1.3"
+        "doctrine/data-fixtures": "<1.8"
     },
     "suggest": {
         "doctrine/data-fixtures": "Load data fixtures"

--- a/src/Command/LoadDataFixturesDoctrineODMCommand.php
+++ b/src/Command/LoadDataFixturesDoctrineODMCommand.php
@@ -9,6 +9,7 @@ use Doctrine\Bundle\MongoDBBundle\ManagerRegistry;
 use Doctrine\Common\DataFixtures\Executor\MongoDBExecutor;
 use Doctrine\Common\DataFixtures\Purger\MongoDBPurger;
 use Psr\Log\AbstractLogger;
+use Stringable;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -84,10 +85,12 @@ EOT
 
         $purger   = new MongoDBPurger($dm);
         $executor = new MongoDBExecutor($dm, $purger);
-        $executor->setLogger(new class($output) extends AbstractLogger {
-            public function __construct(private readonly OutputInterface $output) {}
+        $executor->setLogger(new class ($output) extends AbstractLogger {
+            public function __construct(private readonly OutputInterface $output)
+            {
+            }
 
-            public function log(mixed $level, string|\Stringable $message, array $context = []): void
+            public function log(mixed $level, string|Stringable $message, array $context = []): void
             {
                 $this->output->writeln(sprintf('  <comment>></comment> <info>%s</info>', $message));
             }

--- a/src/Command/LoadDataFixturesDoctrineODMCommand.php
+++ b/src/Command/LoadDataFixturesDoctrineODMCommand.php
@@ -8,6 +8,7 @@ use Doctrine\Bundle\MongoDBBundle\Loader\SymfonyFixturesLoaderInterface;
 use Doctrine\Bundle\MongoDBBundle\ManagerRegistry;
 use Doctrine\Common\DataFixtures\Executor\MongoDBExecutor;
 use Doctrine\Common\DataFixtures\Purger\MongoDBPurger;
+use Psr\Log\AbstractLogger;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -83,8 +84,13 @@ EOT
 
         $purger   = new MongoDBPurger($dm);
         $executor = new MongoDBExecutor($dm, $purger);
-        $executor->setLogger(static function ($message) use ($output): void {
-            $output->writeln(sprintf('  <comment>></comment> <info>%s</info>', $message));
+        $executor->setLogger(new class($output) extends AbstractLogger {
+            public function __construct(private readonly OutputInterface $output) {}
+
+            public function log(mixed $level, string|\Stringable $message, array $context = []): void
+            {
+                $this->output->writeln(sprintf('  <comment>></comment> <info>%s</info>', $message));
+            }
         });
         $executor->execute($fixtures, $input->getOption('append'));
 


### PR DESCRIPTION
Fixes https://github.com/doctrine/DoctrineMongoDBBundle/issues/864