### PR TITLE
kernel.reset tag to doctrine_mongodb definition

### DIFF
--- a/config/mongodb.php
+++ b/config/mongodb.php
@@ -56,6 +56,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
                 abstract_arg('Proxy Interface Name'),
                 service('service_container'),
             ])
+            ->tag('kernel.reset', ['method' => 'reset'])
 
         ->set('doctrine_mongodb.odm.listeners.resolve_target_document', ResolveTargetDocumentListener::class)
 


### PR DESCRIPTION
Fixes https://github.com/php/frankenphp/issues/1767

the `ResetInterface` is not autoconfigured for bundles therefore this is never triggered by the ServicesResetter. 