### PR TITLE
Exclude other Document attributes from DIC

### DIFF
--- a/src/DependencyInjection/DoctrineMongoDBExtension.php
+++ b/src/DependencyInjection/DoctrineMongoDBExtension.php
@@ -17,6 +17,11 @@ use Doctrine\Common\EventSubscriber;
 use Doctrine\ODM\MongoDB\Configuration as ODMConfiguration;
 use Doctrine\ODM\MongoDB\DocumentManager;
 use Doctrine\ODM\MongoDB\Mapping\Annotations\Document;
+use Doctrine\ODM\MongoDB\Mapping\Annotations\EmbeddedDocument;
+use Doctrine\ODM\MongoDB\Mapping\Annotations\File;
+use Doctrine\ODM\MongoDB\Mapping\Annotations\MappedSuperclass;
+use Doctrine\ODM\MongoDB\Mapping\Annotations\QueryResultDocument;
+use Doctrine\ODM\MongoDB\Mapping\Annotations\View;
 use Doctrine\ODM\MongoDB\Mapping\Driver\AttributeDriver;
 use Doctrine\Persistence\Mapping\Driver\MappingDriverChain;
 use Doctrine\Persistence\Proxy;
@@ -151,8 +156,24 @@ class DoctrineMongoDBExtension extends AbstractDoctrineExtension
             ]);
         });
 
+        // Document classes are excluded from the container by default
         $container->registerAttributeForAutoconfiguration(Document::class, static function (ChildDefinition $definition): void {
-            $definition->addTag('container.excluded', ['source' => __FILE__]);
+            $definition->addTag('container.excluded', ['source' => sprintf('with #[%s] attribute', Document::class)])->setAbstract(true);
+        });
+        $container->registerAttributeForAutoconfiguration(EmbeddedDocument::class, static function (ChildDefinition $definition): void {
+            $definition->addTag('container.excluded', ['source' => sprintf('with #[%s] attribute', EmbeddedDocument::class)])->setAbstract(true);
+        });
+        $container->registerAttributeForAutoconfiguration(MappedSuperclass::class, static function (ChildDefinition $definition): void {
+            $definition->addTag('container.excluded', ['source' => sprintf('with #[%s] attribute', MappedSuperclass::class)])->setAbstract(true);
+        });
+        $container->registerAttributeForAutoconfiguration(View::class, static function (ChildDefinition $definition): void {
+            $definition->addTag('container.excluded', ['source' => sprintf('with #[%s] attribute', View::class)])->setAbstract(true);
+        });
+        $container->registerAttributeForAutoconfiguration(QueryResultDocument::class, static function (ChildDefinition $definition): void {
+            $definition->addTag('container.excluded', ['source' => sprintf('with #[%s] attribute', QueryResultDocument::class)])->setAbstract(true);
+        });
+        $container->registerAttributeForAutoconfiguration(File::class, static function (ChildDefinition $definition): void {
+            $definition->addTag('container.excluded', ['source' => sprintf('with #[%s] attribute', File::class)])->setAbstract(true);
         });
 
         $this->loadMessengerServices($container, $loader);

--- a/tests/DependencyInjection/DoctrineMongoDBExtensionTest.php
+++ b/tests/DependencyInjection/DoctrineMongoDBExtensionTest.php
@@ -4,14 +4,17 @@ declare(strict_types=1);
 
 namespace Doctrine\Bundle\MongoDBBundle\Tests\DependencyInjection;
 
+use Closure;
 use Composer\InstalledVersions;
 use Composer\Semver\VersionParser;
 use Doctrine\Bundle\MongoDBBundle\Attribute\MapDocument;
 use Doctrine\Bundle\MongoDBBundle\DependencyInjection\DoctrineMongoDBExtension;
 use Doctrine\Bundle\MongoDBBundle\Tests\DependencyInjection\Fixtures\Bundles\DocumentListenerBundle\EventListener\TestAttributeListener;
+use Doctrine\ODM\MongoDB\Mapping\Annotations;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bridge\Doctrine\Messenger\DoctrineClearEntityManagerWorkerSubscriber;
 use Symfony\Component\DependencyInjection\Alias;
+use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
@@ -23,6 +26,7 @@ use function array_merge;
 use function class_exists;
 use function interface_exists;
 use function is_dir;
+use function sprintf;
 use function sys_get_temp_dir;
 
 class DoctrineMongoDBExtensionTest extends TestCase
@@ -100,6 +104,36 @@ class DoctrineMongoDBExtensionTest extends TestCase
                 'priority' => 10,
             ],
         ], $listenerDefinition->getTag('doctrine_mongodb.odm.event_listener'));
+    }
+
+    /** @return array<array{0: class-string}> */
+    public static function provideAttributeExcludedFromContainer(): array
+    {
+        return [
+            'Document' => [Annotations\Document::class],
+            'EmbeddedDocument' => [Annotations\EmbeddedDocument::class],
+            'MappedSuperclass' => [Annotations\MappedSuperclass::class],
+            'View' => [Annotations\View::class],
+            'QueryResultDocument' => [Annotations\QueryResultDocument::class],
+            'File' => [Annotations\File::class],
+        ];
+    }
+
+    /** @dataProvider provideAttributeExcludedFromContainer */
+    public function testDocumentAttributeExcludesFromContainer(string $class): void
+    {
+        $container = $this->getContainer();
+        $extension = new DoctrineMongoDBExtension();
+        $extension->load($this->buildConfiguration(), $container);
+
+        $attributes = $container->getAutoconfiguredAttributes();
+        $this->assertInstanceOf(Closure::class, $attributes[$class]);
+
+        $definition = new ChildDefinition('');
+        $attributes[$class]($definition);
+
+        $this->assertSame([['source' => sprintf('with #[%s] attribute', $class)]], $definition->getTag('container.excluded'));
+        $this->assertTrue($definition->isAbstract());
     }
 
     /** @param string|string[] $bundles */


### PR DESCRIPTION
In https://github.com/doctrine/DoctrineMongoDBBundle/pull/876, I forgot to handle other attributes.

The new implementation align with [DoctrineBundle](https://github.com/doctrine/DoctrineBundle/blob/a91383d6d8788f8c63dbf9e6d51677d5d6fac093/src/DependencyInjection/DoctrineExtension.php#L650-L658).