### PR TITLE
[BC break] Remove namespace aliases from the configuration

### DIFF
--- a/UPGRADE-5.6.md
+++ b/UPGRADE-5.6.md
@@ -1,0 +1,13 @@
+UPGRADE from 5.5 to 5.6
+=======================
+
+Remove namespace aliases
+------------------------
+
+The namespace alias shortcut feature was deprecated in Doctrine Persistence 2.3.0
+and removed in 3.0.0. This is already not supported by Doctrine MongoDB Bundle 5.x
+
+ * [BC break] Remove the method `Doctrine\Bundle\MongoDBBundle\ManagerRegistry::getAliasNamespace()`
+ * Remove parameter `$aliasMap` in `Doctrine\Bundle\MongoDBBundle\DependencyInjection\Compiler\RegisterMappingsPass`
+ * The `Doctrine\ODM\MongoDB\Configuration` class is not populated with namespace aliases anymore;
+   the method `Configuration::getDocumentNamespaces()` always return an empty array.

--- a/src/DependencyInjection/Compiler/DoctrineMongoDBMappingsPass.php
+++ b/src/DependencyInjection/Compiler/DoctrineMongoDBMappingsPass.php
@@ -30,9 +30,8 @@ final class DoctrineMongoDBMappingsPass extends RegisterMappingsPass
      * @param string[]             $managerParameters list of parameters that could tell the manager name to use
      * @param string|false         $enabledParameter  if specified, the compiler pass only
      *                                                executes if this parameter exists in the service container.
-     * @param string[]             $aliasMap          Map of alias to namespace.
      */
-    public function __construct(Definition|Reference $driver, array $namespaces, array $managerParameters, string|false $enabledParameter = false, array $aliasMap = [])
+    public function __construct(Definition|Reference $driver, array $namespaces, array $managerParameters, string|false $enabledParameter = false)
     {
         $managerParameters[] = 'doctrine_mongodb.odm.default_document_manager';
 
@@ -42,9 +41,6 @@ final class DoctrineMongoDBMappingsPass extends RegisterMappingsPass
             $managerParameters,
             'doctrine_mongodb.odm.%s_metadata_driver',
             $enabledParameter,
-            'doctrine_mongodb.odm.%s_configuration',
-            'addDocumentNamespace',
-            $aliasMap,
         );
     }
 
@@ -57,15 +53,14 @@ final class DoctrineMongoDBMappingsPass extends RegisterMappingsPass
      * @param string|false $enabledParameter  Service container parameter that must be present to
      *                                        enable the mapping. Set to false to not do any check,
      *                                        optional.
-     * @param string[]     $aliasMap          Map of alias to namespace.
      */
-    public static function createXmlMappingDriver(array $mappings, array $managerParameters, string|false $enabledParameter = false, array $aliasMap = []): DoctrineMongoDBMappingsPass
+    public static function createXmlMappingDriver(array $mappings, array $managerParameters, string|false $enabledParameter = false): DoctrineMongoDBMappingsPass
     {
         $arguments = [$mappings, '.mongodb.xml'];
         $locator   = new Definition(SymfonyFileLocator::class, $arguments);
         $driver    = new Definition(XmlDriver::class, [$locator]);
 
-        return new DoctrineMongoDBMappingsPass($driver, $mappings, $managerParameters, $enabledParameter, $aliasMap);
+        return new DoctrineMongoDBMappingsPass($driver, $mappings, $managerParameters, $enabledParameter);
     }
 
     /**
@@ -77,15 +72,14 @@ final class DoctrineMongoDBMappingsPass extends RegisterMappingsPass
      * @param string|false $enabledParameter  Service container parameter that must be present to
      *                                        enable the mapping. Set to false to not do any check,
      *                                        optional.
-     * @param string[]     $aliasMap          Map of alias to namespace.
      */
