### PR TITLE
Mark the definition with the new Document attribute as excluded

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -20,3 +20,6 @@ on:
 jobs:
   static-analysis:
     uses: "doctrine/.github/.github/workflows/phpstan.yml@13.1.0"
+    with:
+      # Remove once doctrine/mongodb-odm 2.16 is released
+      composer-options: "--minimum-stability=dev"

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -20,6 +20,3 @@ on:
 jobs:
   static-analysis:
     uses: "doctrine/.github/.github/workflows/phpstan.yml@13.1.0"
-    with:
-      # Remove once doctrine/mongodb-odm 2.16 is released
-      composer-options: "--minimum-stability=dev"

--- a/src/DependencyInjection/DoctrineMongoDBExtension.php
+++ b/src/DependencyInjection/DoctrineMongoDBExtension.php
@@ -17,12 +17,8 @@ use Doctrine\Common\DataFixtures\Loader as DataFixturesLoader;
 use Doctrine\Common\EventSubscriber;
 use Doctrine\ODM\MongoDB\Configuration as ODMConfiguration;
 use Doctrine\ODM\MongoDB\DocumentManager;
-use Doctrine\ODM\MongoDB\Mapping\Annotations\Document;
-use Doctrine\ODM\MongoDB\Mapping\Annotations\EmbeddedDocument;
-use Doctrine\ODM\MongoDB\Mapping\Annotations\File;
-use Doctrine\ODM\MongoDB\Mapping\Annotations\MappedSuperclass;
-use Doctrine\ODM\MongoDB\Mapping\Annotations\QueryResultDocument;
-use Doctrine\ODM\MongoDB\Mapping\Annotations\View;
+use Doctrine\ODM\MongoDB\Mapping\Annotations;
+use Doctrine\ODM\MongoDB\Mapping\Attribute;
 use Doctrine\ODM\MongoDB\Mapping\Driver\AttributeDriver;
 use Doctrine\Persistence\Mapping\Driver\MappingDriverChain;
 use Doctrine\Persistence\Proxy;
@@ -510,24 +506,30 @@ class DoctrineMongoDBExtension extends Extension
         });
 
         // Document classes are excluded from the container by default
-        $container->registerAttributeForAutoconfiguration(Document::class, static function (ChildDefinition $definition): void {
-            $definition->addTag('container.excluded', ['source' => sprintf('with #[%s] attribute', Document::class)]);
-        });
-        $container->registerAttributeForAutoconfiguration(EmbeddedDocument::class, static function (ChildDefinition $definition): void {
-            $definition->addTag('container.excluded', ['source' => sprintf('with #[%s] attribute', EmbeddedDocument::class)]);
-        });
-        $container->registerAttributeForAutoconfiguration(MappedSuperclass::class, static function (ChildDefinition $definition): void {
-            $definition->addTag('container.excluded', ['source' => sprintf('with #[%s] attribute', MappedSuperclass::class)]);
-        });
-        $container->registerAttributeForAutoconfiguration(View::class, static function (ChildDefinition $definition): void {
-            $definition->addTag('container.excluded', ['source' => sprintf('with #[%s] attribute', View::class)]);
-        });
-        $container->registerAttributeForAutoconfiguration(QueryResultDocument::class, static function (ChildDefinition $definition): void {
-            $definition->addTag('container.excluded', ['source' => sprintf('with #[%s] attribute', QueryResultDocument::class)]);
-        });
-        $container->registerAttributeForAutoconfiguration(File::class, static function (ChildDefinition $definition): void {
-            $definition->addTag('container.excluded', ['source' => sprintf('with #[%s] attribute', File::class)]);
-        });
+        foreach (
+            [
+                // Deprecated since ODM 2.16
+                Annotations\Document::class,
+                Annotations\EmbeddedDocument::class,
+                Annotations\MappedSuperclass::class,
+                Annotations\View::class,
+                Annotations\QueryResultDocument::class,
+                Annotations\File::class,
+                // New in ODM 2.16
+                Attribute\Document::class,
+                Attribute\EmbeddedDocument::class,
+                Attribute\MappedSuperclass::class,
+                Attribute\View::class,
+                Attribute\QueryResultDocument::class,
+                Attribute\File::class,
+            ] as $class
+        ) {
+            if (class_exists($class)) {
+                $container->registerAttributeForAutoconfiguration($class, static function (ChildDefinition $definition, object $attribute): void {
+                    $definition->addTag('container.excluded', ['source' => sprintf('with #[%s] attribute', $attribute::class)]);
+                });
+            }
+        }
 
         $this->loadMessengerServices($container, $loader);
 

