### PR TITLE
[Encryption] Validate extraOptions configuration

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -12,6 +12,7 @@ use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 
 use function count;
+use function explode;
 use function in_array;
 use function is_array;
 use function is_string;
@@ -428,7 +429,20 @@ class Configuration implements ConfigurationInterface
                                         ->end()
                                     ->end()
                                     ->arrayNode('extraOptions')
-                                        ->prototype('variable')->end()
+                                        ->children()
+                                            ->scalarNode('mongocryptdURI')->end()
+                                            ->booleanNode('mongocryptdBypassSpawn')->end()
+                                            ->scalarNode('mongocryptdSpawnPath')->end()
+                                            ->arrayNode('mongocryptdSpawnArgs')
+                                                ->beforeNormalization()
+                                                    ->ifString()
+                                                    ->then(static fn ($v) => explode(' ', $v))
+                                                ->end()
+                                                ->prototype('scalar')->cannotBeEmpty()->end()
+                                            ->end()
+                                            ->scalarNode('cryptSharedLibPath')->end()
+                                            ->booleanNode('cryptSharedLibRequired')->end()
+                                        ->end()
                                     ->end()
                                     ->booleanNode('bypassQueryAnalysis')->end()
                                     ->arrayNode('tlsOptions')

--- a/tests/DependencyInjection/ConfigurationTest.php
+++ b/tests/DependencyInjection/ConfigurationTest.php
@@ -257,7 +257,7 @@ class ConfigurationTest extends TestCase
                             'mongocryptdURI' => 'mongodb://localhost:27020',
                             'mongocryptdBypassSpawn' => true,
                             'mongocryptdSpawnPath' => '%kernel.project_dir%/bin/mongocryptd',
-                            'mongocryptdSpawnArgs' => '--pidfilepath=%kernel.project_dir%/var/mongocryptd.pid --idleShutdownTimeoutSecs=60',
+                            'mongocryptdSpawnArgs' => ['--pidfilepath=%kernel.project_dir%/var/mongocryptd.pid', '--idleShutdownTimeoutSecs=60'],
                             'cryptSharedLibPath' => '%kernel.project_dir%/bin/mongo_crypt_v1.dylib',
                             'cryptSharedLibRequired' => true,
                         ],

--- a/tests/DependencyInjection/Fixtures/config/yml/full.yml
+++ b/tests/DependencyInjection/Fixtures/config/yml/full.yml
@@ -130,7 +130,9 @@ doctrine_mongodb:
                     mongocryptdURI: 'mongodb://localhost:27020'
                     mongocryptdBypassSpawn: true
                     mongocryptdSpawnPath: '%kernel.project_dir%/bin/mongocryptd'
-                    mongocryptdSpawnArgs: '--pidfilepath=%kernel.project_dir%/var/mongocryptd.pid --idleShutdownTimeoutSecs=60'
+                    mongocryptdSpawnArgs:
+                        - '--pidfilepath=%kernel.project_dir%/var/mongocryptd.pid'
+                        - '--idleShutdownTimeoutSecs=60'
                     cryptSharedLibPath: '%kernel.project_dir%/bin/mongo_crypt_v1.dylib'
                     cryptSharedLibRequired: true
 


### PR DESCRIPTION
Adding the details of `extraOptions` configuration, I found that `mongocryptdSpawnArgs` needs to be an array.

The string is converted into an array of option because the option can be provided as an XML attribute.