### PR TITLE
Support MongoDB Driver v2

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -18,6 +18,7 @@ jobs:
       SYMFONY_REQUIRE: ${{matrix.symfony-version}}
 
     strategy:
+      fail-fast: false
       matrix:
         os:
           - "ubuntu-20.04"
@@ -25,11 +26,12 @@ jobs:
           - "8.1"
           - "8.2"
           - "8.3"
+          - "8.4"
         stability:
           - "stable"
         symfony-version:
           - "6.4.*"
-          - "7.0.*"
+          - "7.2.*"
         driver-version:
           - "stable"
         dependencies:
@@ -38,12 +40,18 @@ jobs:
           - dependencies: "lowest"
             os: "ubuntu-20.04"
             php-version: "8.1"
-            driver-version: "1.5.0"
+            driver-version: "1.16.0"
             stability: "stable"
             symfony-version: "6.4.*"
+          - dependencies: "highest"
+            os: "ubuntu-20.04"
+            php-version: "8.2"
+            driver-version: "mongodb/mongo-php-driver@v2.x"
+            stability: "dev"
+            symfony-version: "7.2.*"
         exclude:
           - php-version: "8.1"
-            symfony-version: "7.0.*"
+            symfony-version: "7.2.*"
 
     services:
       mongodb:

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     "homepage": "http://www.doctrine-project.org",
     "require": {
         "php": "^8.1",
-        "ext-mongodb": "^1.16",
+        "ext-mongodb": "^1.16 || ^2",
         "composer-runtime-api": "^2.0",
         "doctrine/mongodb-odm": "^2.6",
         "doctrine/persistence": "^3.0",


### PR DESCRIPTION
- Requires https://github.com/doctrine/mongodb-odm/pull/2683
- Enable support and test MongoDB Extension v2
- Test supported versions on Symfony (6.4 and 7.2)
- Test PHP 8.1 to 8.4
