### PR TITLE
Test with Symfony 7.3

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -32,6 +32,7 @@ jobs:
         symfony-version:
           - "6.4.*"
           - "7.2.*"
+          - "7.3.*"
         driver-version:
           - "stable"
         dependencies:
@@ -52,6 +53,8 @@ jobs:
         exclude:
           - php-version: "8.1"
             symfony-version: "7.2.*"
+          - php-version: "8.1"
+            symfony-version: "7.3.*"
 
     services:
       mongodb:

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -49,9 +49,9 @@ Sample Configuration
 
     .. code-block:: php
 
+        use Symfony\Config\DoctrineMongodbConfig;
         use function Symfony\Component\DependencyInjection\Loader\Configurator\env;
         use function Symfony\Component\DependencyInjection\Loader\Configurator\param;
-        use Symfony\Config\DoctrineMongodbConfig;
 
         return static function (DoctrineMongodbConfig $config): void {
             $config->connection('default')
@@ -142,9 +142,9 @@ If you wish to use memcached to cache your metadata, you need to configure the
 
     .. code-block:: php
 
-        use function Symfony\Component\DependencyInjection\Loader\Configurator\param;
         use Symfony\Component\Cache\Adapter\MemcachedAdapter;
         use Symfony\Config\DoctrineMongodbConfig;
+        use function Symfony\Component\DependencyInjection\Loader\Configurator\param;
 
         return static function (DoctrineMongodbConfig $config): void {
             $config->defaultDatabase('hello_' . param('kernel.environment'));
@@ -260,8 +260,8 @@ The following configuration shows a bunch of mapping examples:
 
     .. code-block:: php
 
-        use function Symfony\Component\DependencyInjection\Loader\Configurator\param;
         use Symfony\Config\DoctrineMongodbConfig;
+        use function Symfony\Component\DependencyInjection\Loader\Configurator\param;
 
         return static function (DoctrineMongodbConfig $config): void {
             $config->documentManager('default')
@@ -475,8 +475,8 @@ following syntax:
 
     .. code-block:: php
 
-        use function Symfony\Component\DependencyInjection\Loader\Configurator\param;
         use Symfony\Config\DoctrineMongodbConfig;
+        use function Symfony\Component\DependencyInjection\Loader\Configurator\param;
 
         return static function (DoctrineMongodbConfig $config): void {
             $config->defaultDatabase('hello_' . param('kernel.environment'));

--- a/src/DependencyInjection/DoctrineMongoDBExtension.php
+++ b/src/DependencyInjection/DoctrineMongoDBExtension.php
@@ -158,22 +158,22 @@ class DoctrineMongoDBExtension extends AbstractDoctrineExtension
 
         // Document classes are excluded from the container by default
         $container->registerAttributeForAutoconfiguration(Document::class, static function (ChildDefinition $definition): void {
-            $definition->addTag('container.excluded', ['source' => sprintf('with #[%s] attribute', Document::class)])->setAbstract(true);
+            $definition->addTag('container.excluded', ['source' => sprintf('with #[%s] attribute', Document::class)]);
         });
         $container->registerAttributeForAutoconfiguration(EmbeddedDocument::class, static function (ChildDefinition $definition): void {
-            $definition->addTag('container.excluded', ['source' => sprintf('with #[%s] attribute', EmbeddedDocument::class)])->setAbstract(true);
+            $definition->addTag('container.excluded', ['source' => sprintf('with #[%s] attribute', EmbeddedDocument::class)]);
         });
         $container->registerAttributeForAutoconfiguration(MappedSuperclass::class, static function (ChildDefinition $definition): void {
-            $definition->addTag('container.excluded', ['source' => sprintf('with #[%s] attribute', MappedSuperclass::class)])->setAbstract(true);
+            $definition->addTag('container.excluded', ['source' => sprintf('with #[%s] attribute', MappedSuperclass::class)]);
         });
         $container->registerAttributeForAutoconfiguration(View::class, static function (ChildDefinition $definition): void {
-            $definition->addTag('container.excluded', ['source' => sprintf('with #[%s] attribute', View::class)])->setAbstract(true);
+            $definition->addTag('container.excluded', ['source' => sprintf('with #[%s] attribute', View::class)]);
         });
         $container->registerAttributeForAutoconfiguration(QueryResultDocument::class, static function (ChildDefinition $definition): void {
-            $definition->addTag('container.excluded', ['source' => sprintf('with #[%s] attribute', QueryResultDocument::class)])->setAbstract(true);
+            $definition->addTag('container.excluded', ['source' => sprintf('with #[%s] attribute', QueryResultDocument::class)]);
         });
         $container->registerAttributeForAutoconfiguration(File::class, static function (ChildDefinition $definition): void {
-            $definition->addTag('container.excluded', ['source' => sprintf('with #[%s] attribute', File::class)])->setAbstract(true);
+            $definition->addTag('container.excluded', ['source' => sprintf('with #[%s] attribute', File::class)]);
         });
 
         $this->loadMessengerServices($container, $loader);


### PR DESCRIPTION
- Add Symfony 7.3 to the test matrix
- Remove the `abstract` from `container.excluded` document classes (same as https://github.com/symfony/symfony/commit/023c44c89ad06acc6bb38f2da2a88dc7aa24918f)
- Update usage of the deprecated `ContainerBuilder::getAutoconfiguredAttributes()` in tests