### PR TITLE
Use LazyGhostObject for proxy objects

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "php": "^8.1",
         "ext-mongodb": "^1.16",
         "composer-runtime-api": "^2.0",
-        "doctrine/mongodb-odm": "^2.10@dev",
+        "doctrine/mongodb-odm": "^2.6",
         "doctrine/persistence": "^3.0",
         "psr/log": "^1.0 || ^2.0 || ^3.0",
         "symfony/config": "^6.4 || ^7.0",

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "php": "^8.1",
         "ext-mongodb": "^1.16",
         "composer-runtime-api": "^2.0",
-        "doctrine/mongodb-odm": "^2.6",
+        "doctrine/mongodb-odm": "^2.10@dev",
         "doctrine/persistence": "^3.0",
         "psr/log": "^1.0 || ^2.0 || ^3.0",
         "symfony/config": "^6.4 || ^7.0",

--- a/config/mongodb.php
+++ b/config/mongodb.php
@@ -8,7 +8,6 @@ use Doctrine\Bundle\MongoDBBundle\ManagerRegistry;
 use Doctrine\Bundle\MongoDBBundle\Repository\ContainerRepositoryFactory;
 use Doctrine\ODM\MongoDB\DocumentManager;
 use Doctrine\ODM\MongoDB\Tools\ResolveTargetDocumentListener;
-use Doctrine\Persistence\Proxy;
 use Symfony\Bridge\Doctrine\ContainerAwareEventManager;
 use Symfony\Bridge\Doctrine\Security\User\EntityUserProvider;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
@@ -54,7 +53,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
                 '%doctrine_mongodb.odm.document_managers%',
                 '%doctrine_mongodb.odm.default_connection%',
                 '%doctrine_mongodb.odm.default_document_manager%',
-                Proxy::class,
+                abstract_arg('Proxy Interface Name'),
                 service('service_container'),
             ])
 

--- a/config/mongodb.php
+++ b/config/mongodb.php
@@ -8,7 +8,7 @@ use Doctrine\Bundle\MongoDBBundle\ManagerRegistry;
 use Doctrine\Bundle\MongoDBBundle\Repository\ContainerRepositoryFactory;
 use Doctrine\ODM\MongoDB\DocumentManager;
 use Doctrine\ODM\MongoDB\Tools\ResolveTargetDocumentListener;
-use ProxyManager\Proxy\GhostObjectInterface;
+use Doctrine\Persistence\Proxy;
 use Symfony\Bridge\Doctrine\ContainerAwareEventManager;
 use Symfony\Bridge\Doctrine\Security\User\EntityUserProvider;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
@@ -54,7 +54,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
                 '%doctrine_mongodb.odm.document_managers%',
                 '%doctrine_mongodb.odm.default_connection%',
                 '%doctrine_mongodb.odm.default_document_manager%',
-                GhostObjectInterface::class,
+                Proxy::class,
                 service('service_container'),
             ])
 

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -15,6 +15,7 @@ use function count;
 use function is_array;
 use function is_string;
 use function json_decode;