-    public static function createPhpMappingDriver(array $mappings, array $managerParameters = [], string|false $enabledParameter = false, array $aliasMap = []): DoctrineMongoDBMappingsPass
+    public static function createPhpMappingDriver(array $mappings, array $managerParameters = [], string|false $enabledParameter = false): DoctrineMongoDBMappingsPass
     {
         $arguments = [$mappings, '.php'];
         $locator   = new Definition(SymfonyFileLocator::class, $arguments);
         $driver    = new Definition(PHPDriver::class, [$locator]);
 
-        return new DoctrineMongoDBMappingsPass($driver, $mappings, $managerParameters, $enabledParameter, $aliasMap);
+        return new DoctrineMongoDBMappingsPass($driver, $mappings, $managerParameters, $enabledParameter);
     }
 
     /**
@@ -98,13 +92,12 @@ final class DoctrineMongoDBMappingsPass extends RegisterMappingsPass
      * @param string|false $enabledParameter  Service container parameter that must be present to
      *                                        enable the mapping. Set to false to not do any check,
      *                                        optional.
-     * @param string[]     $aliasMap          Map of alias to namespace.
      */
-    public static function createAttributeMappingDriver(array $namespaces, array $directories, array $managerParameters, string|false $enabledParameter = false, array $aliasMap = []): DoctrineMongoDBMappingsPass
+    public static function createAttributeMappingDriver(array $namespaces, array $directories, array $managerParameters, string|false $enabledParameter = false): DoctrineMongoDBMappingsPass
     {
         $driver = new Definition(AttributeDriver::class, [$directories]);
 
-        return new DoctrineMongoDBMappingsPass($driver, $namespaces, $managerParameters, $enabledParameter, $aliasMap);
+        return new DoctrineMongoDBMappingsPass($driver, $namespaces, $managerParameters, $enabledParameter);
     }
 
     /**
@@ -117,12 +110,11 @@ final class DoctrineMongoDBMappingsPass extends RegisterMappingsPass
      * @param string|false $enabledParameter  Service container parameter that must be present to
      *                                        enable the mapping. Set to false to not do any check,
      *                                        optional.
-     * @param string[]     $aliasMap          Map of alias to namespace.
      */
-    public static function createStaticPhpMappingDriver(array $namespaces, array $directories, array $managerParameters = [], string|false $enabledParameter = false, array $aliasMap = []): DoctrineMongoDBMappingsPass
+    public static function createStaticPhpMappingDriver(array $namespaces, array $directories, array $managerParameters = [], string|false $enabledParameter = false): DoctrineMongoDBMappingsPass
     {
         $driver = new Definition(StaticPHPDriver::class, [$directories]);
 
-        return new DoctrineMongoDBMappingsPass($driver, $namespaces, $managerParameters, $enabledParameter, $aliasMap);
+        return new DoctrineMongoDBMappingsPass($driver, $namespaces, $managerParameters, $enabledParameter);
     }
 }

--- a/src/DependencyInjection/DoctrineMongoDBExtension.php
+++ b/src/DependencyInjection/DoctrineMongoDBExtension.php
@@ -82,13 +82,6 @@ class DoctrineMongoDBExtension extends Extension
     /**
      * Used inside metadata driver method to simplify aggregation of data.
      *
-     * @var array<string, string> List of alias => namespace
-     */
-    protected $aliasMap = [];
-
-    /**
-     * Used inside metadata driver method to simplify aggregation of data.
-     *
      * @var array<string, array<string, string>> List of driver type => prefix => path
      */
     protected $drivers = [];
@@ -162,27 +155,6 @@ class DoctrineMongoDBExtension extends Extension
 
             $this->assertValidMappingConfiguration($mappingConfig, $objectManager['name']);
             $this->setMappingDriverConfig($mappingConfig, $mappingName);
-            $this->setMappingDriverAlias($mappingConfig, $mappingName);
-        }
-    }
-
-    /**
-     * Register the alias for this mapping driver.
-     *
-     * Aliases can be used in the Query languages of all the Doctrine object managers to simplify writing tasks.
-     *
-     * @param array<string, mixed> $mappingConfig
-     *
-     * @return void
-     */
-    protected function setMappingDriverAlias(
-        array $mappingConfig,
-        string $mappingName,
-    ) {
-        if (isset($mappingConfig['alias'])) {
-            $this->aliasMap[$mappingConfig['alias']] = $mappingConfig['prefix'];
-        } else {
-            $this->aliasMap[$mappingName] = $mappingConfig['prefix'];
         }
     }
 
