### PR TITLE
Remove `@phpstan-ignore` after release of `doctrine/data-fixture`

### DIFF
--- a/src/Command/LoadDataFixturesDoctrineODMCommand.php
+++ b/src/Command/LoadDataFixturesDoctrineODMCommand.php
@@ -101,7 +101,6 @@ EOT
                 return self::INVALID;
             }
 
-            // @phpstan-ignore method.notFound
             $purger->setPurgeMode(MongoDBPurgeMode::Delete);
         }
 


### PR DESCRIPTION
Release of [`doctrine/data-fixtures: 2.1`](https://github.com/doctrine/data-fixtures/releases/tag/2.1.0) fixed the issue.

```
 ------ ------------------------------------------------------------------- 
  Line   src/Command/LoadDataFixturesDoctrineODMCommand.php                 
 ------ ------------------------------------------------------------------- 
  105    No error with identifier method.notFound is reported on line 105.  
```