### PR TITLE
Document, test and expose the `DoctrineMongoDBMappingsPass`

### DIFF
--- a/docs/cookbook/bundles.rst
+++ b/docs/cookbook/bundles.rst
@@ -1,0 +1,55 @@
+Bundles
+=======
+
+If you are developing a bundle that provides Doctrine MongoDB documents, you need to register the mappings so that the application's DocumentManager knows about them.
+
+The ``DoctrineMongoDBBundle`` provides a compiler pass called ``DoctrineMongoDBMappingsPass`` that simplifies this process.
+
+Example
+-------
+
+Here is an example of how to use ``DoctrineMongoDBMappingsPass`` in your bundle's ``build`` method:
+
+.. code-block:: php
+
+    namespace Awesome\AwesomeBundle;
+
+    use Doctrine\Bundle\MongoDBBundle\DependencyInjection\Compiler\DoctrineMongoDBMappingsPass;
+    use Symfony\Component\DependencyInjection\ContainerBuilder;
+    use Symfony\Component\HttpKernel\Bundle\Bundle;
+
+    class AwesomeBundle extends Bundle
+    {
+        public function build(ContainerBuilder $container): void
+        {
+            parent::build($container);
+
+            // The path to your mapping files
+            $mappings = [
+                __DIR__.'/Resources/config/doctrine-mapping' => 'Awesome\AwesomeBundle\Model',
+            ];
+
+            $container->addCompilerPass(
+                DoctrineMongoDBMappingsPass::createXmlMappingDriver(
+                    $mappings,
+                    ['awesome_bundle.model_manager_name'],
+                    'awesome_bundle.backend_type_mongodb'
+                )
+            );
+        }
+    }
+
+The mapping configuration will be enabled for the specified DocumentManager
+when parameter ``awesome_bundle.backend_type_mongodb`` is set to ``true``;
+the DocumentManager that is used is determined by the value of the
+``awesome_bundle.model_manager_name`` parameter.
+
+Available Methods
+-----------------
+
+The ``DoctrineMongoDBMappingsPass`` class provides several static methods to create the compiler pass depending on your mapping type:
+
+* ``createXmlMappingDriver``
+* ``createPhpMappingDriver``
+* ``createAttributeMappingDriver``
+* ``createStaticPhpMappingDriver``

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -32,6 +32,7 @@ helping you to configure and use it in your application.
    events
    console
    cookbook/registration_form
+   cookbook/bundles
 
 Doctrine Extensions: Timestampable, Sluggable, etc.
 ---------------------------------------------------

