### PR TITLE
[Encryption] Fix query option min/max type for exported encrypted fields map

### DIFF
--- a/src/Command/EncryptionDumpFieldsMapCommand.php
+++ b/src/Command/EncryptionDumpFieldsMapCommand.php
@@ -89,14 +89,6 @@ final class EncryptionDumpFieldsMapCommand extends Command
                         if (isset($field['queries']['max']['$numberInt'])) {
                             $field['queries']['max'] = ['$numberLong' => $field['queries']['max']['$numberInt']];
                         }
-                    } elseif ($field['bsonType'] === 'decimal') {
-                        if (isset($field['queries']['min']['$numberDouble'])) {
-                            $field['queries']['min'] = ['$numberDecimal' => $field['queries']['min']['$numberDouble']];
-                        }
-
-                        if (isset($field['queries']['max']['$numberDouble'])) {
-                            $field['queries']['max'] = ['$numberDecimal' => $field['queries']['max']['$numberDouble']];
-                        }
                     }
                 }
 

--- a/src/Command/EncryptionDumpFieldsMapCommand.php
+++ b/src/Command/EncryptionDumpFieldsMapCommand.php
@@ -76,9 +76,32 @@ final class EncryptionDumpFieldsMapCommand extends Command
                 continue;
             }
 
+            // The min/max query options must have the same type as the field.
+            // But the PHP driver always convert to "int" or "float" when the value fit in the range
             foreach ($encryptedFieldsMap as $ns => $encryptedFields) {
+                $fields = json_decode(PackedArray::fromPHP($encryptedFields['fields'])->toCanonicalExtendedJSON(), true);
+                foreach ($fields as &$field) {
+                    if ($field['bsonType'] === 'long') {
+                        if (isset($field['queries']['min']['$numberInt'])) {
+                            $field['queries']['min'] = ['$numberLong' => $field['queries']['min']['$numberInt']];
+                        }
+
+                        if (isset($field['queries']['max']['$numberInt'])) {
+                            $field['queries']['max'] = ['$numberLong' => $field['queries']['max']['$numberInt']];
+                        }
+                    } elseif ($field['bsonType'] === 'decimal') {
+                        if (isset($field['queries']['min']['$numberDouble'])) {
+                            $field['queries']['min'] = ['$numberDecimal' => $field['queries']['min']['$numberDouble']];
+                        }
+
+                        if (isset($field['queries']['max']['$numberDouble'])) {
+                            $field['queries']['max'] = ['$numberDecimal' => $field['queries']['max']['$numberDouble']];
+                        }
+                    }
+                }
+
                 // Keep only the "fields" key and ignore "escCollection" and "ecocCollection"
-                $encryptedFieldsMap[$ns] = ['fields' => json_decode(PackedArray::fromPHP($encryptedFields['fields'])->toRelaxedExtendedJSON(), true)];
+                $encryptedFieldsMap[$ns] = ['fields' => $fields];
             }
 
             $io->section(sprintf('Dumping encrypted fields map for document manager "%s"', $name));


### PR DESCRIPTION
When running the command `bin/console doctrine:mongodb:encryption:dump-fields-map` the min/max option of field query must match the field type.

But when we read the field map from the collection metadata, the `long` values are automatically converted to `int`.

In this PR, in manipulate the exported extends JSON to ensure the option value has the expected type.

Same issue as https://github.com/doctrine/mongodb-odm/pull/2805