+use function method_exists;
 use function preg_match;
 
 /**
@@ -39,6 +40,13 @@ class Configuration implements ConfigurationInterface
             ->children()
                 ->scalarNode('proxy_namespace')->defaultValue('MongoDBODMProxies')->end()
                 ->scalarNode('proxy_dir')->defaultValue('%kernel.cache_dir%/doctrine/odm/mongodb/Proxies')->end()
+                ->booleanNode('enable_lazy_ghost_objects')
+                    ->defaultValue(method_exists(ODMConfiguration::class, 'setUseLazyGhostObject'))
+                    ->validate()
+                        ->ifTrue(static fn ($v) => $v === true && ! method_exists(ODMConfiguration::class, 'setUseLazyGhostObject'))
+                        ->thenInvalid('Lazy ghost objects require doctrine/mongodb-odm 2.10 or higher.')
+                    ->end()
+                ->end()
                 ->scalarNode('auto_generate_proxy_classes')
                     ->defaultValue(ODMConfiguration::AUTOGENERATE_EVAL)
                     ->beforeNormalization()

--- a/src/DependencyInjection/DoctrineMongoDBExtension.php
+++ b/src/DependencyInjection/DoctrineMongoDBExtension.php
@@ -19,8 +19,10 @@ use Doctrine\ODM\MongoDB\DocumentManager;
 use Doctrine\ODM\MongoDB\Mapping\Annotations\Document;
 use Doctrine\ODM\MongoDB\Mapping\Driver\AttributeDriver;
 use Doctrine\Persistence\Mapping\Driver\MappingDriverChain;
+use Doctrine\Persistence\Proxy;
 use InvalidArgumentException;
 use MongoDB\Client;
+use ProxyManager\Proxy\LazyLoadingInterface;
 use Symfony\Bridge\Doctrine\DependencyInjection\AbstractDoctrineExtension;
 use Symfony\Bridge\Doctrine\Messenger\DoctrineClearEntityManagerWorkerSubscriber;
 use Symfony\Component\Cache\Adapter\ApcuAdapter;
@@ -46,6 +48,7 @@ use function class_implements;
 use function in_array;
 use function interface_exists;
 use function is_dir;
+use function method_exists;
 use function sprintf;
 
 /**
@@ -105,6 +108,11 @@ class DoctrineMongoDBExtension extends AbstractDoctrineExtension
             $container->removeDefinition('doctrine_mongodb.odm.command.load_data_fixtures');
         }
 
+        // Requires doctrine/mongodb-odm 2.10
+        $useLazyGhostObject = method_exists(ODMConfiguration::class, 'setUseLazyGhostObject');
+        $container->getDefinition('doctrine_mongodb')
+            ->setArgument(5, $useLazyGhostObject ? Proxy::class : LazyLoadingInterface::class);
+
         // load the connections
         $this->loadConnections($config['connections'], $container);
 
@@ -116,6 +124,7 @@ class DoctrineMongoDBExtension extends AbstractDoctrineExtension
             $config['default_document_manager'],
             $config['default_database'],
             $container,
+            $useLazyGhostObject,
         );
 
         if ($config['resolve_target_documents']) {
@@ -197,7 +206,7 @@ class DoctrineMongoDBExtension extends AbstractDoctrineExtension
      * @param string           $defaultDB The default db name
      * @param ContainerBuilder $container A ContainerBuilder instance
      */
-    protected function loadDocumentManagers(array $dmConfigs, string|null $defaultDM, string $defaultDB, ContainerBuilder $container): void
+    protected function loadDocumentManagers(array $dmConfigs, string|null $defaultDM, string $defaultDB, ContainerBuilder $container, bool $useLazyGhostObject = false): void
     {
         $dms = [];
         foreach ($dmConfigs as $name => $documentManager) {
@@ -207,6 +216,7 @@ class DoctrineMongoDBExtension extends AbstractDoctrineExtension
                 $defaultDM,
                 $defaultDB,
                 $container,
+                $useLazyGhostObject,
             );
             $dms[$name] = sprintf('doctrine_mongodb.odm.%s_document_manager', $name);
         }
@@ -222,7 +232,7 @@ class DoctrineMongoDBExtension extends AbstractDoctrineExtension
      * @param string           $defaultDB       The default db name
      * @param ContainerBuilder $container       A ContainerBuilder instance
      */
-    protected function loadDocumentManager(array $documentManager, string|null $defaultDM, string $defaultDB, ContainerBuilder $container): void
+    protected function loadDocumentManager(array $documentManager, string|null $defaultDM, string $defaultDB, ContainerBuilder $container, bool $useLazyGhostObject = false): void
     {
         $connectionName  = $documentManager['connection'] ?? $documentManager['name'];
         $configurationId = sprintf('doctrine_mongodb.odm.%s_configuration', $documentManager['name']);
@@ -254,9 +264,15 @@ class DoctrineMongoDBExtension extends AbstractDoctrineExtension
             'setPersistentCollectionDir' => '%doctrine_mongodb.odm.persistent_collection_dir%',
             'setPersistentCollectionNamespace' => '%doctrine_mongodb.odm.persistent_collection_namespace%',
             'setAutoGeneratePersistentCollectionClasses' => '%doctrine_mongodb.odm.auto_generate_persistent_collection_classes%',
-            'setUseLazyGhostObject' => true,
-            'setUseTransactionalFlush' => $documentManager['use_transactional_flush'],
         ];
+
+        if ($useLazyGhostObject) {
+            $methods['setUseLazyGhostObject'] = $useLazyGhostObject;
+        }
+
+        if (method_exists(ODMConfiguration::class, 'setUseTransactionalFlush')) {
+            $methods['setUseTransactionalFlush'] = $documentManager['use_transactional_flush'];
+        }
 
         if ($documentManager['repository_factory']) {
             $methods['setRepositoryFactory'] = new Reference($documentManager['repository_factory']);

--- a/src/DependencyInjection/DoctrineMongoDBExtension.php
+++ b/src/DependencyInjection/DoctrineMongoDBExtension.php
@@ -109,9 +109,8 @@ class DoctrineMongoDBExtension extends AbstractDoctrineExtension
         }
 
         // Requires doctrine/mongodb-odm 2.10