@@ -974,26 +946,11 @@ class DoctrineMongoDBExtension extends Extension
      */
     protected function loadDocumentManagerBundlesMappingInformation(array $documentManager, Definition $odmConfigDef, ContainerBuilder $container): void
     {
-        // reset state of drivers and alias map. They are only used by this methods and children.
-        $this->drivers  = [];
-        $this->aliasMap = [];
+        // reset the state of drivers. They are only used by this method and children.
+        $this->drivers = [];
 
         $this->loadMappingInformation($documentManager, $container);
         $this->registerMappingDrivers($documentManager, $container);
-
-        if ($odmConfigDef->hasMethodCall('setDocumentNamespaces')) {
-            // TODO: Can we make a method out of it on Definition? replaceMethodArguments() or something.
-            $calls = $odmConfigDef->getMethodCalls();
-            foreach ($calls as $call) {
-                if ($call[0] === 'setDocumentNamespaces') {
-                    $this->aliasMap = array_merge($call[1][0], $this->aliasMap);
-                }
-            }
-
-            $method = $odmConfigDef->removeMethodCall('setDocumentNamespaces');
-        }
-
-        $odmConfigDef->addMethodCall('setDocumentNamespaces', [$this->aliasMap]);
     }
 
     protected function getObjectManagerElementName(string $name): string

--- a/src/ManagerRegistry.php
+++ b/src/ManagerRegistry.php
@@ -5,14 +5,12 @@ declare(strict_types=1);
 namespace Doctrine\Bundle\MongoDBBundle;
 
 use Doctrine\ODM\MongoDB\DocumentManager;
-use Doctrine\ODM\MongoDB\MongoDBException;
 use ProxyManager\Proxy\LazyLoadingInterface;
 use Psr\Container\ContainerInterface;
 use Symfony\Bridge\Doctrine\ManagerRegistry as BaseManagerRegistry;
 use Symfony\Component\VarExporter\LazyObjectInterface;
 use Symfony\Contracts\Service\ResetInterface;
 
-use function array_keys;
 use function assert;
 
 class ManagerRegistry extends BaseManagerRegistry implements ResetInterface
@@ -22,29 +20,6 @@ class ManagerRegistry extends BaseManagerRegistry implements ResetInterface
         $this->container = $container;
 
         parent::__construct($name, $connections, $managers, $defaultConnection, $defaultManager, $proxyInterfaceName);
