### PR TITLE
Fix proxy interface for ProxyManager or Symfony LazyGhost

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -577,6 +577,18 @@ parameters:
 			path: tests/DependencyInjection/ConfigurationTest.php
 
 		-
+			message: '#^Call to function method_exists\(\) with ''Doctrine\\\\ODM\\\\MongoDB\\\\Configuration'' and ''setUseLazyGhostObje…'' will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 1
+			path: tests/DependencyInjection/DoctrineMongoDBExtensionTest.php
+
+		-
+			message: '#^Call to function method_exists\(\) with ''Doctrine\\\\ODM\\\\MongoDB\\\\Configuration'' and ''setUseNativeLazyObj…'' will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 1
+			path: tests/DependencyInjection/DoctrineMongoDBExtensionTest.php
+
+		-
 			message: '#^Method Doctrine\\Bundle\\MongoDBBundle\\Tests\\DependencyInjection\\DoctrineMongoDBExtensionTest\:\:assertDICDefinitionMethodCall\(\) has parameter \$params with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1

--- a/src/DependencyInjection/DoctrineMongoDBExtension.php
+++ b/src/DependencyInjection/DoctrineMongoDBExtension.php
@@ -487,7 +487,7 @@ class DoctrineMongoDBExtension extends Extension
         }
 
         $container->getDefinition('doctrine_mongodb')
-            ->setArgument(5, $config['enable_lazy_ghost_objects'] ? LazyLoadingInterface::class : Proxy::class);
+            ->setArgument(5, $config['enable_lazy_ghost_objects'] ? Proxy::class : LazyLoadingInterface::class);
 
         // load the connections
         $this->loadConnections($config['connections'], $container, $config);

--- a/tests/DependencyInjection/DoctrineMongoDBExtensionTest.php
+++ b/tests/DependencyInjection/DoctrineMongoDBExtensionTest.php
@@ -777,13 +777,13 @@ class DoctrineMongoDBExtensionTest extends TestCase
             ];
         }
 
