### PR TITLE
Ignore issue for `method_exists` always `true` reported by phpstan

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -199,6 +199,12 @@ parameters:
 			path: src/DependencyInjection/Configuration.php
 
 		-
+			message: '#^Call to function method_exists\(\) with ''Doctrine\\\\ODM\\\\MongoDB\\\\Configuration'' and ''setUseLazyGhostObje…'' will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 2
+			path: src/DependencyInjection/Configuration.php
+
+		-
 			message: '#^Parameter \#1 \$rootNode of method Doctrine\\Bundle\\MongoDBBundle\\DependencyInjection\\Configuration\:\:addConnectionsSection\(\) expects Symfony\\Component\\Config\\Definition\\Builder\\ArrayNodeDefinition, Symfony\\Component\\Config\\Definition\\Builder\\NodeDefinition given\.$#'
 			identifier: argument.type
 			count: 1
@@ -515,6 +521,12 @@ parameters:
 			identifier: argument.type
 			count: 1
 			path: tests/DependencyInjection/AbstractMongoDBExtensionTestCase.php
+
+		-
+			message: '#^Call to function method_exists\(\) with ''Doctrine\\\\ODM\\\\MongoDB\\\\Configuration'' and ''setUseLazyGhostObje…'' will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 2
+			path: tests/DependencyInjection/ConfigurationTest.php
 
 		-
 			message: '#^Method Doctrine\\Bundle\\MongoDBBundle\\Tests\\DependencyInjection\\ConfigurationTest\:\:testFullConfiguration\(\) has parameter \$config with no value type specified in iterable type array\.$#'


### PR DESCRIPTION
The method `Doctrine\ODM\MongoDB\Configuration::setUseLazyGhostObject()` always exist when `doctrine/mongodb-odm: ^2.10` is installed.


- PHPstan error instroduced by: https://github.com/doctrine/DoctrineMongoDBBundle/pull/877
- Method introduced by https://github.com/doctrine/mongodb-odm/pull/2700