-    }
-
-    /**
-     * Resolves a registered namespace alias to the full namespace.
-     *
-     * @throws MongoDBException
-     */
-    public function getAliasNamespace(string $alias): string
-    {
-        foreach (array_keys($this->getManagers()) as $name) {
-            $objectManager = $this->getManager($name);
-
-            if (! $objectManager instanceof DocumentManager) {
-                continue;
-            }
-
-            try {
-                return $objectManager->getConfiguration()->getDocumentNamespace($alias);
-            } catch (MongoDBException) {
-            }
-        }
-
-        throw MongoDBException::unknownDocumentNamespace($alias);
     }
 
     /**

--- a/tests/DependencyInjection/AbstractMongoDBExtensionTestCase.php
+++ b/tests/DependencyInjection/AbstractMongoDBExtensionTestCase.php
@@ -253,22 +253,6 @@ abstract class AbstractMongoDBExtensionTestCase extends TestCase
         $this->assertEquals('doctrine_mongodb.odm.conn2_connection.event_manager', (string) $container->getAlias('doctrine_mongodb.odm.event_manager'));
     }
 
-    public function testBundleDocumentAliases(): void
-    {
-        $container = $this->getContainer();
-        $loader    = new DoctrineMongoDBExtension();
-
-        $config = DoctrineMongoDBExtensionTest::buildConfiguration(
-            ['document_managers' => ['default' => ['mappings' => ['XmlBundle' => []]]]],
-        );
-        $loader->load($config, $container);
-
-        $definition = $container->getDefinition('doctrine_mongodb.odm.default_configuration');
-        $calls      = $definition->getMethodCalls();
-        $this->assertTrue(isset($calls[0][1][0]['XmlBundle']));
-        $this->assertEquals('Doctrine\Bundle\MongoDBBundle\Tests\DependencyInjection\Fixtures\Bundles\XmlBundle\Document', $calls[0][1][0]['XmlBundle']);
-    }
-
     public function testXmlBundleMappingDetection(): void
     {
         $container = $this->getContainer('XmlBundle');

--- a/tests/DependencyInjection/DoctrineMongoDBExtensionTest.php
+++ b/tests/DependencyInjection/DoctrineMongoDBExtensionTest.php
@@ -40,6 +40,7 @@ use function array_merge;
 use function interface_exists;
 use function is_dir;
 use function method_exists;
+use function realpath;
 use function sprintf;
 use function sys_get_temp_dir;
 use function trait_exists;
@@ -294,38 +295,20 @@ class DoctrineMongoDBExtensionTest extends TestCase
             $container,
         );
 
-        $configDm1 = $container->getDefinition('doctrine_mongodb.odm.dm1_configuration');
-        $configDm2 = $container->getDefinition('doctrine_mongodb.odm.dm2_configuration');
-        $configDm3 = $container->getDefinition('doctrine_mongodb.odm.dm3_configuration');
-
-        $this->assertContains(
-            [
-                'setDocumentNamespaces',
-                [
-                    ['OtherXmlBundle' => 'Doctrine\Bundle\MongoDBBundle\Tests\DependencyInjection\Fixtures\Bundles\OtherXmlBundle\Document'],
-                ],
-            ],
-            $configDm1->getMethodCalls(),
+        $baseDir = realpath(__DIR__) . '/Fixtures/Bundles/';
+        $this->assertSame(
+            [$baseDir . 'OtherXmlBundle/Resources/config/doctrine' => 'Doctrine\Bundle\MongoDBBundle\Tests\DependencyInjection\Fixtures\Bundles\OtherXmlBundle\Document'],
+            $container->getDefinition('doctrine_mongodb.odm.dm1_xml_metadata_driver')->getArguments()[0],
         );
 
-        $this->assertContains(
-            [
-                'setDocumentNamespaces',
-                [
-                    ['XmlBundle' => 'Doctrine\Bundle\MongoDBBundle\Tests\DependencyInjection\Fixtures\Bundles\XmlBundle\Document'],
-                ],
-            ],
-            $configDm2->getMethodCalls(),
+        $this->assertSame(
+            [$baseDir . 'XmlBundle/Resources/config/doctrine' => 'Doctrine\Bundle\MongoDBBundle\Tests\DependencyInjection\Fixtures\Bundles\XmlBundle\Document'],
+            $container->getDefinition('doctrine_mongodb.odm.dm2_xml_metadata_driver')->getArguments()[0],
         );
 
-        $this->assertContains(
-            [
-                'setDocumentNamespaces',
-                [
-                    ['NewXmlBundle' => 'Doctrine\Bundle\MongoDBBundle\Tests\DependencyInjection\Fixtures\Bundles\NewXmlBundle\Document'],
-                ],
-            ],
-            $configDm3->getMethodCalls(),
+        $this->assertSame(
+            [$baseDir . 'NewXmlBundle/config/doctrine' => 'Doctrine\Bundle\MongoDBBundle\Tests\DependencyInjection\Fixtures\Bundles\NewXmlBundle\Document'],
+            $container->getDefinition('doctrine_mongodb.odm.dm3_xml_metadata_driver')->getArguments()[0],
         );
     }
 


### PR DESCRIPTION
Namespace aliases are not supported by `doctrine/persistence` since 3.0.0, which is the minimum version required by this bundle.

This means the aliases injected into the configuration are not used. And we deprecated the methods that inject them in https://github.com/doctrine/mongodb-odm/pull/2957

I propose introducing a breaking change, since short aliases no longer work anyway.

Related to https://github.com/symfony/symfony/pull/62792

Fix https://github.com/doctrine/mongodb-odm/pull/2957#issuecomment-3657892490

