### PR TITLE
Update phpstan baseline for new auto encryption feature

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -211,6 +211,12 @@ parameters:
 			path: src/DependencyInjection/Configuration.php
 
 		-
+			message: '#^Call to function method_exists\(\) with ''Doctrine\\\\ODM\\\\MongoDB\\\\Configuration'' and ''setAutoEncryption'' will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 1
+			path: src/DependencyInjection/DoctrineMongoDBExtension.php
+
+		-
 			message: '#^Call to function method_exists\(\) with ''Doctrine\\\\ODM\\\\MongoDB\\\\Configuration'' and ''setUseTransactional…'' will always evaluate to true\.$#'
 			identifier: function.alreadyNarrowedType
 			count: 1
@@ -527,24 +533,6 @@ parameters:
 			identifier: argument.type
 			count: 1
 			path: tests/DependencyInjection/ConfigurationTest.php
-
-		-
-			message: '#^Call to an undefined method Doctrine\\ODM\\MongoDB\\Configuration\:\:getDefaultKmsProvider\(\)\.$#'
-			identifier: method.notFound
-			count: 3
-			path: tests/DependencyInjection/DoctrineMongoDBExtensionTest.php
-
-		-
-			message: '#^Call to an undefined method Doctrine\\ODM\\MongoDB\\Configuration\:\:getDefaultMasterKey\(\)\.$#'
-			identifier: method.notFound
-			count: 3
-			path: tests/DependencyInjection/DoctrineMongoDBExtensionTest.php
-
-		-
-			message: '#^Call to an undefined method Doctrine\\ODM\\MongoDB\\Configuration\:\:getDriverOptions\(\)\.$#'
-			identifier: method.notFound
-			count: 7
-			path: tests/DependencyInjection/DoctrineMongoDBExtensionTest.php
 
 		-
 			message: '#^Method Doctrine\\Bundle\\MongoDBBundle\\Tests\\DependencyInjection\\DoctrineMongoDBExtensionTest\:\:assertDICDefinitionMethodCall\(\) has parameter \$params with no value type specified in iterable type array\.$#'


### PR DESCRIPTION
Revert some of the ignored phpstan issues introduces by https://github.com/doctrine/DoctrineMongoDBBundle/pull/897, now that the methods are available in [doctrine/mongodb-odm 2.12](https://github.com/doctrine/mongodb-odm/releases/tag/2.12.0).