-        $useLazyGhostObject = method_exists(ODMConfiguration::class, 'setUseLazyGhostObject');
         $container->getDefinition('doctrine_mongodb')
-            ->setArgument(5, $useLazyGhostObject ? Proxy::class : LazyLoadingInterface::class);
+            ->setArgument(5, $config['enable_lazy_ghost_objects'] ? Proxy::class : LazyLoadingInterface::class);
 
         // load the connections
         $this->loadConnections($config['connections'], $container);
@@ -124,7 +123,7 @@ class DoctrineMongoDBExtension extends AbstractDoctrineExtension
             $config['default_document_manager'],
             $config['default_database'],
             $container,
-            $useLazyGhostObject,
+            $config['enable_lazy_ghost_objects'],
         );
 
         if ($config['resolve_target_documents']) {

--- a/src/DependencyInjection/DoctrineMongoDBExtension.php
+++ b/src/DependencyInjection/DoctrineMongoDBExtension.php
@@ -46,7 +46,6 @@ use function class_implements;
 use function in_array;
 use function interface_exists;
 use function is_dir;
-use function method_exists;
 use function sprintf;
 
 /**
@@ -255,11 +254,9 @@ class DoctrineMongoDBExtension extends AbstractDoctrineExtension
             'setPersistentCollectionDir' => '%doctrine_mongodb.odm.persistent_collection_dir%',
             'setPersistentCollectionNamespace' => '%doctrine_mongodb.odm.persistent_collection_namespace%',
             'setAutoGeneratePersistentCollectionClasses' => '%doctrine_mongodb.odm.auto_generate_persistent_collection_classes%',
+            'setUseLazyGhostObject' => true,
+            'setUseTransactionalFlush' => $documentManager['use_transactional_flush'],
         ];
-
-        if (method_exists(ODMConfiguration::class, 'setUseTransactionalFlush')) {
-            $methods['setUseTransactionalFlush'] = $documentManager['use_transactional_flush'];
-        }
 
         if ($documentManager['repository_factory']) {
             $methods['setRepositoryFactory'] = new Reference($documentManager['repository_factory']);

--- a/tests/DependencyInjection/ConfigurationTest.php
+++ b/tests/DependencyInjection/ConfigurationTest.php
@@ -22,6 +22,7 @@ use Symfony\Component\Yaml\Yaml;
 
 use function array_key_exists;
 use function file_get_contents;
+use function method_exists;
 
 class ConfigurationTest extends TestCase
 {
@@ -37,6 +38,7 @@ class ConfigurationTest extends TestCase
             'auto_generate_hydrator_classes' => false,
             'auto_generate_proxy_classes'    => ODMConfiguration::AUTOGENERATE_EVAL,
             'auto_generate_persistent_collection_classes' => ODMConfiguration::AUTOGENERATE_NEVER,
+            'enable_lazy_ghost_objects'      => method_exists(ODMConfiguration::class, 'setUseLazyGhostObject'),
             'default_database'               => 'default',
             'document_managers'              => [],
             'connections'                    => [],
@@ -69,6 +71,7 @@ class ConfigurationTest extends TestCase
             'auto_generate_hydrator_classes' => 1,
             'auto_generate_proxy_classes'    => ODMConfiguration::AUTOGENERATE_FILE_NOT_EXISTS,
             'auto_generate_persistent_collection_classes' => ODMConfiguration::AUTOGENERATE_EVAL,
+            'enable_lazy_ghost_objects'      => method_exists(ODMConfiguration::class, 'setUseLazyGhostObject'),
             'default_connection'             => 'conn1',
             'default_database'               => 'default_db_name',
             'default_document_manager'       => 'default_dm_name',


### PR DESCRIPTION
Requires the release of `doctrine/mongodb-odm: 2.10` with LazyGhostObject support provided by `symfony/var-exporter`: 

Enable `UseLazyGhostObject` configuration and fix proxy interface after the default configuration is reset to Proxy Manager by https://github.com/doctrine/mongodb-odm/pull/2720 for compatibility with older versions of the bundle.

New configuration setting: `enable_lazy_ghost_objects` which is true by default when the feature is available.