-        if (trait_exists(LazyGhostTrait::class)) {
+        if (trait_exists(LazyGhostTrait::class) && method_exists(Configuration::class, 'setUseLazyGhostObject')) {
             yield 'Symfony Lazy Objects' => [
                 ['enable_lazy_ghost_objects' => true, 'enable_native_lazy_objects' => false],
             ];
         }
 
-        if (PHP_VERSION_ID >= 80400) {
+        if (PHP_VERSION_ID >= 80400 && method_exists(Configuration::class, 'setUseNativeLazyObject')) {
             yield 'Native Lazy Objects' => [
                 ['enable_lazy_ghost_objects' => false, 'enable_native_lazy_objects' => true],
             ];

--- a/tests/DependencyInjection/DoctrineMongoDBExtensionTest.php
+++ b/tests/DependencyInjection/DoctrineMongoDBExtensionTest.php
@@ -758,7 +758,7 @@ class DoctrineMongoDBExtensionTest extends TestCase
         // Create a lazy object
         $ref = $dm->getReference(TestDocument::class, 'some');
         self::assertInstanceOf(TestDocument::class, $ref);
-        self::assertSame($dm, $registry->getManagerForClass($ref::class));
+        self::assertSame($dm, $registry->getManagerForClass($ref::class), 'The manager is found for the proxy document class');
     }
 
     public static function provideLazyObjectConfigurations(): iterable

--- a/tests/DependencyInjection/DoctrineMongoDBExtensionTest.php
+++ b/tests/DependencyInjection/DoctrineMongoDBExtensionTest.php
@@ -46,6 +46,12 @@ use function trait_exists;
 
 use const PHP_VERSION_ID;
 
+/**
+ * @phpstan-type ConfigurationArray array{
+ *     enable_lazy_ghost_objects?: bool,
+ *     enable_native_lazy_objects?: bool,
+ * }
+ */
 class DoctrineMongoDBExtensionTest extends TestCase
 {
     public static function buildConfiguration(array $settings = []): array
@@ -727,6 +733,7 @@ class DoctrineMongoDBExtensionTest extends TestCase
         $loader->load([$config], $container);
     }
 
+    /** @phpstan-param ConfigurationArray $config */
     #[DataProvider('provideLazyObjectConfigurations')]
     public function testRegistryGetManagerForClass(array $config): void
     {
@@ -761,6 +768,7 @@ class DoctrineMongoDBExtensionTest extends TestCase
         self::assertSame($dm, $registry->getManagerForClass($ref::class), 'The manager is found for the proxy document class');
     }
 
+    /** @phpstan-return iterable<ConfigurationArray> */
     public static function provideLazyObjectConfigurations(): iterable
     {
         if (interface_exists(GhostObjectInterface::class)) {

--- a/tests/DependencyInjection/DoctrineMongoDBExtensionTest.php
+++ b/tests/DependencyInjection/DoctrineMongoDBExtensionTest.php
@@ -10,30 +10,41 @@ use Composer\Semver\VersionParser;
 use Doctrine\Bundle\MongoDBBundle\Attribute\MapDocument;
 use Doctrine\Bundle\MongoDBBundle\Command\Encryption\DiagnosticCommand;
 use Doctrine\Bundle\MongoDBBundle\Command\Encryption\DumpFieldsMapCommand;
+use Doctrine\Bundle\MongoDBBundle\DependencyInjection\Compiler\CreateProxyDirectoryPass;
 use Doctrine\Bundle\MongoDBBundle\DependencyInjection\Compiler\ServiceRepositoryCompilerPass;
 use Doctrine\Bundle\MongoDBBundle\DependencyInjection\DoctrineMongoDBExtension;
+use Doctrine\Bundle\MongoDBBundle\ManagerRegistry;
+use Doctrine\Bundle\MongoDBBundle\Tests\DependencyInjection\Fixtures\Bundles\AttributesBundle\Document\TestDocument;
 use Doctrine\Bundle\MongoDBBundle\Tests\DependencyInjection\Fixtures\Bundles\DocumentListenerBundle\EventListener\TestAttributeListener;
 use Doctrine\ODM\MongoDB\Configuration;
+use Doctrine\ODM\MongoDB\DocumentManager;
 use Doctrine\ODM\MongoDB\Mapping\Annotations;
 use InvalidArgumentException;
 use MongoDB\Client;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
+use ProxyManager\Proxy\GhostObjectInterface;
 use stdClass;
 use Symfony\Component\DependencyInjection\Alias;
 use Symfony\Component\DependencyInjection\ChildDefinition;
+use Symfony\Component\DependencyInjection\Compiler\ResolveParameterPlaceHoldersPass;
 use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
 use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\VarExporter\LazyGhostTrait;
 
 use function array_diff_key;
 use function array_merge;
+use function interface_exists;
 use function is_dir;
 use function method_exists;
 use function sprintf;
 use function sys_get_temp_dir;
+use function trait_exists;
+
+use const PHP_VERSION_ID;
 
 class DoctrineMongoDBExtensionTest extends TestCase
 {
@@ -714,6 +725,61 @@ class DoctrineMongoDBExtensionTest extends TestCase
         self::expectException(InvalidArgumentException::class);
         self::expectExceptionMessage('The "autoEncryption" option requires doctrine/mongodb-odm version 2.12 or higher');
         $loader->load([$config], $container);
+    }
+
+    #[DataProvider('provideLazyObjectConfigurations')]
+    public function testRegistryGetManagerForClass(array $config): void
+    {
+        $container = $this->getContainer('AttributesBundle');
+        $loader    = new DoctrineMongoDBExtension();
+        $loader->load(self::buildConfiguration($config + [
+            'connections' => [
+                'default' => [],
+            ],
+            'document_managers' => [
+                'default' => [
+                    'mappings' => [
+                        'AttributesBundle' => ['type' => 'attribute'],
+                    ],
+                ],
+            ],
+        ]), $container);
+        (new ResolveParameterPlaceHoldersPass())->process($container);
+        (new ServiceRepositoryCompilerPass())->process($container);
+        (new CreateProxyDirectoryPass())->process($container);
+
+        $container->compile();
+        $registry = $container->get('doctrine_mongodb');
+        $dm       = $container->get('doctrine_mongodb.odm.document_manager');
+
+        self::assertInstanceOf(ManagerRegistry::class, $registry);
+        self::assertInstanceOf(DocumentManager::class, $dm);
+
+        // Create a lazy object
+        $ref = $dm->getReference(TestDocument::class, 'some');
+        self::assertInstanceOf(TestDocument::class, $ref);
+        self::assertSame($dm, $registry->getManagerForClass($ref::class));
+    }
+
+    public static function provideLazyObjectConfigurations(): iterable
+    {
+        if (interface_exists(GhostObjectInterface::class)) {
+            yield 'Proxy Manager' => [
+                ['enable_lazy_ghost_objects' => false, 'enable_native_lazy_objects' => false],
+            ];
+        }
+
+        if (trait_exists(LazyGhostTrait::class)) {
+            yield 'Symfony Lazy Objects' => [
+                ['enable_lazy_ghost_objects' => true, 'enable_native_lazy_objects' => false],
+            ];
+        }
+
+        if (PHP_VERSION_ID >= 80400) {
+            yield 'Native Lazy Objects' => [
+                ['enable_lazy_ghost_objects' => false, 'enable_native_lazy_objects' => true],
+            ];
+        }
     }
 
     private static function requireAutoEncryptionSupportInODM(): void

--- a/tests/DependencyInjection/Fixtures/Bundles/AttributesBundle/Document/TestDocument.php
+++ b/tests/DependencyInjection/Fixtures/Bundles/AttributesBundle/Document/TestDocument.php
@@ -9,4 +9,9 @@ use Doctrine\ODM\MongoDB\Mapping\Annotations as MongoDB;
 #[MongoDB\Document]
 class TestDocument
 {
+    #[MongoDB\Id]
+    public ?string $id = null;
+
+    #[MongoDB\Field(type: 'string')]
+    public ?string $name = null;
 }


### PR DESCRIPTION
I was wrong in https://github.com/doctrine/DoctrineMongoDBBundle/pull/940#discussion_r2527440188.

Fix the interface that identifies the lazy objects.

Note that `Doctrine\Persistence\Mapping\ProxyClassNameResolver` should be used by `Doctrine\Persistence\AbstractManagerRegistry` instead of repeating the same logic.