--- a/src/DependencyInjection/Compiler/DoctrineMongoDBMappingsPass.php
+++ b/src/DependencyInjection/Compiler/DoctrineMongoDBMappingsPass.php
@@ -16,8 +16,6 @@ use Symfony\Component\DependencyInjection\Reference;
 /**
  * Class for Symfony bundles to configure mappings for model classes not in the
  * automapped folder.
- *
- * @internal
  */
 final class DoctrineMongoDBMappingsPass extends RegisterMappingsPass
 {

--- a/tests/DependencyInjection/Compiler/DoctrineMongoDBMappingsPassTest.php
+++ b/tests/DependencyInjection/Compiler/DoctrineMongoDBMappingsPassTest.php
@@ -1,0 +1,137 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Bundle\MongoDBBundle\Tests\DependencyInjection\Compiler;
+
+use Doctrine\Bundle\MongoDBBundle\DependencyInjection\Compiler\DoctrineMongoDBMappingsPass;
+use Doctrine\ODM\MongoDB\Mapping\Driver\AttributeDriver;
+use Doctrine\ODM\MongoDB\Mapping\Driver\XmlDriver;
+use Doctrine\Persistence\Mapping\Driver\PHPDriver;
+use Doctrine\Persistence\Mapping\Driver\StaticPHPDriver;
+use Doctrine\Persistence\Mapping\Driver\SymfonyFileLocator;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+
+class DoctrineMongoDBMappingsPassTest extends TestCase
+{
+    public function testCreateXmlMappingDriver(): void
+    {
+        $mappings = ['/path/to/xml' => 'MyNamespace'];
+        $pass     = DoctrineMongoDBMappingsPass::createXmlMappingDriver($mappings, []);
+
+        $container = new ContainerBuilder();
+        $container->setParameter('doctrine_mongodb.odm.default_document_manager', 'default');
+        $container->register('doctrine_mongodb.odm.default_metadata_driver');
+
+        $pass->process($container);
+
+        $chainDriverDef = $container->getDefinition('doctrine_mongodb.odm.default_metadata_driver');
+        $methodCalls    = $chainDriverDef->getMethodCalls();
+
+        $this->assertCount(1, $methodCalls);
+        $this->assertSame('addDriver', $methodCalls[0][0]);
+
+        $args      = $methodCalls[0][1];
+        $driverDef = $args[0];
+        $namespace = $args[1];
+
+        $this->assertSame('MyNamespace', $namespace);
+        $this->assertInstanceOf(Definition::class, $driverDef);
+        $this->assertSame(XmlDriver::class, $driverDef->getClass());
+
+        $locatorDef = $driverDef->getArgument(0);
+        $this->assertInstanceOf(Definition::class, $locatorDef);
+        $this->assertSame(SymfonyFileLocator::class, $locatorDef->getClass());
+        $this->assertSame($mappings, $locatorDef->getArgument(0));
+        $this->assertSame('.mongodb.xml', $locatorDef->getArgument(1));
+    }
+
+    public function testCreatePhpMappingDriver(): void
+    {
+        $mappings = ['/path/to/php' => 'MyNamespace'];
+        $pass     = DoctrineMongoDBMappingsPass::createPhpMappingDriver($mappings, []);
+
+        $container = new ContainerBuilder();
+        $container->setParameter('doctrine_mongodb.odm.default_document_manager', 'default');
+        $container->register('doctrine_mongodb.odm.default_metadata_driver');
+
+        $pass->process($container);
+
+        $chainDriverDef = $container->getDefinition('doctrine_mongodb.odm.default_metadata_driver');
+        $methodCalls    = $chainDriverDef->getMethodCalls();
+
+        $this->assertCount(1, $methodCalls);
+        $this->assertSame('addDriver', $methodCalls[0][0]);
+
+        $args      = $methodCalls[0][1];
+        $driverDef = $args[0];
+        $namespace = $args[1];
+
+        $this->assertSame('MyNamespace', $namespace);
+        $this->assertInstanceOf(Definition::class, $driverDef);
+        $this->assertSame(PHPDriver::class, $driverDef->getClass());
+
+        $locatorDef = $driverDef->getArgument(0);
+        $this->assertInstanceOf(Definition::class, $locatorDef);
+        $this->assertSame(SymfonyFileLocator::class, $locatorDef->getClass());
+        $this->assertSame($mappings, $locatorDef->getArgument(0));
+    }
+
+    public function testCreateAttributeMappingDriver(): void
+    {
+        $namespaces  = ['MyNamespace'];
+        $directories = ['/path/to/attributes'];
+        $pass        = DoctrineMongoDBMappingsPass::createAttributeMappingDriver($namespaces, $directories, []);
+
+        $container = new ContainerBuilder();
+        $container->setParameter('doctrine_mongodb.odm.default_document_manager', 'default');
+        $container->register('doctrine_mongodb.odm.default_metadata_driver');
+
+        $pass->process($container);
+
+        $chainDriverDef = $container->getDefinition('doctrine_mongodb.odm.default_metadata_driver');
+        $methodCalls    = $chainDriverDef->getMethodCalls();
+
+        $this->assertCount(1, $methodCalls);
+        $this->assertSame('addDriver', $methodCalls[0][0]);
+
+        $args      = $methodCalls[0][1];
+        $driverDef = $args[0];
+        $namespace = $args[1];
+
+        $this->assertSame('MyNamespace', $namespace);
+        $this->assertInstanceOf(Definition::class, $driverDef);
+        $this->assertSame(AttributeDriver::class, $driverDef->getClass());
+        $this->assertSame($directories, $driverDef->getArgument(0));
+    }
+
+    public function testCreateStaticPhpMappingDriver(): void
+    {
+        $namespaces  = ['MyNamespace'];
+        $directories = ['/path/to/static-php'];
+        $pass        = DoctrineMongoDBMappingsPass::createStaticPhpMappingDriver($namespaces, $directories, []);
+
+        $container = new ContainerBuilder();
+        $container->setParameter('doctrine_mongodb.odm.default_document_manager', 'default');
+        $container->register('doctrine_mongodb.odm.default_metadata_driver');
+
+        $pass->process($container);
+
+        $chainDriverDef = $container->getDefinition('doctrine_mongodb.odm.default_metadata_driver');
+        $methodCalls    = $chainDriverDef->getMethodCalls();
+
+        $this->assertCount(1, $methodCalls);
+        $this->assertSame('addDriver', $methodCalls[0][0]);
+
+        $args      = $methodCalls[0][1];
+        $driverDef = $args[0];
+        $namespace = $args[1];
+
+        $this->assertSame('MyNamespace', $namespace);
+        $this->assertInstanceOf(Definition::class, $driverDef);
+        $this->assertSame(StaticPHPDriver::class, $driverDef->getClass());
+        $this->assertSame($directories, $driverDef->getArgument(0));
+    }
+}


### PR DESCRIPTION
Marking `DoctrineMongoDBMappingsPass` as `@internal` is incorrect. This class is made to be used by 3rd party bundles to register mapping for their own document classes.

Example of usage: 
- [FOSUserBundle](https://github.com/FriendsOfSymfony/FOSUserBundle/blob/607a7fb975bc0c39bc2aa7e4ab8c52aded74d63c/src/FOSUserBundle.php#L51) 
- [ParthenonBundle ](https://github.com/getparthenon/parthenon/blob/0fcfaa01b7fd84845d01e34ebcbf0b0370f45921/src/ParthenonBundle.php#L90-L97)
- [BabDevMoneyBundle](https://github.com/BabDev/MoneyBundle/blob/3b9b06cda58d3e1796872094d8568d6c15ad5069/src/BabDevMoneyBundle.php#L30-L32)