### PR TITLE
Enable support for Symfony 8

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -6,6 +6,9 @@ on:
       - "*.x"
       - "feature/*"
   push:
+    branches:
+      - "*.x"
+      - "feature/*"
 
 env:
   fail-fast: true
@@ -14,8 +17,6 @@ jobs:
   phpunit:
     name: "PHPUnit"
     runs-on: "${{ matrix.os }}"
-    env:
-      SYMFONY_REQUIRE: ${{matrix.symfony-version}}
 
     strategy:
       fail-fast: false
@@ -27,34 +28,32 @@ jobs:
           - "8.2"
           - "8.3"
           - "8.4"
-        stability:
-          - "stable"
         symfony-version:
-          - "6.4.*"
-          - "7.2.*"
-          - "7.3.*"
+          - "locked"
         driver-version:
           - "stable"
         dependencies:
           - "highest"
         include:
           - dependencies: "lowest"
-            os: "ubuntu-24.04"
             php-version: "8.1"
             driver-version: "1.21.0"
-            stability: "stable"
             symfony-version: "6.4.*"
+          - dependencies: "stable"
+            php-version: "8.4"
+            symfony-version: "6.4.*"
+          - dependencies: "lowest"
+            php-version: "8.1"
+            symfony-version: "^7"
+          - dependencies: "stable"
+            php-version: "8.4"
+            symfony-version: "^7"
           - dependencies: "highest"
-            os: "ubuntu-24.04"
-            php-version: "8.2"
+            php-version: "8.1"
+            symfony-version: "^8"
+          - dependencies: "highest"
+            php-version: "8.4"
             driver-version: "mongodb/mongo-php-driver@v2.x"
-            stability: "dev"
-            symfony-version: "7.2.*"
-        exclude:
-          - php-version: "8.1"
-            symfony-version: "7.2.*"
-          - php-version: "8.1"
-            symfony-version: "7.3.*"
 
     services:
       mongodb:
@@ -92,13 +91,12 @@ jobs:
           coverage: "pcov"
           ini-values: "zend.assertions=1"
 
-      - name: "Set minimum-stability to stable in Composer"
-        run: "composer config minimum-stability ${{ matrix.stability }}"
-
       - name: "Install dependencies with Composer"
         uses: "ramsey/composer-install@v3"
         with:
           dependency-versions: "${{ matrix.dependencies }}"
+        env:
+          SYMFONY_REQUIRE: ${{matrix.symfony-version}}
 
       - name: "Run PHPUnit"
         run: "vendor/bin/phpunit --coverage-clover=coverage.xml"

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -35,25 +35,20 @@ jobs:
         dependencies:
           - "highest"
         include:
+          # Tests the lowest set of dependencies
           - dependencies: "lowest"
             php-version: "8.1"
             driver-version: "1.21.0"
-            symfony-version: "6.4.*"
-          - dependencies: "stable"
+
+          # Test LTS
+          - symfony-require: "6.4.*"
             php-version: "8.4"
-            symfony-version: "6.4.*"
-          - dependencies: "lowest"
-            php-version: "8.1"
-            symfony-version: "^7"
-          - dependencies: "stable"
+          - symfony-require: "7.4.*"
             php-version: "8.4"
-            symfony-version: "^7"
-          - dependencies: "highest"
-            php-version: "8.1"
-            symfony-version: "^8"
-          - dependencies: "highest"
+
+          # Test with the latest driver version
+          - driver-version: "mongodb/mongo-php-driver@v2.x"
             php-version: "8.4"
-            driver-version: "mongodb/mongo-php-driver@v2.x"
 
     services:
       mongodb:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -28,7 +28,7 @@ jobs:
           - "8.2"
           - "8.3"
           - "8.4"
-        symfony-version:
+        symfony-require:
           - ""
         driver-version:
           - "stable"
@@ -41,9 +41,9 @@ jobs:
             driver-version: "1.21.0"
 
           # Test Symfony LTS
-          - symfony-version: "6.4.*"
+          - symfony-require: "6.4.*"
             php-version: "8.4"
-          - symfony-version: "7.4.*"
+          - symfony-require: "7.4.*"
             php-version: "8.4"
 
           # Test with the latest driver version
@@ -91,10 +91,12 @@ jobs:
         with:
           dependency-versions: "${{ matrix.dependencies }}"
         env:
-          SYMFONY_REQUIRE: ${{matrix.symfony-version}}
+          SYMFONY_REQUIRE: ${{matrix.symfony-require}}
 
       - name: "Run PHPUnit"
         run: "vendor/bin/phpunit --coverage-clover=coverage.xml"
+        env:
+          SYMFONY_DEPRECATIONS_HELPER: ${{ matrix.dependencies == 'lowest' && 'disabled=1' || 'max[direct]=0' }}
 
       - name: "Upload coverage file"
         uses: "actions/upload-artifact@v5"

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -16,13 +16,11 @@ env:
 jobs:
   phpunit:
     name: "PHPUnit"
-    runs-on: "${{ matrix.os }}"
+    runs-on: "ubuntu-24.04"
 
     strategy:
       fail-fast: false
       matrix:
