### PR TITLE
Restrict compatibility constraints with `psr/log` and `doctrine/data-fixtures`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "composer-runtime-api": "^2.0",
         "doctrine/mongodb-odm": "^2.6",
         "doctrine/persistence": "^3.0",
-        "psr/log": "^1.0 || ^2.0 || ^3.0",
+        "psr/log": "^2.0 || ^3.0",
         "symfony/config": "^6.4 || ^7.0",
         "symfony/console": "^6.4 || ^7.0",
         "symfony/dependency-injection": "^6.4 || ^7.0",
@@ -53,7 +53,7 @@
         "vimeo/psalm": "^5.25"
     },
     "conflict": {
-        "doctrine/data-fixtures": "<1.8"
+        "doctrine/data-fixtures": "<1.8 || >=3"
     },
     "suggest": {
         "doctrine/data-fixtures": "Load data fixtures"


### PR DESCRIPTION
- Change in https://github.com/doctrine/DoctrineMongoDBBundle/pull/865 is not compatible with `psr/log:^1`
- We cannot garantee compatibility with `doctrine/data-fixtures:>3`.