### PR TITLE
Exclude classes with `#[Document]` attribute from container

### DIFF
--- a/src/DependencyInjection/DoctrineMongoDBExtension.php
+++ b/src/DependencyInjection/DoctrineMongoDBExtension.php
@@ -16,6 +16,7 @@ use Doctrine\Common\DataFixtures\Loader as DataFixturesLoader;
 use Doctrine\Common\EventSubscriber;
 use Doctrine\ODM\MongoDB\Configuration as ODMConfiguration;
 use Doctrine\ODM\MongoDB\DocumentManager;
+use Doctrine\ODM\MongoDB\Mapping\Annotations\Document;
 use Doctrine\ODM\MongoDB\Mapping\Driver\AttributeDriver;
 use Doctrine\Persistence\Mapping\Driver\MappingDriverChain;
 use InvalidArgumentException;
@@ -141,6 +142,10 @@ class DoctrineMongoDBExtension extends AbstractDoctrineExtension
                 'connection' => $attribute->connection,
                 'priority'   => $attribute->priority,
             ]);
+        });
+
+        $container->registerAttributeForAutoconfiguration(Document::class, static function (ChildDefinition $definition): void {
+            $definition->addTag('container.excluded', ['source' => __FILE__]);
         });
 
         $this->loadMessengerServices($container, $loader);


### PR DESCRIPTION
Related to https://github.com/symfony/symfony/discussions/59280

Avoids any problems if the `src/Document` directory is not excluded from the container configuration. This directory is not excluded by default by the Symfony recipe.