-        os:
-          - "ubuntu-24.04"
         php-version:
           - "8.1"
           - "8.2"

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -44,10 +44,6 @@ jobs:
           - symfony-require: "7.4.*"
             php-version: "8.4"
 
-          # Test with the latest driver version
-          - driver-version: "mongodb/mongo-php-driver@v2.x"
-            php-version: "8.4"
-
     services:
       mongodb:
         image: "mongo"
@@ -99,7 +95,7 @@ jobs:
       - name: "Upload coverage file"
         uses: "actions/upload-artifact@v5"
         with:
-          name: "phpunit-${{ matrix.php-version }}-${{ hashFiles('composer.lock') }}.coverage"
+          name: "phpunit-${{ matrix.php-version }}-${{ hashFiles('composer.lock') }}-${{ matrix.driver-version }}.coverage"
           path: "coverage.xml"
 
   upload_coverage:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -29,7 +29,7 @@ jobs:
           - "8.3"
           - "8.4"
         symfony-version:
-          - "locked"
+          - ""
         driver-version:
           - "stable"
         dependencies:
@@ -40,10 +40,10 @@ jobs:
             php-version: "8.1"
             driver-version: "1.21.0"
 
-          # Test LTS
-          - symfony-require: "6.4.*"
+          # Test Symfony LTS
+          - symfony-version: "6.4.*"
             php-version: "8.4"
-          - symfony-require: "7.4.*"
+          - symfony-version: "7.4.*"
             php-version: "8.4"
 
           # Test with the latest driver version

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -13,6 +13,9 @@ on:
       - phpstan*
       - tests/StaticAnalysis/**
   push:
+    branches:
+      - "*.x"
+      - "feature/*"
 
 jobs:
   static-analysis:

--- a/composer.json
+++ b/composer.json
@@ -30,13 +30,13 @@
         "doctrine/mongodb-odm": "^2.6",
         "doctrine/persistence": "^3.0 || ^4.0",
         "psr/log": "^1.0 || ^2.0 || ^3.0",
-        "symfony/config": "^6.4 || ^7.0",
-        "symfony/console": "^6.4 || ^7.0",
-        "symfony/dependency-injection": "^6.4 || ^7.0",
-        "symfony/doctrine-bridge": "^6.4 || ^7.0",
-        "symfony/framework-bundle": "^6.4 || ^7.0",
-        "symfony/http-kernel": "^6.4 || ^7.0",
-        "symfony/options-resolver": "^6.4 || ^7.0"
+        "symfony/config": "^6.4 || ^7.0 || ^8.0",
+        "symfony/console": "^6.4 || ^7.0 || ^8.0",
+        "symfony/dependency-injection": "^6.4 || ^7.0 || ^8.0",
+        "symfony/doctrine-bridge": "^6.4 || ^7.0 || ^8.0",
+        "symfony/framework-bundle": "^6.4 || ^7.0 || ^8.0",
+        "symfony/http-kernel": "^6.4 || ^7.0 || ^8.0",
+        "symfony/options-resolver": "^6.4 || ^7.0 || ^8.0"
     },
     "require-dev": {
         "composer/semver": "^3.4",
@@ -45,14 +45,14 @@
         "phpstan/phpstan": "^2.1",
         "phpunit/phpunit": "^10.5",
         "squizlabs/php_codesniffer": "^4",
-        "symfony/browser-kit": "^6.4 || ^7.0",
-        "symfony/form": "^6.4 || ^7.0",
-        "symfony/messenger": "^6.4 || ^7.0",
+        "symfony/browser-kit": "^6.4 || ^7.0 || ^8.0",
+        "symfony/form": "^6.4 || ^7.0 || ^8.0",
+        "symfony/messenger": "^6.4 || ^7.0 || ^8.0",
         "symfony/phpunit-bridge": "^6.4.1 || ^7.0.1",
-        "symfony/security-bundle": "^6.4 || ^7.0",
-        "symfony/stopwatch": "^6.4 || ^7.0",
-        "symfony/validator": "^6.4 || ^7.0",
-        "symfony/yaml": "^6.4 || ^7.0"
+        "symfony/security-bundle": "^6.4 || ^7.0 || ^8.0",
+        "symfony/stopwatch": "^6.4 || ^7.0 || ^8.0",
+        "symfony/validator": "^6.4 || ^7.0 || ^8.0",
+        "symfony/yaml": "^6.4 || ^7.0 || ^8.0"
     },
     "conflict": {
         "doctrine/data-fixtures": "<1.8 || >=3"

--- a/composer.json
+++ b/composer.json
@@ -60,7 +60,8 @@
     "suggest": {
         "doctrine/data-fixtures": "Load data fixtures"
     },
-    "minimum-stability": "stable",
+    "minimum-stability": "dev",
+    "prefer-stable": true,
     "autoload": {
         "psr-4": {
             "Doctrine\\Bundle\\MongoDBBundle\\": "src"


### PR DESCRIPTION
Rework the test matrix to test all PHP versions with latest composer versions, and all Symfony versions with PHP 8.4