--- a/tests/DependencyInjection/DoctrineMongoDBExtensionTest.php
+++ b/tests/DependencyInjection/DoctrineMongoDBExtensionTest.php
@@ -19,11 +19,13 @@ use Doctrine\Bundle\MongoDBBundle\Tests\DependencyInjection\Fixtures\Bundles\Doc
 use Doctrine\ODM\MongoDB\Configuration;
 use Doctrine\ODM\MongoDB\DocumentManager;
 use Doctrine\ODM\MongoDB\Mapping\Annotations;
+use Doctrine\ODM\MongoDB\Mapping\Attribute;
 use InvalidArgumentException;
 use MongoDB\Client;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use ProxyManager\Proxy\GhostObjectInterface;
+use ReflectionClass;
 use stdClass;
 use Symfony\Component\DependencyInjection\Alias;
 use Symfony\Component\DependencyInjection\ChildDefinition;
@@ -37,6 +39,7 @@ use Symfony\Component\VarExporter\LazyGhostTrait;
 
 use function array_diff_key;
 use function array_merge;
+use function class_exists;
 use function interface_exists;
 use function is_dir;
 use function method_exists;
@@ -135,18 +138,28 @@ class DoctrineMongoDBExtensionTest extends TestCase
     public static function provideAttributeExcludedFromContainer(): array
     {
         return [
-            'Document' => [Annotations\Document::class],
-            'EmbeddedDocument' => [Annotations\EmbeddedDocument::class],
-            'MappedSuperclass' => [Annotations\MappedSuperclass::class],
-            'View' => [Annotations\View::class],
-            'QueryResultDocument' => [Annotations\QueryResultDocument::class],
-            'File' => [Annotations\File::class],
+            'Annotations\Document' => [Annotations\Document::class],
+            'Annotations\EmbeddedDocument' => [Annotations\EmbeddedDocument::class],
+            'Annotations\MappedSuperclass' => [Annotations\MappedSuperclass::class],
+            'Annotations\View' => [Annotations\View::class],
+            'Annotations\QueryResultDocument' => [Annotations\QueryResultDocument::class],
+            'Annotations\File' => [Annotations\File::class],
+            'Attribute\Document' => [Attribute\Document::class],
+            'Attribute\EmbeddedDocument' => [Attribute\EmbeddedDocument::class],
+            'Attribute\MappedSuperclass' => [Attribute\MappedSuperclass::class],
+            'Attribute\View' => [Attribute\View::class],
+            'Attribute\QueryResultDocument' => [Attribute\QueryResultDocument::class],
+            'Attribute\File' => [Attribute\File::class],
         ];
     }
 
     #[DataProvider('provideAttributeExcludedFromContainer')]
     public function testDocumentAttributeExcludesFromContainer(string $class): void
     {
+        if (! class_exists($class)) {
+            $this->markTestSkipped(sprintf('Class %s does not exist.', $class));
+        }
+
         $container = $this->getContainer();
         $extension = new DoctrineMongoDBExtension();
         $extension->load($this->buildConfiguration(), $container);
@@ -164,7 +177,8 @@ class DoctrineMongoDBExtensionTest extends TestCase
         $this->assertInstanceOf(Closure::class, $autoconfigurator);
 
         $definition = new ChildDefinition('');
-        $autoconfigurator($definition);
+        $attribute  = (new ReflectionClass($class))->newInstanceWithoutConstructor();
+        $autoconfigurator($definition, $attribute);
 
         $this->assertSame([['source' => sprintf('with #[%s] attribute', $class)]], $definition->getTag('container.excluded'));
     }


### PR DESCRIPTION
Ensure compatibility with https://github.com/doctrine/mongodb-odm/pull/2933 when the new attribute classes are used.