### PR TITLE
Static PHP config

### DIFF
--- a/src/DependencyInjection/DoctrineMongoDBExtension.php
+++ b/src/DependencyInjection/DoctrineMongoDBExtension.php
@@ -25,6 +25,8 @@ use Doctrine\ODM\MongoDB\Mapping\Annotations\QueryResultDocument;
 use Doctrine\ODM\MongoDB\Mapping\Annotations\View;
 use Doctrine\ODM\MongoDB\Mapping\Driver\AttributeDriver;
 use Doctrine\Persistence\Mapping\Driver\MappingDriverChain;
+use Doctrine\Persistence\Mapping\Driver\PHPDriver;
+use Doctrine\Persistence\Mapping\Driver\StaticPHPDriver;
 use Doctrine\Persistence\Proxy;
 use InvalidArgumentException;
 use LogicException;
@@ -326,7 +328,7 @@ class DoctrineMongoDBExtension extends Extension
         }
 
         if (! in_array($mappingConfig['type'], ['xml', 'php', 'staticphp', 'attribute'])) {
-            throw new InvalidArgumentException(sprintf('Can only configure "xml", "yml", "php", "staticphp" or "attribute" through the DoctrineBundle. Use your own bundle to configure other metadata drivers. You can register them by adding a new driver to the "%s" service definition.', $this->getObjectManagerElementName($objectManagerName . '_metadata_driver')));
+            throw new InvalidArgumentException(sprintf('Can only configure "xml", "php", "staticphp" or "attribute" through the DoctrineMongoDBBundle. Use your own bundle to configure other metadata drivers. You can register them by adding a new driver to the "%s" service definition.', $this->getObjectManagerElementName($objectManagerName . '_metadata_driver')));
         }
     }
 
@@ -1024,6 +1026,8 @@ class DoctrineMongoDBExtension extends Extension
         return match ($driverType) {
             'driver_chain' => MappingDriverChain::class,
             'attribute' => AttributeDriver::class,
+            'staticphp' => StaticPHPDriver::class,
+            'php' => PHPDriver::class,
             'xml' => XmlDriver::class,
             default => throw new InvalidArgumentException(sprintf('Metadata driver not supported: "%s"', $driverType))
         };

--- a/src/Mapping/StaticClassMetadata.php
+++ b/src/Mapping/StaticClassMetadata.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Bundle\MongoDBBundle\Mapping;
+
+use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
+
+interface StaticClassMetadata
+{
+    public static function loadMetadata(ClassMetadata $metadata): void;
+}

--- a/tests/DependencyInjection/Fixtures/Bundles/PhpBundle/Document/TestDocument.php
+++ b/tests/DependencyInjection/Fixtures/Bundles/PhpBundle/Document/TestDocument.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Bundle\MongoDBBundle\Tests\DependencyInjection\Fixtures\Bundles\AttributesBundle\Document;
+
+class TestDocument
+{
+}

--- a/tests/DependencyInjection/Fixtures/Bundles/PhpBundle/PhpBundle.php
+++ b/tests/DependencyInjection/Fixtures/Bundles/PhpBundle/PhpBundle.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Bundle\MongoDBBundle\Tests\DependencyInjection\Fixtures\Bundles\AttributesBundle;
+
+use Symfony\Component\HttpKernel\Bundle\Bundle;
+
+class PhpBundle extends Bundle
+{
+}

--- a/tests/DependencyInjection/Fixtures/Bundles/PhpBundle/config/Doctrine.Bundle.MongoDBBundle.Tests.DependencyInjection.Fixtures.Bundles.AttributesBundle.Document.php
+++ b/tests/DependencyInjection/Fixtures/Bundles/PhpBundle/config/Doctrine.Bundle.MongoDBBundle.Tests.DependencyInjection.Fixtures.Bundles.AttributesBundle.Document.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
+use Doctrine\ODM\MongoDB\Types\Type;
+
+return static function (ClassMetadata $metadata): void {
+    $metadata->mapField([
+        'name'      => '_id',
+        'fieldName' => 'id',
+        'type'      => Type::ID,
+        'id'        => true,
+    ]);
+    $metadata->mapField([
+        'name'      => 'name',
+        'fieldName' => 'name',
+        'type'      => Type::STRING,
+    ]);
+};

--- a/tests/DependencyInjection/Fixtures/Bundles/StaticPhpBundle/Document/TestDocument.php
+++ b/tests/DependencyInjection/Fixtures/Bundles/StaticPhpBundle/Document/TestDocument.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Bundle\MongoDBBundle\Tests\DependencyInjection\Fixtures\Bundles\AttributesBundle\Document;
+
+use Doctrine\Bundle\MongoDBBundle\Mapping\StaticClassMetadata;
+use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
+use Doctrine\ODM\MongoDB\Types\Type;
+
+class TestDocument implements StaticClassMetadata
+{
+    public static function loadMetadata(ClassMetadata $metadata): void
+    {
+        $metadata->mapField([
+            'name'      => '_id',
+            'fieldName' => 'id',
+            'type'      => Type::ID,
+            'id'        => true,
+        ]);
+        $metadata->mapField([
+            'name'      => 'name',
+            'fieldName' => 'name',
+            'type'      => Type::STRING,
+        ]);
+    }
+}

--- a/tests/DependencyInjection/Fixtures/Bundles/StaticPhpBundle/StaticPhpBundle.php
+++ b/tests/DependencyInjection/Fixtures/Bundles/StaticPhpBundle/StaticPhpBundle.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Bundle\MongoDBBundle\Tests\DependencyInjection\Fixtures\Bundles\AttributesBundle;
+
+use Symfony\Component\HttpKernel\Bundle\Bundle;
+
+class StaticPhpBundle extends Bundle
+{
+}


### PR DESCRIPTION
Enable [`PHPDriver`](https://github.com/doctrine/persistence/blob/4.1.x/src/Persistence/Mapping/Driver/PHPDriver.php) and [`StaticPHPDriver`](https://github.com/doctrine/persistence/blob/4.1.x/src/Persistence/Mapping/Driver/StaticPHPDriver.php) drivers.

But, we should probably have a new driver that gets raw PHP array, and leverage array shapes. This would replace the XML format.