### PR TITLE
Clean supported metadata driver types

### DIFF
--- a/src/DependencyInjection/DoctrineMongoDBExtension.php
+++ b/src/DependencyInjection/DoctrineMongoDBExtension.php
@@ -235,7 +235,7 @@ class DoctrineMongoDBExtension extends Extension
         }
 
         if (! $bundleConfig['dir']) {
-            if (in_array($bundleConfig['type'], ['staticphp', 'attribute'])) {
+            if (in_array($bundleConfig['type'], ['attribute'])) {
                 $bundleConfig['dir'] = $bundleClassDir . '/' . $this->getMappingObjectDefaultName();
             } else {
                 $bundleConfig['dir'] = $bundleDir . '/' . $this->getMappingResourceConfigDirectory($bundleDir);
@@ -325,8 +325,8 @@ class DoctrineMongoDBExtension extends Extension
             throw new InvalidArgumentException(sprintf('Specified non-existing directory "%s" as Doctrine mapping source.', $mappingConfig['dir']));
         }
 
-        if (! in_array($mappingConfig['type'], ['xml', 'php', 'staticphp', 'attribute'])) {
-            throw new InvalidArgumentException(sprintf('Can only configure "xml", "yml", "php", "staticphp" or "attribute" through the DoctrineBundle. Use your own bundle to configure other metadata drivers. You can register them by adding a new driver to the "%s" service definition.', $this->getObjectManagerElementName($objectManagerName . '_metadata_driver')));
+        if (! in_array($mappingConfig['type'], ['xml', 'attribute'])) {
+            throw new InvalidArgumentException(sprintf('Can only configure  "xml" or "attribute" through the DoctrineMongoDBBundle. Use your own bundle to configure other metadata drivers. You can register them by adding a new driver to the "%s" service definition.', $this->getObjectManagerElementName($objectManagerName . '_metadata_driver')));
         }
     }
 

--- a/src/DependencyInjection/DoctrineMongoDBExtension.php
+++ b/src/DependencyInjection/DoctrineMongoDBExtension.php
@@ -279,10 +279,6 @@ class DoctrineMongoDBExtension extends Extension
                 }
 
                 $mappingDriverDef->setArguments($args);
-            } elseif ($driverType === 'attribute') {
-                $mappingDriverDef = new Definition($this->getMetadataDriverClass($driverType), [
-                    array_values($driverPaths),
-                ]);
             } else {
                 $mappingDriverDef = new Definition($this->getMetadataDriverClass($driverType), [
                     array_values($driverPaths),
@@ -326,7 +322,7 @@ class DoctrineMongoDBExtension extends Extension
         }
 
         if (! in_array($mappingConfig['type'], ['xml', 'attribute'])) {
-            throw new InvalidArgumentException(sprintf('Can only configure  "xml" or "attribute" through the DoctrineMongoDBBundle. Use your own bundle to configure other metadata drivers. You can register them by adding a new driver to the "%s" service definition.', $this->getObjectManagerElementName($objectManagerName . '_metadata_driver')));
+            throw new InvalidArgumentException(sprintf('Can only configure "xml" or "attribute" through the DoctrineMongoDBBundle. Use your own bundle to configure other metadata drivers. You can register them by adding a new driver to the "%s" service definition.', $this->getObjectManagerElementName($objectManagerName . '_metadata_driver')));
         }
     }
 


### PR DESCRIPTION
After https://github.com/doctrine/DoctrineMongoDBBundle/pull/923, we can cleanup some legacy.
- The `yml` format isn't supported since MongoDB ODM v2
- The `php` and `staticphp` format have never been supported by the bundle itself. They require a custom driver configuration (see https://github.com/doctrine/DoctrineMongoDBBundle/pull/936)