### PR TITLE
[Encryption] Update required version of mongodb driver and odm

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - "*.x"
+      - "feature/*"
   push:
     branches:
       - "*.x"

--- a/.github/workflows/composer-lint.yml
+++ b/.github/workflows/composer-lint.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - "*.x"
+      - "feature/*"
     paths:
       - "composer.json"
   push:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     branches:
       - "*.x"
-      - "master"
+      - "feature/*"
   push:
 
 env:
@@ -41,7 +41,7 @@ jobs:
           - dependencies: "lowest"
             os: "ubuntu-24.04"
             php-version: "8.1"
-            driver-version: "1.16.0"
+            driver-version: "1.21.0"
             stability: "stable"
             symfony-version: "6.4.*"
           - dependencies: "highest"

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - "*.x"
+      - "feature/*"
     paths:
       - .github/workflows/static-analysis.yml
       - composer.*

--- a/composer.json
+++ b/composer.json
@@ -25,9 +25,9 @@
     "homepage": "http://www.doctrine-project.org",
     "require": {
         "php": "^8.1",
-        "ext-mongodb": "^1.16 || ^2",
+        "ext-mongodb": "^1.21 || ^2",
         "composer-runtime-api": "^2.0",
-        "doctrine/mongodb-odm": "^2.6",
+        "doctrine/mongodb-odm": "dev-feature/queryable-encryption as 2.12.x-dev",
         "doctrine/persistence": "^3.0 || ^4.0",
         "psr/log": "^1.0 || ^2.0 || ^3.0",
         "symfony/config": "^6.4 || ^7.0",

--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
         "doctrine/coding-standard": "^11.0",
         "doctrine/data-fixtures": "^1.8 || ^2.0",
         "phpstan/phpstan": "^2.0",
-        "phpunit/phpunit": "^9.5.5",
+        "phpunit/phpunit": "^9.6.23",
         "symfony/browser-kit": "^6.4 || ^7.0",
         "symfony/form": "^6.4 || ^7.0",
         "symfony/phpunit-bridge": "^6.4.1 || ^7.0.1",


### PR DESCRIPTION
Update the minimum version of PHPUnit in order to support readonly properties in `nikic/php-parser` when lowest dependencies are installed.