### PR TITLE
Inject the `ManagerRegistry` into `DumpFieldsMapCommand` for compatibility with Symfony 6.4

### DIFF
--- a/config/command.php
+++ b/config/command.php
@@ -30,7 +30,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
 
         ->set('doctrine_mongodb.odm.command.encryption_dump_fields_map', DumpFieldsMapCommand::class)
             ->tag('console.command', ['command' => 'doctrine:mongodb:encryption:dump-fields-map'])
-            ->args([tagged_locator('doctrine_mongodb.odm.document_manager', 'name')])
+            ->args([service('doctrine_mongodb')])
 
         ->set('doctrine_mongodb.odm.command.create_schema', CreateSchemaDoctrineODMCommand::class)
             ->tag('console.command', ['command' => 'doctrine:mongodb:schema:create'])

--- a/src/Command/Encryption/DumpFieldsMapCommand.php
+++ b/src/Command/Encryption/DumpFieldsMapCommand.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\Bundle\MongoDBBundle\Command\Encryption;
 
+use Doctrine\Bundle\MongoDBBundle\ManagerRegistry;
 use Doctrine\ODM\MongoDB\DocumentManager;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
 use MongoDB\BSON\PackedArray;
@@ -14,8 +15,8 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\Yaml\Dumper;
-use Symfony\Contracts\Service\ServiceCollectionInterface;
 
+use function assert;
 use function json_decode;
 use function json_encode;
 use function sprintf;
@@ -34,8 +35,7 @@ use const JSON_UNESCAPED_UNICODE;
 )]
 final class DumpFieldsMapCommand extends Command
 {
-    /** @param ServiceCollectionInterface<DocumentManager> $documentManagers */
-    public function __construct(private readonly ServiceCollectionInterface $documentManagers)
+    public function __construct(private readonly ManagerRegistry $registry)
     {
         parent::__construct();
     }
@@ -60,7 +60,8 @@ final class DumpFieldsMapCommand extends Command
 
         $dumper = new Dumper();
 
-        foreach ($this->documentManagers as $name => $documentManager) {
+        foreach ($this->registry->getManagers() as $name => $documentManager) {
+            assert($documentManager instanceof DocumentManager);
             $encryptedFieldsMap = [];
             foreach ($documentManager->getMetadataFactory()->getAllMetadata() as $metadata) {
                 $database               = $documentManager->getDocumentDatabase($metadata->getName());

--- a/tests/DependencyInjection/DoctrineMongoDBExtensionTest.php
+++ b/tests/DependencyInjection/DoctrineMongoDBExtensionTest.php
@@ -8,6 +8,8 @@ use Closure;
 use Composer\InstalledVersions;
 use Composer\Semver\VersionParser;
 use Doctrine\Bundle\MongoDBBundle\Attribute\MapDocument;
+use Doctrine\Bundle\MongoDBBundle\Command\Encryption\DiagnosticCommand;
+use Doctrine\Bundle\MongoDBBundle\Command\Encryption\DumpFieldsMapCommand;
 use Doctrine\Bundle\MongoDBBundle\DependencyInjection\Compiler\ServiceRepositoryCompilerPass;
 use Doctrine\Bundle\MongoDBBundle\DependencyInjection\DoctrineMongoDBExtension;
 use Doctrine\Bundle\MongoDBBundle\Tests\DependencyInjection\Fixtures\Bundles\DocumentListenerBundle\EventListener\TestAttributeListener;
@@ -485,6 +487,34 @@ class DoctrineMongoDBExtensionTest extends TestCase
             ],
             $configuration->getMethodCalls(),
         );
+    }
+
+    public function testEncryptionCommands(): void
+    {
+        self::requireAutoEncryptionSupportInODM();
+
+        $container = $this->buildMinimalContainer();
+        $loader    = new DoctrineMongoDBExtension();
+
+        $config = [
+            'connections' => [
+                'default' => [
+                    'autoEncryption' => [
+                        'kmsProvider' => ['type' => 'local', 'key' => 'base64_encoded_key'],
+                    ],
+                ],
+            ],
+            'document_managers' => ['default' => []],
+        ];
+
+        $loader->load([$config], $container);
+        (new ServiceRepositoryCompilerPass())->process($container);
+
+        $dumpFieldsMapCommand = $container->get('doctrine_mongodb.odm.command.encryption_dump_fields_map');
+        $this->assertInstanceOf(DumpFieldsMapCommand::class, $dumpFieldsMapCommand);
+
+        $diagnosticCommand = $container->get('doctrine_mongodb.odm.command.encryption_diagnostic');
+        $this->assertInstanceOf(DiagnosticCommand::class, $diagnosticCommand);
     }
 
     public function testAutoEncryptionWithKeyVaultClientService(): void


### PR DESCRIPTION
Fix #924
[PHPORM-405](https://jira.mongodb.org/browse/PHPORM-405)

The `ManagerRegistry` is the way to iterator over the document managers of an application.