### PR TITLE
Update .doctrine-project.json for 5.5.0 and remove old branches

### DIFF
--- a/.doctrine-project.json
+++ b/.doctrine-project.json
@@ -4,105 +4,30 @@
     "slug": "doctrine-mongodb-bundle",
     "versions": [
         {
-            "name": "5.5",
-            "branchName": "5.5.x",
-            "slug": "5.5",
+            "name": "5.6",
+            "branchName": "5.6.x",
+            "slug": "latest",
             "upcoming": true
         },
         {
-            "name": "5.4",
-            "branchName": "5.4.x",
-            "slug": "latest",
+            "name": "5.5",
+            "branchName": "5.5.x",
+            "slug": "5.5",
             "current": true
         },
         {
+            "name": "5.4",
+            "slug": "5.4",
+            "maintained": false
+        },
+        {
             "name": "5.3",
-            "branchName": "5.3.x",
             "slug": "5.3",
             "maintained": false
         },
         {
-            "name": "5.2",
-            "branchName": "5.2.x",
-            "slug": "5.2",
-            "maintained": false
-        },
-        {
-            "name": "5.1",
-            "branchName": "5.1.x",
-            "slug": "5.1",
-            "maintained": false
-        },
-        {
-            "name": "5.0",
-            "branchName": "5.0.x",
-            "slug": "5.0",
-            "maintained": false
-        },
-        {
             "name": "4.7",
-            "branchName": "4.7.x",
             "slug": "4.7",
-            "maintained": false
-        },
-        {
-            "name": "4.6",
-            "branchName": "4.6.x",
-            "slug": "4.6",
-            "maintained": false
-        },
-        {
-            "name": "4.5",
-            "branchName": "4.5.x",
-            "slug": "4.5",
-            "maintained": false
-        },
-        {
-            "name": "4.4",
-            "branchName": "4.4.x",
-            "slug": "4.4",
-            "maintained": false
-        },
-        {
-            "name": "4.3",
-            "branchName": "4.3.x",
-            "slug": "4.3",
-            "maintained": false
-        },
-        {
-            "name": "4.2",
-            "branchName": "4.2.x",
-            "slug": "4.2",
-            "maintained": false
-        },
-        {
-            "name": "4.1",
-            "branchName": "4.1.x",
-            "slug": "4.1",
-            "maintained": false
-        },
-        {
-            "name": "4.0",
-            "branchName": "4.0.x",
-            "slug": "4.0",
-            "maintained": false
-        },
-        {
-            "name": "3.6",
-            "branchName": "3.6.x",
-            "slug": "3.6",
-            "maintained": false
-        },
-        {
-            "name": "3.5",
-            "branchName": "3.5",
-            "slug": "3.5",
-            "maintained": false
-        },
-        {
-            "name": "3.4",
-            "branchName": "3.4",
-            "slug": "3.4",
             "maintained": false
         }
     ]


### PR DESCRIPTION
Currently only branches from 5.x have the documentation published.

<img width="530" height="566" alt="image" src="https://github.com/user-attachments/assets/e0ffa427-f132-4fb5-8675-ad77c8f50e5e" />

But the version 4.7 is still very used:
<img width="947" height="459" alt="image" src="https://github.com/user-attachments/assets/f179b78e-89cf-4d43-a14f-acd5d2d96742" />
